### PR TITLE
Changes to ML apps: remove $ in shell commands, use module help

### DIFF
--- a/docs/apps/mxnet.md
+++ b/docs/apps/mxnet.md
@@ -8,7 +8,7 @@ The `mxnet` module is available on Puhti only.  Currently supported MXNet versio
 
 - 1.5.0
 
-Activates a conda environment that includes [MXNet](https://mxnet.apache.org/) for Python with GPU support via CUDA.  Also includes all the packages from [Python Data](python-data.md).
+Includes [MXNet](https://mxnet.apache.org/) for Python with GPU support via CUDA.  Also includes all the packages from [Python Data](python-data.md).
 
 If you find that some package is missing, you can often install it yourself with `pip install --user`.
 
@@ -22,23 +22,22 @@ MXNet is licensed under [Apache License 2.0](https://github.com/apache/incubator
 
 To use this software on Puhti, initialize it with:
 
-```bash
-$ module load mxnet
+```text
+module load mxnet
 ```
 
 to access the default version.
 
 This will show all available versions:
 
-```bash
-$ module avail mxnet
+```text
+module avail mxnet
 ```
 
 To check the exact packages and version included a specific module, you can run for example:
 
-```bash
-$ module load mxnet/1.5.0
-$ conda list
+```text
+module help mxnet/1.5.0
 ```
 
 !!! note 

--- a/docs/apps/python-data.md
+++ b/docs/apps/python-data.md
@@ -6,7 +6,7 @@ Collection of Python libraries for data analytics and machine learning.
 
 The `python-data` module is available on Puhti only.
 
-Activates a conda environment that comes with a recent version of Python, and includes several data analytics and machine learning libraries, for example:
+Includes a recent version of Python and several data analytics and machine learning libraries, for example:
 
 - [Dask](https://dask.org/): Scalable analytics in Python
 - [Gensim](https://radimrehurek.com/gensim/): Topic modelling
@@ -29,25 +29,24 @@ All packages are licensed under various free and open source licenses (FOSS).
 
 To use this software on Puhti, initialize it with:
 
-```bash
-$ module load python-data
+```text
+module load python-data
 ```
 
 to access the default version.
 
 This will show all available versions:
 
-```bash
-$ module avail python-data
+```text
+module avail python-data
 ```
 
 Versions are numbered as `X.Y.Z-N`, where `X.Y.Z` is the version of the Python interpreter included, and `N` is a running version number starting from 1.
 
 To check the exact packages and version included a specific module, you can run for example:
 
-```bash
-$ module load python-data/3.7.3-1
-$ conda list
+```text
+module help python-data/3.7.3-1
 ```
 
 !!! note 

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -10,7 +10,7 @@ The `pytorch` module is available on Puhti only.  Currently supported PyTorch ve
 - 1.1.0
 - 1.0.1
 
-Activates a conda environment that includes [PyTorch](https://pytorch.org/) and related libraries with GPU support via CUDA.  Also includes all the packages from [Python Data](python-data.md).
+Includes [PyTorch](https://pytorch.org/) and related libraries with GPU support via CUDA.  Also includes all the packages from [Python Data](python-data.md).
 
 If you find that some package is missing, you can often install it yourself with `pip install --user`.
 
@@ -24,23 +24,22 @@ PyTorch is BSD-style licensed, as found in the [LICENSE file](https://github.com
 
 To use this software on Puhti, initialize it with:
 
-```bash
-$ module load pytorch
+```text
+module load pytorch
 ```
 
 to access the default version.
 
 This will show all available versions:
 
-```bash
-$ module avail pytorch
+```text
+module avail pytorch
 ```
 
 To check the exact packages and version included a specific module, you can run for example:
 
-```bash
-$ module load pytorch/1.2.0
-$ conda list
+```text
+module help pytorch/1.2.0
 ```
 
 !!! note 

--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -10,7 +10,7 @@ The `tensorflow` module is available on Puhti only.  Currently supported TensorF
 - 1.13.1
 - 1.13.1-hvd (with [Horovod](https://github.com/horovod/horovod) support)
 
-Activates a conda environment that includes [TensorFlow](https://www.tensorflow.org/) and [Keras](https://keras.io/) with GPU support via CUDA.  Also includes all the packages from [Python Data](python-data.md).
+Includes [TensorFlow](https://www.tensorflow.org/) and [Keras](https://keras.io/) with GPU support via CUDA.  Also includes all the packages from [Python Data](python-data.md).
 
 If you find that some package is missing, you can often install it yourself with `pip install --user`.
 
@@ -24,23 +24,22 @@ TensorFlow is licensed under [Apache License 2.0](https://github.com/tensorflow/
 
 To use this software on Puhti, initialize it with:
 
-```bash
-$ module load tensorflow
+```text
+module load tensorflow
 ```
 
 to access the default version.
 
 This will show all available versions:
 
-```bash
-$ module avail tensorflow
+```text
+module avail tensorflow
 ```
 
 To check the exact packages and version included a specific module, you can run for example:
 
-```bash
-$ module load tensorflow/1.14.0
-$ conda list
+```text
+module help tensorflow/1.14.0
 ```
 
 !!! note 


### PR DESCRIPTION
Removed references to conda, instead use "module help" to list packages.  Removed "$ " in front of shell commands as agreed in Tuesday's documentation-meeting.