### PR TITLE
Remove quota from command, default view also shows files

### DIFF
--- a/docs/computing/disk.md
+++ b/docs/computing/disk.md
@@ -62,7 +62,7 @@ It is not intended for running applications, so please run them in _scratch_ ins
 
 An overview of your directories in Puhti:
 ```text
-csc-workspaces quota
+csc-workspaces 
 ```
 The above command displays all _scratch_ and _projappl_ directories you have access to within
 active projects with Puhti access. You can find the projects' names and

--- a/docs/support/tutorials/conda.md
+++ b/docs/support/tutorials/conda.md
@@ -199,7 +199,7 @@ the [ProjAppl]( ../../computing/disk.md) directory of your Puhti project.
 
 To get an overview of your directories in Puhti, run command:
 ```text
-csc-workspaces quota
+csc-workspaces 
 ```
 You can pick the path of your ProjAppl directory from the ouput of the command above or if you 
 are mostly using just one project in Puhti, you can set the environment variables 


### PR DESCRIPTION
quota command was not meant to be the overview. Now default view also shows files.