### PR TITLE
Disables the spell check test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ script:
   # Checks all *.md files with aspell.
   # The number of spelling mistakes that are allowed.
   # Test will work properly when dictionary is large enough
-  # Now set so that tests are ok
-  - bash tests/aspellcheck.bash 10000
+  # Currently not in use. Enable when there is a proper plan
+  # for usage
+  #- bash tests/aspellcheck.bash 10000
+
   # Testing if there are any warnings
   - bash tests/checkwarnings.bash
   # Testing if the build works


### PR DESCRIPTION
The typo test in .travis.yaml
is not used for anything at the moment, so i disabled it.
_It was just producing a lot of output to the travis test which i need to scroll through
every time i need to see why the tests fail._


We can enable it once we have a plan+ workflow for how to use it 