### PR TITLE
Use project name instead of project ID

### DIFF
--- a/docs/apps/bwa.md
+++ b/docs/apps/bwa.md
@@ -96,7 +96,7 @@ In Puhti, BWA jobs should be run as batch jobs. Below is a sample batch job file
 #SBATCH --nodes=1  
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=32000
-#SBATCH --account=project_XXXXXX
+#SBATCH --account=<project>
 #
 
 #load the bio tools
@@ -111,7 +111,7 @@ bwa mem -t $SLURM_CPUS_PER_TASK Homo_sapiens.GRCh38.dna.toplevel.fa reads1.fq re
  
 
 In the batch job example above one BWA task (-n 1) is executed. The BWA job uses 8 cores (--cpus-per-task=8 ) with total of 32 GB of memory (--mem=32000). The maximum duration of the job is twelve hours (-t 08:00:00 ). All the cores are assigned from one computing node (--nodes=1 ). In addition to the resource reservations, you have to define the billing project for your batch job. This is done by replacing
-the _project_XXXXXX_ with your project ID. (You can use command `csc-workspaces` to see what project you have in Puhti). 
+the _<project>_ with the name of your project. (You can use command `csc-workspaces` to see what project you have in Puhti).
 
 You can submit the batch job file to the batch job system with command:
 ```text

--- a/docs/apps/gpaw.md
+++ b/docs/apps/gpaw.md
@@ -17,14 +17,15 @@ Some features of the software:
 
 [TOC]
 
-## Available 
+## Available
 
 -   Puhti: 1.4.0, 1.5.2
--   Check all available versions (and default version) with `module avail gpaw`
+-   Check all available versions (and default version) with
+    `module avail gpaw`
 
 ### PAW Setups
 
-All installations use version **0.9.20000** of GPAW's PAW Setups. 
+All installations use version **0.9.20000** of GPAW's PAW Setups.
 
 ## License
 GPAW is free software available under GPL, version 3+
@@ -49,12 +50,12 @@ A specific version can be initialized with `module load gpaw/version`, e.g.
 #SBATCH --ntasks-per-node=40
 #SBATCH --nodes=2
 #SBATCH --mem-per-cpu=2GB
-#SBATCH --account=project_20XXXXX
+#SBATCH --account=<project>
 #SBATCH --mail-type=END
 ##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
 
-# this script runs a 80 core (2 full nodes) gpaw job, requesting 30 minutes time
-# and 2 GB of memory for each core
+# this script runs a 80 core (2 full nodes) gpaw job, requesting
+# 30 minutes time and 2 GB of memory for each core
 
 module load gpaw
 

--- a/docs/apps/gromacs.md
+++ b/docs/apps/gromacs.md
@@ -60,7 +60,7 @@ Note, a scaling test with a very large system (1M+ particles) may take a while t
 #SBATCH --partition=large
 #SBATCH --ntasks-per-node=40
 #SBATCH --nodes=2
-#SBATCH --account=project_20XXXXX
+#SBATCH --account=<project>
 #SBATCH --mail-type=END
 ##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
 
@@ -83,7 +83,7 @@ srun gmx_mpi mdrun -s topol -maxh 0.5 -dlb yes
 #SBATCH --time=00:30:00
 #SBATCH --partition=small
 #SBATCH --ntasks=1
-#SBATCH --account=project_20XXXXX
+#SBATCH --account=<project>
 #SBATCH --mail-type=END
 ##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
 
@@ -95,9 +95,9 @@ srun gmx_mpi mdrun -s topol -maxh 0.5 -dlb yes
 ```
 
 !!! note
-    You *must* fill in the computing project code in your script.
-    Otherwise, your job will not run. This project will be used for
-    billing the cpu usage.
+    You *must* fill in the computing project name in your script (replace
+    <project> with it). Otherwise, your job will not run. This project will be
+    used for billing the cpu usage.
 
 Submit the script with `sbatch script_name.sh`
 

--- a/docs/apps/minimap2.md
+++ b/docs/apps/minimap2.md
@@ -122,7 +122,7 @@ for running a minimap2 paired end alignment in Puhti.
 #SBATCH -n 1
 #SBATCH --nodes=1  
 #SBATCH --cpus-per-task=8
-#SBATCH --account=project_XXXXXX
+#SBATCH --account=<project>
 #SBATCH --mem=16000
 #
 
@@ -131,7 +131,13 @@ minimap2 -t $SLURM_CPUS_PER_TASK -ax splice -uf ref.fa iso-seq.fq > aln.sam
 
 ```
 
-In the batch job example above one task (-n 1) is executed. The Minimap2 job uses 8 cores (--cpus-per-task=8 ) with total of 16 GB of memory (--mem=16000). The maximum duration of the job is four hours (-t 04:00:00 ). All the cores are assigned from one computing node (--nodes=1 ). In addition to the resource reservations, you have to define the billing project for your batch job. This is done by replacing the _project_XXXXXX_ with your project ID. (You can use command `csc-workspaces` to see what projects you have in Puhti). 
+In the batch job example above one task (-n 1) is executed. The Minimap2 job
+uses 8 cores (--cpus-per-task=8 ) with total of 16 GB of memory (--mem=16000).
+The maximum duration of the job is four hours (-t 04:00:00 ). All the cores
+are assigned from one computing node (--nodes=1 ). In addition to the resource
+reservations, you have to define the billing project for your batch job. This
+is done by replacing the _<project>_ with the name of your project. (You can
+use command `csc-workspaces` to see what projects you have in Puhti).
 
 You can submit the batch job file to the batch job system with command:
 

--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -72,7 +72,7 @@ Below is an example slurm batch script that uses 8 tasks across two nodes.  Each
 #SBATCH --gres=gpu:v100:4
 #SBATCH --time=1:00:00
 #SBATCH --mem=32G
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 
 module load tensorflow/1.13.1-hvd
 

--- a/docs/apps/trinity.md
+++ b/docs/apps/trinity.md
@@ -48,7 +48,7 @@ reads.right.fq --SS_lib_type RF --CPU $SLURM_CPUS_PER_TASK \
 --output trinity_run_out --grid_exec sbatch_commandlist
 ```
 The command script above reserves 6 computing cores from one node for the job. The maximal run time of the sample job here is 48 hours. About 4 GB of memory is reserved for each core so the total memory reservation is 6 * 4 GB= 24 GB. In Puhti you muts batch job option
-`--account=` to define the project to be used, so you should replace project_1234567 with your own project ID. You can check your proects
+`--account=` to define the project to be used, so you should replace project_1234567 with your own project. You can check your proects
 with command: `csc-workspaces`.
 
 In the actual Trinity command the number of computing cores to be used (--CPU) is set using environment variable: $SLURM_CPUS_PER_TASK. This variable contains the value set the --cpus-per-task SLURM option.

--- a/docs/computing/disk.md
+++ b/docs/computing/disk.md
@@ -5,8 +5,8 @@ Puhti has three main disk areas: **home**, **projappl** and **scratch**. Please 
 |              | Default quota | Owner    | Environment variable | Path                                            | Cleaning      |
 | ------------ | ------------- | -------- | -------------------- | ----------------------------------------------- | ------------- |
 | **home**     | 10 GiB        | Personal | `$(HOME)`            | <small>`/home/<user-name>`</small>              | No            |
-| **projappl** | 50 GiB        | Project  | Not available        | <small>`/projappl/project_<project_id>`</small> | No            |
-| **scratch**  | 1 TiB         | Project  | Not available        | <small>`/scratch/project_<project_id>`</small>  | Yes - 90 days |
+| **projappl** | 50 GiB        | Project  | Not available        | <small>`/projappl/<project>`</small> | No            |
+| **scratch**  | 1 TiB         | Project  | Not available        | <small>`/scratch/<project>`</small>  | Yes - 90 days |
 
 
 There are quotas for the number of files:
@@ -40,7 +40,7 @@ to several _scratch_ or _projappl_ directories, but still have only one home dir
 ## Scratch directory
 
 Each project has 1 TB of scratch disk space in the directory
-`/scratch/<project_id>`.
+`/scratch/<project>`.
 
 This fast parallel scratch space is intended as temporary storage
 space for the data that is used in Puhti. The scratch directory is not intended for
@@ -50,7 +50,7 @@ be automatically removed**.
 ## ProjAppl directory
 
 Each project has also a 50 GB project application disk space in the directory
-`/projappl/project_<project_id>`.
+`/projappl/project_<project>`.
 
 It is intended for storing applications you have compiled yourself and libraries
 etc. that you are sharing within the project. It is not a personal storage space but it
@@ -85,7 +85,7 @@ If you are mostly involved in only one Puhti project, you can set the
 environment variables $SCRATCH and $PROJAPPL to point at the _scratch_ and
 _projappl_ directories of a CSC project:
 <pre>
-csc-workspaces set <i>project_ID</i>
+csc-workspaces set <i>project</i>
 </pre>
 
 The _scratch_ and _projappl_ directories are shared by **all the members of the

--- a/docs/computing/running/array-jobs.md
+++ b/docs/computing/running/array-jobs.md
@@ -41,7 +41,7 @@ Each of the subtasks requires less than 2 hours of computing time and less than 
 #SBATCH --jobname array_job
 #SBATCH --output array_job_out_%A_%a.txt
 #SBATCH --error array_job_err_%A_%a.txt
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition small
 #SBATCH --timet 02:00:00
 #SBATCH --ntask 1
@@ -95,7 +95,7 @@ to read a certain line form the name list file. In this case the actual command 
 #SBATCH --jobname array_job
 #SBATCH --output array_job_out_%A_%a.txt
 #SBATCH --error array_job_err_%A_%a.txt
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition small
 #SBATCH --timet 02:00:00
 #SBATCH --ntask 1

--- a/docs/computing/running/creating-job-scripts.md
+++ b/docs/computing/running/creating-job-scripts.md
@@ -12,7 +12,7 @@ An example of a simple batch job script.
 ```
 #!/bin/bash
 #SBATCH --job-name=myTest
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --time=02:00:00
 #SBATCH --mem-per-cpu=2G
 #SBATCH --partition=small
@@ -44,13 +44,13 @@ sets the name of the job. It can be used to identify a job in the queue and
 other listings.
 
 ```
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 ```
 
 sets the billing project for the job. **This argument is mandatory, failing to
 set it will cause your job to be held with the reason "_AssocMaxJobsLimit_"**
-You can check you projects in [My CSC](https://my.csc.fi) in the "My Projects"
-tab. More information about [billing](../../accounts/billing.md). 
+You can check your projects in [My CSC](https://my.csc.fi) in the "My Projects"
+tab. More information about [billing](../../accounts/billing.md).
 
 Time reservation is set with option `--time`
 

--- a/docs/computing/running/example-job-scripts.md
+++ b/docs/computing/running/example-job-scripts.md
@@ -8,14 +8,14 @@ Below are example job scripts for running different types of programs:
     If you copy them (please do!), remember to change at least the resources
     (time, tasks etc.) to match your needs and to replace `myprog <options>`
     with the executable (and options) of the program you wish to run as well
-    as `<project_id>` with your project ID.
+    as `<project>` with the name of your project.
 
 ## Serial
 
 ```
 #!/bin/bash
 #SBATCH --job-name=example
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition=small
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=1
@@ -29,7 +29,7 @@ srun myprog <options>
 ```
 #!/bin/bash
 #SBATCH --job-name=example
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition=small
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=1
@@ -47,7 +47,7 @@ srun myprog <options>
 ```
 #!/bin/bash
 #SBATCH --job-name=example
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition=large
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=80
@@ -61,7 +61,7 @@ srun myprog <options>
 ```
 #!/bin/bash
 #SBATCH --job-name=example
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition=gpu
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=1
@@ -79,7 +79,7 @@ srun myprog <options>
 ```
 #!/bin/bash
 #SBATCH --job-name=example
-#SBATCH --account=project_<project_id>
+#SBATCH --account=<project>
 #SBATCH --partition=gpu
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=4

--- a/docs/support/tutorials/conda.md
+++ b/docs/support/tutorials/conda.md
@@ -206,7 +206,7 @@ are mostly using just one project in Puhti, you can set the environment variable
 $SCRATCH and $PROJAPPL to point to the scratch and projappl directories of a CSC project. 
 This setting can be done with command:
 ```text
-csc-workspaces set <project_ID>
+csc-workspaces set <project>
 ```
 Below we assume that $PROJAPPL has been defined. After that the actual installation 
 can be done with commands:

--- a/docs/support/tutorials/puhti_quick.md
+++ b/docs/support/tutorials/puhti_quick.md
@@ -71,7 +71,7 @@ Instructions on how to submit jobs can be found [here](../../computing/running/c
 and example batch job scripts are found [here](../../computing/running/example-job-scripts.md)
 
 !!! note "Very important change!!"
-    You have to specify your billing project in your batch script with the `--account=project_<project_number>` 
+    You have to specify your billing project in your batch script with the `--account=<project>`
     flag. Failing to do so will cause your job to be held with the reason “_AssocMaxJobsLimit_”.
     Running `srun` directly also requires the flag.
 
@@ -86,10 +86,10 @@ More information about billing [here](../../accounts/billing.md)
 
 ## Storage
 
-The **project based** shared storage can be found under `/scratch/project_<project_id>`.
+The **project based** shared storage can be found under `/scratch/<project>`.
 Note that this folder is shared by **all users** in a project. This folder is not meant for long term data storage
 and files that have not been used for 90 days will be automatically removed. The default quota for this folder is 1 TB. There is also a persistent **project based**
-storage with a default quota of 50 GB. It is located under `/projappl/project_<project_id>`. Each user can store up to 10 GB of data in their home directory (`$HOME`).
+storage with a default quota of 50 GB. It is located under `/projappl/<project>`. Each user can store up to 10 GB of data in their home directory (`$HOME`).
 
 More detailed information about storage can be found [here](../../computing/disk.md).
 


### PR DESCRIPTION
Refer to project name (or <project>) instead of project ID (or project_<project_id> or similar) to avoid confusion with projects that have a different naming scheme.