### PR TITLE
recolor menu level 2 items (and up) consistently

### DIFF
--- a/mkdocs_csc/css/base.css
+++ b/mkdocs_csc/css/base.css
@@ -407,7 +407,7 @@ span.input-group-btn {
 }
 
 .wm-toc-lev1 > .wm-toc-text { padding-left: 14px; }
-.wm-toc-lev2 > .wm-toc-text { padding-left: 28px; }
+.wm-toc-lev2 > .wm-toc-text { padding-left: 28px; background-color: rgb(227,227,227); color: rgb(64,64,64);}
 .wm-toc-lev3 > .wm-toc-text { padding-left: 42px; }
 .wm-toc-lev4 > .wm-toc-text { padding-left: 56px; }
 


### PR DESCRIPTION
Level 2 items (and up) in menu were colored with same color as level 1 items. Now all levels from level 2 have same coloring.