### PR TITLE
Update how-to-switch-between-projects.md

### DIFF
--- a/docs/accounts/how-to-switch-between-projects.md
+++ b/docs/accounts/how-to-switch-between-projects.md
@@ -11,9 +11,6 @@ follows:
 
 The selected default billing project is migrated to several services:
 
-* In Puhti, the billing project dictates the default group ownership
-  of new files you create (there is one Linux group for each
-  project).
 * In Taito, the usage is by default charged to the billing
   project. The billing project also dictates the default group
   ownership of new files you create (there is one Linux group


### PR DESCRIPTION
The default billing project selected in MyCSC is not migrated to Puhti.