### PR TITLE
added r-env documentation

### DIFF
--- a/docs/apps/alpha.md
+++ b/docs/apps/alpha.md
@@ -46,6 +46,7 @@
 * [PyTorch](pytorch.md) Machine learning framework for Python
 * [QGIS](qgis.md) GIS application for viewing, editing, and analysing geospatial data
 * [QIIME2](qiime.md) Package for microbial community analysis of amplicon sequencing data
+* [R](r-env.md) Open-source language and environment for statistical analysis and graphics
 * [SAGA GIS](saga-gis.md) GIS application for spatial data editing and analysis
 * [SageMath](sagemath.md) Free open-source mathematics software system
 * [Salmon](salmon.md) Program to produce transcript-level quantification estimates from RNA-seq data

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -1,6 +1,7 @@
 <h1> Applications</h1>
 
 ## Biosciences
+
 * [BAMtools](bamtools.md) Tools for working with BAM formatted files
 * [Bioconda](bioconda.md) Package manger for installing bioinformatics software
 * [BioPerl](bioperl.md) Perl environment with bioperl extension
@@ -64,6 +65,7 @@
 * [MXNet](mxnet.md) Deep learning library for Python
 
 ## Geosciences
+
 * [GDAL](gdal.md) Translator library for geospatial data formats
 * [Geoconda](geoconda.md) Spatial analysis libraries for Python, QGIS, GDAL and LasTools
 * [LAStools](lastools.md) Toolbox for LiDAR datasets
@@ -76,6 +78,9 @@
 * [Solaris](solaris.md) Open source deep learning pipeline for geospatial imagery
 
 ## Mathematics and Statistics
+
+* [R](r-env.md) Open-source language and environment for statistical analysis and graphics
+
 * [SageMath](sagemath.md) Free open-source mathematics software system
 
 * [Julia](julia.md)  High-level, high-performance dynamic programming language for numerical computing
@@ -85,4 +90,5 @@
 * [VASP](vasp.md) Ab initio DFT electronic structures
 
 ## Miscellaneous
+
 * [NoMachine](nomachine.md) Remote Desktop enabling fast graphics without X-emulators

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -39,7 +39,7 @@ Note that Puhti login nodes are not intended for heavy computing. To use R in Pu
 To interactively use R on Puhti's computational nodes, run this command after initializing the `r-env` module. This will request a single-processor R session. Note that you will need to modify the requested duration, memory, project ID and partition as required:
 
 ```
-srun -n1 -t hh:mm:ss --x11=first --mem=4G --pty --account=project_id -p partition R --no-save 
+srun --ntasks=1 --time=hh:mm:ss --x11=first --mem=4G --pty --account=project_id  --partition=partition R --no-save
 ```
 
 For information on available partitions, see [here](../computing/running/batch-job-partitions.md).

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -42,28 +42,29 @@ To interactively use R on Puhti's computational nodes, run this command after in
 srun -n1 -t hh:mm:ss --x11=first --mem=4G --pty --account=project_id -p partition R --no-save 
 ```
 
-For information on available partitions, see [here](https://docs.csc.fi/#computing/running/batch-job-partitions/#puhti-partitions).
+For information on available partitions, see [here](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/running/batch-job-partitions.md).
 
 **Note:** RStudio is currently unavailable on Puhti, but is included in future installation plans.
 
 #### Non-interactive use
 
-You can also run R scripts non-interactively using batch job files. This is particularly useful for jobs that require multiple cores or a lot of memory. See this [link](https://docs.csc.fi/#computing/running/creating-job-scripts/) for detailed information on how to prepare batch jobs. Information on submitting array jobs can be found [here](https://docs.csc.fi/#computing/running/array-jobs/).
+You can also run R scripts non-interactively using batch job files. This is particularly useful for jobs that require multiple cores or a lot of memory. See this [link](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/running/creating-job-scripts.md) for detailed information on how to prepare batch jobs. Information on submitting array jobs can be found [here](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/running/array-jobs.md).
 
 Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used here (which has a time limit of 15 minutes and is used for testing purposes only).
 
 ```
 #!/bin/bash -l
-#SBATCH -J r_single_proc
-#SBATCH -o output_%j.txt
-#SBATCH -e errors_%j.txt
-#SBATCH -p test
-#SBATCH -t 00:05:00
+#SBATCH --job-name=r_single_proc
+#SBATCH --account=<project>
+#SBATCH --output=output_%j.txt
+#SBATCH --error=errors_%j.txt
+#SBATCH --partition=test
+#SBATCH --time=00:05:00
 #SBATCH --ntasks=1
 #SBATCH --nodes=1
 #SBATCH --mem-per-cpu=1000
 
-module load r-env
+module load r-env/3.6.1
 srun Rscript --no-save myrscript.R
 ```
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -1,0 +1,132 @@
+# R
+
+R is an open-source language and environment for statistical computing and graphics. More information on R can be found on the [R Project website](https://www.r-project.org/about.html). A useful set of R manuals is also hosted on [CRAN](https://cran.r-project.org/manuals.html).
+
+## Available
+
+The `r-env` module module has been built for diverse use cases and includes 800+ pre-installed R packages, including support for geospatial analyses. Several [Bioconductor](https://www.bioconductor.org/) packages are also included. Bioconductor is an open-source project providing tools for the analysis of high-throughput genomic data.
+
+Currently supported R versions:
+
+- 3.6.1
+
+Currently supported Bioconductor versions:
+
+- 3.9 (with R 3.6.1)
+
+Other software included in the module:
+
+- GRASS 7.8.0 and Saga-GIS 7.3.0 (with R 3.6.1)
+
+## Licenses
+
+Information on licenses that are in use for R and associated software (such as packages) can be found on the [R Project website](https://www.r-project.org/Licenses/).
+
+## Usage
+
+#### Loading the module
+
+To use the default version of this module on Puhti, initialize it with:
+
+```
+module load r-env
+```
+
+Note that Puhti login nodes are not intended for heavy computing. To use R in Puhti, please either request an interactive job in a computing node or submit a non-interactive batch job in Slurm. 
+
+#### Interactive use
+
+To interactively use R on Puhti's computational nodes, run this command after initializing the `r-env` module. This will request a single-processor R session. Note that you will need to modify the requested duration, memory, project ID and partition as required:
+
+```
+srun -n1 -t hh:mm:ss --x11=first --mem=4G --pty --account=project_id -p partition R --no-save 
+```
+
+For information on available partitions, see [here](https://docs.csc.fi/#computing/running/batch-job-partitions/#puhti-partitions).
+
+**Note:** RStudio is currently unavailable on Puhti, but is included in future installation plans.
+
+#### Non-interactive use
+
+You can also run R scripts non-interactively using batch job files. This is particularly useful for jobs that require multiple cores or a lot of memory. See this [link](https://docs.csc.fi/#computing/running/creating-job-scripts/) for detailed information on how to prepare batch jobs. Information on submitting array jobs can be found [here](https://docs.csc.fi/#computing/running/array-jobs/).
+
+Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used here (which has a time limit of 15 minutes and is used for testing purposes only).
+
+```
+#!/bin/bash -l
+#SBATCH -J r_single_proc
+#SBATCH -o output_%j.txt
+#SBATCH -e errors_%j.txt
+#SBATCH -p test
+#SBATCH -t 00:05:00
+#SBATCH --ntasks=1
+#SBATCH --nodes=1
+#SBATCH --mem-per-cpu=1000
+
+module load r-env
+srun Rscript --no-save myrscript.R
+```
+
+#### R package installations
+
+It is possible to check if a particular package is already installed as follows.
+
+```r
+# One way is to try loading the package:
+library(packagename)
+
+# If you don't want to load the package, it is also
+# possible to search through a list:
+installed_packages <- library()$results[,1]
+"packagename" %in% installed_packages
+
+# Note: both ways are sensitive to upper- and lower-case letters
+```
+
+Additional R package installations can be arranged via two separate routes:
+
+- Project-specific installations can be used by creating a separate package directory in the `/projappl/<project>` directory (instructions below; also see [here](https://docs.csc.fi/#computing/disk/#projappl-directory) for information on ProjAppl)
+
+- Requests for general installations (provided to all users as part of the module): please contact [servicedesk@csc.fi](mailto:servicedesk@csc.fi)
+
+To make use of a project-specific package library, follow these instructions. First create a new folder inside your project directory:
+
+```r
+# On the command prompt:
+# First navigate to /projappl/<project>, then
+mkdir project_rpackages
+```
+
+Then you can add the folder to your library trees in R:
+
+```r
+# Add this to your R code:
+.libPaths(c("/projappl/<project>/project_rpackages", .libPaths()))
+libpath <- .libPaths()[1]
+
+# This command can be used to check that the folder is now visible:
+.libPaths() # It should be first on the list
+
+# Package installations should now be directed to the project
+# folder by default. You can also specify the path, e.g.:
+install.packages("package", lib = libpath)
+```
+
+## Citation
+
+For finding out the correct citations for R and different R packages, you can type:
+
+```r
+citation() # for citing R
+citation("package") # for citing R packages
+```
+
+## Further information
+
+This section contains links to other R-related documentation hosted by CSC, as well as external information sources.
+
+- [R FAQs](https://cran.r-project.org/faqs.html) (hosted by CRAN)
+
+- [Related Projects](https://www.r-project.org/other-projects.html) (list of R-related projects on R Project website)
+
+- [tidyverse](https://www.tidyverse.org/) (pre-installed on the `r-env` module)

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -42,13 +42,13 @@ To interactively use R on Puhti's computational nodes, run this command after in
 srun -n1 -t hh:mm:ss --x11=first --mem=4G --pty --account=project_id -p partition R --no-save 
 ```
 
-For information on available partitions, see [here](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/running/batch-job-partitions.md).
+For information on available partitions, see [here](../computing/running/batch-job-partitions.md).
 
 **Note:** RStudio is currently unavailable on Puhti, but is included in future installation plans.
 
 #### Non-interactive use
 
-You can also run R scripts non-interactively using batch job files. This is particularly useful for jobs that require multiple cores or a lot of memory. See this [link](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/running/creating-job-scripts.md) for detailed information on how to prepare batch jobs. Information on submitting array jobs can be found [here](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/running/array-jobs.md).
+You can also run R scripts non-interactively using batch job files. This is particularly useful for jobs that require multiple cores or a lot of memory. See this [link](../computing/running/creating-job-scripts.md) for detailed information on how to prepare batch jobs. Information on submitting array jobs can be found [here](../computing/running/array-jobs.md).
 
 Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used here (which has a time limit of 15 minutes and is used for testing purposes only).
 
@@ -86,7 +86,7 @@ installed_packages <- library()$results[,1]
 
 Additional R package installations can be arranged via two separate routes:
 
-- Project-specific installations can be used by creating a separate package directory in the `/projappl/<project>` directory (instructions below; also see [here](https://docs.csc.fi/#computing/disk/#projappl-directory) for information on ProjAppl)
+- Project-specific installations can be used by creating a separate package directory in the `/projappl/<project>` directory (instructions below; also see [here](../computing/disk.md#projappl-directory) for information on ProjAppl)
 
 - Requests for general installations (provided to all users as part of the module): please contact [servicedesk@csc.fi](mailto:servicedesk@csc.fi)
 


### PR DESCRIPTION
First draft of general r-env document for docs.csc.fi.

Parallel R examples are currently missing, these will be added either into the current document or as a separate md file (depending on length)