### PR TITLE
parallel R documentation

### DIFF
--- a/docs/apps/r-env-for-gis.md
+++ b/docs/apps/r-env-for-gis.md
@@ -51,18 +51,15 @@ module load r-env
 You can also install your own additional libraries. Just follow the instructions in the [main R page](r-env.md)
 
 `r-env` loads also:
- * [GDAL](gdal.md) 2.4.2 and its commandline tools.
- * [Saga-GIS](saga-gis.md) 7.2.0.
 
+* [GDAL](gdal.md) 2.4.2 and its commandline tools.
+* [Saga-GIS](saga-gis.md) 7.2.0.
 
-### Parallel computing 
+### Parallel computing
 
 Some R packages like __raster__ and __spatial.tools__ include functions that support parallel computing. There is an example of using predict function from raster package in parallel among our [examples](https://github.com/csc-training/geocomputing/tree/master/R/raster_predict). 
 
-Other than those, you have to parallelize your own R code which can be done with libraries like __Rmpi__ and __snow__.
-
-!!! note
-    Parallel computing with `Rmpi` (like on Taito) does not work at the moment in Puhti. `snow` seems to work.
+Other than those, you have to parallelize your own R code which can be done with libraries including __snow__ (see the documentation for the [r-env module](r-env.md)).
 
 ## Citation
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -71,7 +71,7 @@ Further to interactive jobs, you can run R scripts non-interactively using batch
 sbatch batch_job_file.sh
 ```
 
-##### Serial batch jobs
+#### Serial batch jobs
 
 Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used (which has a time limit of 15 minutes and is used for testing purposes only). It's also possible to list a project-specific temporary directory in `/scratch/<project>`, which may be useful when running memory-intensive jobs.
 
@@ -94,7 +94,7 @@ srun Rscript --no-save myscript.R
 
 In the above example, one task (`--ntasks=1`) is executed with 1 GB of memory (`--mem-per-cpu=10000`) and a run time of five minutes (`--time=00:05:00`) reserved for the job.
 
-##### Parallel batch jobs
+#### Parallel batch jobs
 
 The `r-env` module can be used for parallel computing in several ways. These include multi-core and array submissions, as well as MPI (Message Passing Interface)-based jobs. The module comes with several packages that support multi-node communication via MPI: `doMPI` (used with `foreach`), `future`, `lidR`, `pbdMPI` and `snow`.
 
@@ -104,7 +104,7 @@ Further to the following examples, please see our separate [documentation](../co
 Notice for users: for jobs employing the Rmpi package, please use snow (which is built on top of Rmpi). Jobs using Rmpi alone, e.g. via the srun Rmpi command, are currently unavailable due to compatibility issues.  
 ```
 
-***Multi-core and array jobs***
+*Multi-core and array jobs*
 
 To submit a job employing multiple cores on a single node, one could use the following batch job file. The job reserves eight cores (`--ntasks=8`) and a total of 8 GB of memory (`--mem-per-cpu=1000)`. The run time is limited to five minutes.
 
@@ -145,7 +145,7 @@ echo "TMPDIR=/scratch/" > .Renviron
 srun Rscript --no-save myscript.R $SLURM_ARRAY_TASK_ID
 ```
 
-***Jobs using doMPI (with foreach)***
+*Jobs using `doMPI` (with `foreach`)*
 
 The `foreach` package implements a for-loop that uses iterators and allows for parallel execution using the `%dopar%` operator. It is possible to execute parallel `foreach` loops on Puhti using the `doMPI` package. While otherwise the batch job file looks similar to that used for a multi-processor job, we could modify the `srun` command at the end of the batch job file:
 
@@ -169,7 +169,7 @@ closeCluster(cl)
 mpi.quit()
 ```
 
-***Jobs using snow***
+*Jobs using `snow`*
 
 Whereas most parallel R jobs can be submitted using `srun Rscript`, those involving the package `snow` need to be executed using a separate command (`RMPISNOW`). For example:
 
@@ -205,7 +205,7 @@ a
 stopCluster(cl)
 ```
 
-***Jobs using pbdMPI***
+*Jobs using `pbdMPI`*
 
 In analyses using the `pbdMPI` package , each process runs the same copy of the program as every other process while operating on its own data. In other words, there is no separate master process as in `snow` or `doMPI`. Executing batch jobs using `pbdMPI` on Puhti can be done using the `srun Rscript` command. For example, we could submit a job with four tasks divided between two nodes (with two tasks allocated to each node):
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -42,7 +42,7 @@ To interactively use R on Puhti's compute nodes, run the following command after
 r_interactive
 ```
 
-This will launch a bash script that will ask for a number of details needed to initialize the session:
+This will launch a bash script that will ask for a number of details needed to start the session:
 
 ```bash
 How many cores? # No. of processors required
@@ -53,26 +53,34 @@ Partition? # Which partition to use
 Project? # Project ID (i.e. the Unix group)
 ```
 
-For information on available partitions, see [here](../computing/running/batch-job-partitions.md).
+For information on available partitions, see [here](../computing/running/batch-job-partitions.md). For sessions requiring more than four cores and/or over 120 GB of memory, please submit a non-interactive batch job instead.
 
-If you would rather launch an interactive session manually, you can do this using `srun`. Note that you will need to modify the requested duration, memory, project ID and partition as required:
+If you would rather launch an interactive session manually, you can do this using `srun`. Note that you will need to modify the requested number of cores, duration, memory, project ID and partition as required:
 
 ```bash
 srun --ntasks=1 --cpus-per-task=1 --time=hh:mm:ss --x11=first --mem-per-cpu=1G --pty --account=project_id --partition=partition R --no-save
 ```
 
-If you prefer to use RStudio for interactive work, `r-env` can also be used together with the `rstudio` module. See the [RStudio documentation](./rstudio.md) for information. 
+If you prefer to use RStudio for interactive work, `r-env` can be launched together with the `rstudio` module. See the [RStudio documentation](./rstudio.md) for information. 
 
 #### Non-interactive use
 
-You can also run R scripts non-interactively using batch job files. This is particularly useful for jobs that require multiple cores or a lot of memory. See this [link](../computing/running/creating-job-scripts.md) for detailed information on how to prepare batch jobs. Information on submitting array jobs can be found [here](../computing/running/array-jobs.md).
+Further to interactive jobs, you can run R scripts non-interactively using batch job files. Some examples are included in the following, but also see this [link](../computing/running/creating-job-scripts.md) for general information on batch jobs. All batch job files can be submitted to the batch job system as follows:
 
-Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used here (which has a time limit of 15 minutes and is used for testing purposes only). Also notice that it's possible to list a project-specific temporary directory in `/scratch/<project>`, which may be useful when running memory-intensive jobs.
-
+```bash
+sbatch batch_job_file.sh
 ```
+
+##### Serial batch jobs
+
+Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used (which has a time limit of 15 minutes and is used for testing purposes only). It's also possible to list a project-specific temporary directory in `/scratch/<project>`, which may be useful when running memory-intensive jobs.
+
+```bash
 #!/bin/bash -l
 #SBATCH --job-name=r_single_proc
-#SBATCH --account=<project>
+#SBATCH --mail-type=END
+#SBATCH --mail-user=
+#SBATCH --account=
 #SBATCH --output=output_%j.txt
 #SBATCH --error=errors_%j.txt
 #SBATCH --partition=test
@@ -82,8 +90,164 @@ Below is an example for submitting a single-processor R batch job on Puhti. Note
 #SBATCH --mem-per-cpu=1000
 
 module load r-env/3.6.1
-echo "TMPDIR=/scratch/<project>" > .Renviron
-srun Rscript --no-save myrscript.R
+echo "TMPDIR=/scratch/" > .Renviron
+srun Rscript --no-save myscript.R
+```
+
+In the above example, one task (`--ntasks=1`) is executed with 1 GB of memory (`--mem-per-cpu=10000`) and a run time of five minutes (`--time=00:05:00`) reserved for the job.
+
+##### Parallel batch jobs
+
+The `r-env` module can be used for parallel computing in several ways. These include multi-core and array submissions, as well as MPI (Message Passing Interface)-based jobs. The module comes with several packages that support multi-node communication via MPI: `doMPI` (used with `foreach`), `future`, `lidR`, `pbdMPI` and `snow`.
+
+Further to the following examples, please see our separate [documentation](../computing/running/creating-job-scripts.md#mpi-based-batch-jobs) on MPI-based jobs. You may also wish to check the relevant R package manuals and [this page](https://github.com/csc-training/geocomputing/tree/master/R/contours) for examples of parallel computing using the `RSAGA` package.
+
+```
+Notice for users: for jobs employing the Rmpi package, please use snow (which is built on top of Rmpi). Jobs using Rmpi alone, e.g. via the srun Rmpi command, are currently unavailable due to compatibility issues.  
+```
+
+***Multi-core and array jobs***
+
+To submit a job employing multiple cores on a single node, one could use the following batch job file. The job reserves eight cores (`--ntasks=8`) and a total of 8 GB of memory (`--mem-per-cpu=1000)`. The run time is limited to five minutes.
+
+```bash
+#!/bin/bash -l
+#SBATCH --job-name=r_multi_proc
+#SBATCH --mail-type=END
+#SBATCH --mail-user=
+#SBATCH --account=
+#SBATCH --output=output_%j.txt
+#SBATCH --error=errors_%j.txt
+#SBATCH --partition=test
+#SBATCH --time=00:05:00
+#SBATCH --ntasks=8
+#SBATCH --nodes=1
+#SBATCH --mem-per-cpu=1000
+
+module load r-env/3.6.1
+echo "TMPDIR=/scratch/" > .Renviron
+srun Rscript --no-save myscript.R
+```
+
+Array jobs can be used to handle *embarrassingly parallel* tasks (see [here](../computing/running/array-jobs.md) for information). The following script would submit a job involving ten subtasks on the `large` partition, with each requiring less than five minutes of computing time and less than 1 GB of memory.
+
+```bash
+#!/bin/bash -l
+#SBATCH --job-name=r_array
+#SBATCH --mail-type=END
+#SBATCH --mail-user=
+#SBATCH --account=
+#SBATCH --output=output_%j_%a.txt
+#SBATCH --error=errors_%j_%a.txt
+#SBATCH --partition=large
+#SBATCH --time=00:05:00
+#SBATCH --array=1-10
+#SBATCH --ntasks=1
+#SBATCH --nodes=1
+#SBATCH --mem-per-cpu=1000
+
+module load r-env/3.6.1
+echo "TMPDIR=/scratch/" > .Renviron
+srun Rscript --no-save myscript.R $SLURM_ARRAY_TASK_ID
+```
+
+***Jobs using doMPI (with foreach)***
+
+The `foreach` package implements a for-loop that uses iterators and allows for parallel execution using the `%dopar%` operator. It is possible to execute parallel `foreach` loops on Puhti using the `doMPI` package. While otherwise the batch job file looks similar to that used for a multi-processor job, we could modify the `srun` command at the end of the batch job file:
+
+```bash
+srun Rscript --no-save --slave myscript.R
+```
+
+The `--slave` argument is optional and will prevent different processes from printing out a welcome message etc.
+
+Unlike when using `snow`, jobs using `doMPI` launch a number of R sessions equal to the number of reserved cores that all begin to execute the given R script. It is important to include the `startMPIcluster()` call near the beginning of the R script as anything before it will be executed by all available processes (while only the master process continues after it). Upon completion, the cluster is closed using `closeCluster()`. The `mpi.quit()` function can then be used to terminate the MPI execution environment and to quit R:
+
+```r
+library(doMPI,quietly = TRUE)
+cl<-startMPIcluster()
+registerDoMPI(cl)
+
+system.time(a<-foreach(i=1:7) %dopar% system.time(sort(runif(1e7))))
+a
+
+closeCluster(cl)
+mpi.quit()
+```
+
+***Jobs using snow***
+
+Whereas most parallel R jobs can be submitted using `srun Rscript`, those involving the package `snow` need to be executed using a separate command (`RMPISNOW`). For example:
+
+```bash
+#!/bin/bash -l
+#SBATCH --job-name=r_snow
+#SBATCH --mail-type=END
+#SBATCH --mail-user=
+#SBATCH --account=
+#SBATCH --output=output_%j.txt
+#SBATCH --error=errors_%j.txt
+#SBATCH --partition=test
+#SBATCH --time=00:05:00
+#SBATCH --ntasks=8
+#SBATCH --nodes=1
+#SBATCH --mem-per-cpu=1000
+
+module load r-env/3.6.1
+echo "TMPDIR=/scratch/" > .Renviron
+srun RMPISNOW --no-save --slave -f myscript.R
+```
+
+Unlike when using `foreach` and `doMPI`, here only the master process runs the R script. The R script must contain the call `getMPIcluster()` that is used to produce a reference to the cluster which can then be passed onto other functions. Upon completion of the analysis, the cluster is stopped using `stopCluster()`. For example:
+
+```r
+cl <- getMPIcluster()
+
+funtorun<-function(k) {
+  system.time(sort(runif(1e7)))
+}
+
+system.time(a <- clusterApply(cl, 1:7, funtorun))
+a
+
+stopCluster(cl)
+```
+
+***Jobs using pbdMPI***
+
+In analyses using the `pbdMPI` package , each process runs the same copy of the program as every other process while operating on its own data. In other words, there is no separate master process as in `snow` or `doMPI`. Executing batch jobs using `pbdMPI` on Puhti can be done using the `srun Rscript` command. For example, we could submit a job with four tasks divided between two nodes (with two tasks allocated to each node):
+
+```bash
+#!/bin/bash -l
+#SBATCH -J r_pbdmpi
+#SBATCH --mail-type=END
+#SBATCH --mail-user=
+#SBATCH --account=
+#SBATCH --output=output_%j.txt
+#SBATCH --error=errors_%j.txt
+#SBATCH --partition=test
+#SBATCH --time=00:05:00
+#SBATCH --ntasks=4
+#SBATCH --ntasks-per-node=2
+#SBATCH --nodes=2
+#SBATCH --mem-per-cpu=1000
+
+module load r-env/3.6.1
+echo "TMPDIR=/scratch/" > .Renviron
+srun Rscript --no-save --slave myscript.R
+```
+
+As an example, this batch job file could be used to execute the following "hello world" script (original version available via the `pbdMPI` [GitHub repository](https://github.com/snoweye/pbdMPI)). The `init()` function initializes the MPI communicators while `finalize()` is used to shut them down and to exit R.
+
+```r
+library(pbdMPI, quietly = TRUE)
+
+init()
+
+message <- paste("Hello from rank", comm.rank(), "of", comm.size())
+comm.print(message, all.rank = TRUE, quiet = TRUE)
+
+finalize()
 ```
 
 #### R package installations
@@ -131,7 +295,11 @@ libpath <- .libPaths()[1]
 install.packages("package", lib = libpath)
 ```
 
-Note that, to use packages installed in the `/projappl` folder, you will need to run `.libPaths(c("/projappl//project_rpackages", .libPaths()))` each time R is launched.
+To use R packages installed in the `/projappl` folder, you have two options.
+
+- Option 1: Add `.libPaths(c("/projappl/<project>/project_rpackages", .libPaths()))` to the beginning of your R script. This modifies your library trees within a given R session only. In other words, you will need to run this each time when launching R.
+
+- Option 2: Before launching R, run `export R_LIBS_USER=$R_LIBS_USER:/projappl/<project>/project_rpackages`. This modifies your library settings outside R, which can be useful if you are planning to use R in combination with other software.
 
 ## Citation
 
@@ -153,3 +321,5 @@ This section contains links to other R-related documentation hosted by CSC, as w
 - [R package cheatsheets](https://rstudio.com/resources/cheatsheets/) (hosted on RStudio website)
 
 - [tidyverse](https://www.tidyverse.org/) (pre-installed on the `r-env` module)
+
+- [doMPI](https://cran.r-project.org/web/packages/doMPI/index.html), [future](https://cran.r-project.org/web/packages/future/index.html), [lidR](https://cran.r-project.org/web/packages/lidR/index.html), [pbdMPI](https://cran.r-project.org/web/packages/pbdMPI/index.html), [snow](https://cran.r-project.org/web/packages/snow/index.html) (CRAN pages for parallel R packages)

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -88,7 +88,7 @@ Below is an example for submitting a single-processor R batch job on Puhti. Note
 #SBATCH --mem-per-cpu=1000
 
 module load r-env/3.6.1
-echo "TMPDIR=/scratch/" > .Renviron
+echo "TMPDIR=/scratch/<project>" > .Renviron
 srun Rscript --no-save myscript.R
 ```
 
@@ -121,7 +121,7 @@ To submit a job employing multiple cores on a single node, one could use the fol
 #SBATCH --mem-per-cpu=1000
 
 module load r-env/3.6.1
-echo "TMPDIR=/scratch/" > .Renviron
+echo "TMPDIR=/scratch/<project>" > .Renviron
 srun Rscript --no-save myscript.R
 ```
 
@@ -141,7 +141,7 @@ Array jobs can be used to handle *embarrassingly parallel* tasks (see [here](../
 #SBATCH --mem-per-cpu=1000
 
 module load r-env/3.6.1
-echo "TMPDIR=/scratch/" > .Renviron
+echo "TMPDIR=/scratch/<project>" > .Renviron
 srun Rscript --no-save myscript.R $SLURM_ARRAY_TASK_ID
 ```
 
@@ -186,7 +186,7 @@ Whereas most parallel R jobs can be submitted using `srun Rscript`, those involv
 #SBATCH --mem-per-cpu=1000
 
 module load r-env/3.6.1
-echo "TMPDIR=/scratch/" > .Renviron
+echo "TMPDIR=/scratch/<project>" > .Renviron
 srun RMPISNOW --no-save --slave -f myscript.R
 ```
 
@@ -223,7 +223,7 @@ In analyses using the `pbdMPI` package , each process runs the same copy of the 
 #SBATCH --mem-per-cpu=1000
 
 module load r-env/3.6.1
-echo "TMPDIR=/scratch/" > .Renviron
+echo "TMPDIR=/scratch/<project>" > .Renviron
 srun Rscript --no-save --slave myscript.R
 ```
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -158,11 +158,11 @@ The `--slave` argument is optional and will prevent different processes from pri
 Unlike when using `snow`, jobs using `doMPI` launch a number of R sessions equal to the number of reserved cores that all begin to execute the given R script. It is important to include the `startMPIcluster()` call near the beginning of the R script as anything before it will be executed by all available processes (while only the master process continues after it). Upon completion, the cluster is closed using `closeCluster()`. The `mpi.quit()` function can then be used to terminate the MPI execution environment and to quit R:
 
 ```r
-library(doMPI,quietly = TRUE)
-cl<-startMPIcluster()
+library(doMPI, quietly = TRUE)
+cl <- startMPIcluster()
 registerDoMPI(cl)
 
-system.time(a<-foreach(i=1:7) %dopar% system.time(sort(runif(1e7))))
+system.time(a <- foreach(i = 1:7) %dopar% system.time(sort(runif(1e7))))
 a
 
 closeCluster(cl)

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -78,9 +78,7 @@ Below is an example for submitting a single-processor R batch job on Puhti. Note
 ```bash
 #!/bin/bash -l
 #SBATCH --job-name=r_single_proc
-#SBATCH --mail-type=END
-#SBATCH --mail-user=
-#SBATCH --account=
+#SBATCH --account=<project>
 #SBATCH --output=output_%j.txt
 #SBATCH --error=errors_%j.txt
 #SBATCH --partition=test
@@ -113,9 +111,7 @@ To submit a job employing multiple cores on a single node, one could use the fol
 ```bash
 #!/bin/bash -l
 #SBATCH --job-name=r_multi_proc
-#SBATCH --mail-type=END
-#SBATCH --mail-user=
-#SBATCH --account=
+#SBATCH --account=<project>
 #SBATCH --output=output_%j.txt
 #SBATCH --error=errors_%j.txt
 #SBATCH --partition=test
@@ -134,9 +130,7 @@ Array jobs can be used to handle *embarrassingly parallel* tasks (see [here](../
 ```bash
 #!/bin/bash -l
 #SBATCH --job-name=r_array
-#SBATCH --mail-type=END
-#SBATCH --mail-user=
-#SBATCH --account=
+#SBATCH --account=<project>
 #SBATCH --output=output_%j_%a.txt
 #SBATCH --error=errors_%j_%a.txt
 #SBATCH --partition=large
@@ -182,9 +176,7 @@ Whereas most parallel R jobs can be submitted using `srun Rscript`, those involv
 ```bash
 #!/bin/bash -l
 #SBATCH --job-name=r_snow
-#SBATCH --mail-type=END
-#SBATCH --mail-user=
-#SBATCH --account=
+#SBATCH --account=<project>
 #SBATCH --output=output_%j.txt
 #SBATCH --error=errors_%j.txt
 #SBATCH --partition=test
@@ -219,10 +211,8 @@ In analyses using the `pbdMPI` package , each process runs the same copy of the 
 
 ```bash
 #!/bin/bash -l
-#SBATCH -J r_pbdmpi
-#SBATCH --mail-type=END
-#SBATCH --mail-user=
-#SBATCH --account=
+#SBATCH --job-name=r_pbdmpi
+#SBATCH --account=<project>
 #SBATCH --output=output_%j.txt
 #SBATCH --error=errors_%j.txt
 #SBATCH --partition=test

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -100,9 +100,8 @@ The `r-env` module can be used for parallel computing in several ways. These inc
 
 Further to the following examples, please see our separate [documentation](../computing/running/creating-job-scripts.md#mpi-based-batch-jobs) on MPI-based jobs. You may also wish to check the relevant R package manuals and [this page](https://github.com/csc-training/geocomputing/tree/master/R/contours) for examples of parallel computing using the `RSAGA` package.
 
-```
-Notice for users: for jobs employing the Rmpi package, please use snow (which is built on top of Rmpi). Jobs using Rmpi alone, e.g. via the srun Rmpi command, are currently unavailable due to compatibility issues.  
-```
+!!! note
+    For jobs employing the Rmpi package, please use snow (which is built on top of Rmpi). Jobs using Rmpi alone, e.g. via the srun Rmpi command, are currently unavailable due to compatibility issues.
 
 *Multi-core and array jobs*
 
@@ -195,7 +194,7 @@ Unlike when using `foreach` and `doMPI`, here only the master process runs the R
 ```r
 cl <- getMPIcluster()
 
-funtorun<-function(k) {
+funtorun <- function(k) {
   system.time(sort(runif(1e7)))
 }
 
@@ -207,7 +206,7 @@ stopCluster(cl)
 
 *Jobs using `pbdMPI`*
 
-In analyses using the `pbdMPI` package , each process runs the same copy of the program as every other process while operating on its own data. In other words, there is no separate master process as in `snow` or `doMPI`. Executing batch jobs using `pbdMPI` on Puhti can be done using the `srun Rscript` command. For example, we could submit a job with four tasks divided between two nodes (with two tasks allocated to each node):
+In analyses using the `pbdMPI` package, each process runs the same copy of the program as every other process while operating on its own data. In other words, there is no separate master process as in `snow` or `doMPI`. Executing batch jobs using `pbdMPI` on Puhti can be done using the `srun Rscript` command. For example, we could submit a job with four tasks divided between two nodes (with two tasks allocated to each node):
 
 ```bash
 #!/bin/bash -l


### PR DESCRIPTION
Bigger changes:

- Added information + guidelines for parallel batch jobs using r-env (multi-core and array jobs, plus jobs using doMPI and foreach, snow or pbdMPI) 
- Modified r-env for GIS page (parallel R section now links to main r-env page + removed note about Rmpi, which is now listed on r-env page along with other parallel R info)

Smaller changes: 

- added `R_LIBS_USER` example under options for employing project-specific R packages (enables using project-specific R packages in combination with software other than R)
- added links to parallel R packages under further reading list
- plus various formatting fixes introduced after the first commit...