### PR TITLE
removed double menu link

### DIFF
--- a/docs/cloud/pouta/launch-vm-from-web-gui.md
+++ b/docs/cloud/pouta/launch-vm-from-web-gui.md
@@ -9,6 +9,7 @@
 This document explains a simple way to launch a virtual machine in the
 Pouta service. Any CSC user with a computing project can request
 access to the service as described in [Applying for Pouta access].
+To use Pouta, you need to have applied Pouta access for your project first.
 Please make sure you are familiar with the [concepts](../concepts.md) and
 [security issues](security.md) first.  You might also want to take a
 look at the webinar recording [in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,6 @@ nav:
      - Pouta:
         - Contents: cloud/pouta/index.md
         - What is Pouta: cloud/pouta/pouta-what-is.md
-        - Applying for Pouta Access: accounts/how-to-add-service-access-for-project.md
         - Security Guidelines for Pouta: cloud/pouta/security.md
         - Pouta Accounting Principles and Quotas: cloud/pouta/accounting.md
         - Virtual machine flavors and Billing Unit rates: cloud/pouta/vm-flavors-and-billing.md


### PR DESCRIPTION
Menu got confused since there were two links to the same page from the left. I removed the one from under cloud and elaborated in the text to get access. 