### PR TITLE
updated r-env / RStudio launch scripts + Allas access

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -286,7 +286,7 @@ To use R packages installed in the `/projappl` folder, you have two options.
 
 ## Working with Allas
 
-The `r-env` module comes with the [`aws.s3`](https://cran.r-project.org/web/packages/aws.s3/) package for working with S3 storage, which makes it possible to use the [Allas storage system](../data/Allas/using_allas/introduction.md) directly from an R script. See [here](https://github.com/csc-training/geocomputing/blob/master/R/allas/working_with_allas_from_R_S3.R) for a practical example involving raster data.
+The `r-env` module comes with the [`aws.s3`](https://cran.r-project.org/web/packages/aws.s3/) package for working with S3 storage, which makes it possible to use the Allas storage system directly from an R script. See [here](https://github.com/csc-training/geocomputing/blob/master/R/allas/working_with_allas_from_R_S3.R) for a practical example involving raster data.
 
 ## Citation
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -50,16 +50,10 @@ Memory per core (e.g. "1G")? # Memory required for each processor
 Hours (e.g. "01")? # Session duration (hours)
 Minutes (e.g. "05")? # Session duration (minutes)
 Partition? # Which partition to use
-Project? # Project ID (i.e. the Unix group)
+Project (use lower-case letters)? # Project ID (i.e. the Unix group)
 ```
 
 For information on available partitions, see [here](../computing/running/batch-job-partitions.md). For sessions requiring more than four cores and/or over 120 GB of memory, please submit a non-interactive batch job instead.
-
-If you would rather launch an interactive session manually, you can do this using `srun`. Note that you will need to modify the requested number of cores, duration, memory, project ID and partition as required:
-
-```bash
-srun --ntasks=1 --cpus-per-task=1 --time=hh:mm:ss --x11=first --mem-per-cpu=1G --pty --account=project_id --partition=partition R --no-save
-```
 
 If you prefer to use RStudio for interactive work, `r-env` can be launched together with the `rstudio` module. See the [RStudio documentation](./rstudio.md) for information. 
 
@@ -73,7 +67,7 @@ sbatch batch_job_file.sh
 
 #### Serial batch jobs
 
-Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used (which has a time limit of 15 minutes and is used for testing purposes only). It's also possible to list a project-specific temporary directory in `/scratch/<project>`, which may be useful when running memory-intensive jobs.
+Below is an example for submitting a single-processor R batch job on Puhti. Note that the `test` partition is used, which has a time limit of 15 minutes and is used for testing purposes only. For memory-intensive jobs, we can also list a project-specific temporary directory in `/scratch/<project>`.
 
 ```bash
 #!/bin/bash -l
@@ -289,6 +283,10 @@ To use R packages installed in the `/projappl` folder, you have two options.
 - Option 1: Add `.libPaths(c("/projappl/<project>/project_rpackages", .libPaths()))` to the beginning of your R script. This modifies your library trees within a given R session only. In other words, you will need to run this each time when launching R.
 
 - Option 2: Before launching R, run `export R_LIBS_USER=$R_LIBS_USER:/projappl/<project>/project_rpackages`. This modifies your library settings outside R, which can be useful if you are planning to use R in combination with other software.
+
+## Working with Allas
+
+The `r-env` module comes with the [`aws.s3`](https://cran.r-project.org/web/packages/aws.s3/) package for working with S3 storage, which makes it possible to use the [Allas storage system](../data/Allas/using_allas/introduction.md) directly from an R script. See [here](https://github.com/csc-training/geocomputing/blob/master/R/allas/working_with_allas_from_R_S3.R) for a practical example involving raster data.
 
 ## Citation
 

--- a/docs/apps/rstudio.md
+++ b/docs/apps/rstudio.md
@@ -41,16 +41,10 @@ Memory per core (e.g. "1G")? # Memory required for each processor
 Hours (e.g. "01")? # Session duration (hours)
 Minutes (e.g. "05")? # Session duration (minutes)
 Partition? # Which partition to use
-Project? # Project ID (i.e. the Unix group)
+Project (use lower-case letters)? # Project ID (i.e. the Unix group)
 ```
 
 For information on available partitions, see [here](../computing/running/batch-job-partitions.md).
-
-If you would rather launch an interactive session manually, you can do this using `srun`. Note that you will need to modify the requested duration, memory, project ID and partition as required:
-
-```
-srun --ntasks=1 --cpus-per-task=1 --time=hh:mm:ss --x11=first --mem-per-cpu=1G --pty --account=project_id --partition=partition rstudio --no-save
-```
 
 ## Citation
 


### PR DESCRIPTION
- Added info on interactive session launch scripts (requesting to use lower-case letters when specifying the Unix group). This reflects a change in the scripts which now automatically specify a TMP directory in `/scratch/<project>` (previously only implemented as an option in non-interactive batch jobs). 
- Deleted examples of manually launching interactive sessions.
- Added a small section on accessing Allas from R scripts using the aws.s3 package, linking to example on R for GIS page. 