### PR TITLE
Test for FIXME in files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,5 @@ script:
   - bash tests/check_mail_commented.sh
   # Use long slurm flags
   - bash tests/check_long_slurm_flags.sh
+  # There should be no FIXME entires present
+  - bash tests/check_fixme.sh

--- a/tests/check_fixme.sh
+++ b/tests/check_fixme.sh
@@ -1,0 +1,17 @@
+FOUND_FIXME=$(grep -o -i -n -r --include \*.md -- FIXME docs ) 
+
+
+if [[ ! -z "$FOUND_FIXME" ]];then
+    echo -e "Documentation contains FIXME"
+    echo -e "Please correct the documentation and remove the FIXME\n"
+    files=$(echo "$FOUND_FIXME" | cut -d ":" -f 1 )
+    lines=$(echo "$FOUND_FIXME" | cut -d ":" -f 2 )
+    line_part=$(echo "$lines" | sed 's/$/ in file /g' | sed 's/^/Line /')
+    file_part=$(echo "$files" | sed 's/$/ contains FIXME/g')
+    paste <(echo "$line_part") <(echo "$file_part") -d ""  
+    exit 1
+
+else
+    echo "No FIXME found in the documentation"
+    exit 0
+fi


### PR DESCRIPTION
Implements a short bash script to test if there are any **FIXME** entries in the documentation.

- Test is done with `grep -o -i -n -r --include \*.md -- FIXME docs `
- Added to `.travis.yml`