### PR TITLE
added moving data index page + FAQ

### DIFF
--- a/docs/data/moving/index.md
+++ b/docs/data/moving/index.md
@@ -1,0 +1,11 @@
+# Moving data between CSC and local workstation
+
+There are many ways to move data, please select
+below the one that suits your needs best.
+
+* [Copying files using scp](scp.md)
+* [Graphical file transfer tools](graphical_transfer.md)
+* [Using rsync for data transfer and synchronization](rsync.md)
+* [Using wget to download data from web sites to CSC](wget.md)
+* [Sharing and transporting files using Funet FileSender](funet.md)
+* [Remote disk mounts](disk_mount.md)

--- a/docs/support/faq/index.md
+++ b/docs/support/faq/index.md
@@ -7,6 +7,7 @@
 * [I cannot login to Puhti from NoMachine](cannot-login-from-nomachine.md)
 * [How to cite CSC in a paper?](how-to-cite-csc.md)
 * [Can I still use CSC services if I'm moving abroad?](can-i-use-csc-services-abroad.md)
+* [How can I move data between CSC and my local computer?](../../data/moving)
 
 ## Batch jobs
 * [Why is my job queuing so long?](why-is-my-job-queueing-so-long.md)


### PR DESCRIPTION
Lisäsin moving -hakemistoon index -sivun. Se ei näy valikossa, mutta toimii, tästä urlista:

.../data/moving/

jota voi siis jakaa sähköpostilla tai FAQ General osion vikasta entrystä. 