### PR TITLE
R/RStudio on interactive partition

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -282,7 +282,21 @@ To use R packages installed in the `/projappl` folder, you have two options.
 
 ## Working with Allas
 
-The `r-env` module comes with the [`aws.s3`](https://cran.r-project.org/web/packages/aws.s3/) package for working with S3 storage, which makes it possible to use the Allas storage system directly from an R script. See [here](https://github.com/csc-training/geocomputing/blob/master/R/allas/working_with_allas_from_R_S3.R) for a practical example involving raster data.
+The `r-env` module comes with the [`aws.s3`](https://cran.r-project.org/web/packages/aws.s3/) package for working with S3 storage, which makes it possible to use the Allas storage system directly from an R script. See [here](https://github.com/csc-training/geocomputing/blob/master/R/allas/working_with_allas_from_R_S3.R) for a practical example involving raster data. 
+
+Accessing Allas via the `r-env` module can be done as follows:
+
+```bash
+# First configure Allas
+module load allas
+allas-conf --mode s3cmd
+
+# Then load aws.s3 in R
+module load r-env
+R
+library(aws.s3) 
+bucketlist()
+```
 
 ## Citation
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -32,28 +32,24 @@ To use the default version of this module on Puhti, initialize it with:
 module load r-env
 ```
 
-Note that Puhti login nodes are [not intended for heavy computing](../computing/overview.md). To use R in Puhti, please either request an interactive job on a compute node or submit a non-interactive batch job in Slurm. 
+Puhti login nodes are [not intended for heavy computing](../computing/overview.md). To use R in Puhti, please either request an interactive job on a compute node or submit a non-interactive batch job in Slurm.
+
+!!! note To use R interactively, you will need to open a session on the `interactive` partition before loading the module (see below).
 
 #### Interactive use
 
-To interactively use R on Puhti's compute nodes, run the following command after initializing the `r-env` module. 
+To interactively use R on Puhti's compute nodes, first open a shell session on the `interactive` partition using the `sinteractive` command. As an example, the following command would launch a session with 8 GiB of memory and 100 GiB of local scratch space. It is also possible to specify the number of cores and the running time among other options ([see the `sinteractive` documentation](../computing/running/interactive-usage.md)).
 
 ```bash
-r_interactive
+sinteractive -p <project> --mem 8000 --tmp 100
 ```
 
-This will launch a bash script that will ask for a number of details needed to start the session:
+Once you have opened an interactive shell session, you can launch the `r-env` module and a command line version of R as follows:
 
 ```bash
-How many cores? # No. of processors required
-Memory per core (e.g. "1G")? # Memory required for each processor
-Hours (e.g. "01")? # Session duration (hours)
-Minutes (e.g. "05")? # Session duration (minutes)
-Partition? # Which partition to use
-Project (use lower-case letters)? # Project ID (i.e. the Unix group)
+module load r-env
+R
 ```
-
-For information on available partitions, see [here](../computing/running/batch-job-partitions.md). For sessions requiring more than four cores and/or over 120 GB of memory, please submit a non-interactive batch job instead.
 
 If you prefer to use RStudio for interactive work, `r-env` can be launched together with the `rstudio` module. See the [RStudio documentation](./rstudio.md) for information. 
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -41,7 +41,7 @@ Puhti login nodes are [not intended for heavy computing](../computing/overview.m
 To interactively use R on Puhti's compute nodes, first open a shell session on the `interactive` partition using the `sinteractive` command. As an example, the following command would launch a session with 8 GB of memory and 100 GB of local scratch space. It is also possible to specify the number of cores and the running time among other options ([see the `sinteractive` documentation](../computing/running/interactive-usage.md)). Maximal reservations in the `interactive` partition include: 1 core, 16 GB of memory, 7 days of time and 160 GB of local scratch space.
 
 ```bash
-sinteractive -p <project> --mem 8000 --tmp 100
+sinteractive --account <project> --mem 8000 --tmp 100
 ```
 
 Once you have opened an interactive shell session, you can launch the `r-env` module and a command line version of R as follows:

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -82,7 +82,7 @@ echo "TMPDIR=/scratch/<project>" > .Renviron
 srun Rscript --no-save myscript.R
 ```
 
-In the above example, one task (`--ntasks=1`) is executed with 1 GB of memory (`--mem-per-cpu=10000`) and a run time of five minutes (`--time=00:05:00`) reserved for the job.
+In the above example, one task (`--ntasks=1`) is executed with 1 GB of memory (`--mem-per-cpu=1000`) and a run time of five minutes (`--time=00:05:00`) reserved for the job.
 
 #### Parallel batch jobs
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -38,7 +38,7 @@ Puhti login nodes are [not intended for heavy computing](../computing/overview.m
 
 #### Interactive use
 
-To interactively use R on Puhti's compute nodes, first open a shell session on the `interactive` partition using the `sinteractive` command. As an example, the following command would launch a session with 8 GiB of memory and 100 GiB of local scratch space. It is also possible to specify the number of cores and the running time among other options ([see the `sinteractive` documentation](../computing/running/interactive-usage.md)).
+To interactively use R on Puhti's compute nodes, first open a shell session on the `interactive` partition using the `sinteractive` command. As an example, the following command would launch a session with 8 GB of memory and 100 GB of local scratch space. It is also possible to specify the number of cores and the running time among other options ([see the `sinteractive` documentation](../computing/running/interactive-usage.md)). Maximal reservations in the `interactive` partition include: 1 core, 16 GB of memory, 7 days of time and 160 GB of local scratch space.
 
 ```bash
 sinteractive -p <project> --mem 8000 --tmp 100

--- a/docs/apps/rstudio.md
+++ b/docs/apps/rstudio.md
@@ -16,35 +16,23 @@ The RStudio Desktop installation on Puhti is based on the [Open Source Edition](
 
 #### Loading the module
 
-To use this module on Puhti, initialize it after loading the `r-env` module (note that `r-env` needs to be loaded in order to use `rstudio`):
+To use this module on Puhti, first start a shell session on the `interactive` partition using the `sinteractive` command. As an example, the following command would launch a session with 8 GiB of memory and 100 GiB of local scratch space. It is also possible to specify the number of cores and the running time among other options ([see the `sinteractive` documentation](../computing/running/interactive-usage.md)).
+
+```bash
+sinteractive -p <project> --mem 8000 --tmp 100
+```
+
+Once you have opened an interactive shell session, you can start RStudio after loading the `r-env` module (note that `r-env` needs to be loaded in order to use `rstudio`):
 
 ```
 module load r-env
 module load rstudio
+rstudio
 ```
 
-For information on `r-env`, see the user documentation [here](./r-env.md). Note that Puhti login nodes are [not intended for heavy computing](../computing/overview.md). To use RStudio in Puhti, please request an interactive job on a compute node.
+!!! note Note that it may take some time to initialize RStudio after running the `rstudio` command.  
 
-#### Interactive use
-
-To interactively use RStudio on Puhti's compute nodes, run the following command.
-
-```bash
-rstudio_interactive
-```
-
-This will launch a bash script that will ask for a number of details needed to initialize the session:
-
-```bash
-How many cores? # No. of processors required
-Memory per core (e.g. "1G")? # Memory required for each processor
-Hours (e.g. "01")? # Session duration (hours)
-Minutes (e.g. "05")? # Session duration (minutes)
-Partition? # Which partition to use
-Project (use lower-case letters)? # Project ID (i.e. the Unix group)
-```
-
-For information on available partitions, see [here](../computing/running/batch-job-partitions.md).
+For information on `r-env`, see the user documentation [here](./r-env.md).
 
 ## Citation
 

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -15,6 +15,7 @@ Puhti has an `interactive` partition which enables immediate access to an intera
 ```text
 sinteractive -p <project_name> 
 ```
+
 This command opens a shell session that runs on a compute node. You can use this
 session as a normal bash shell without additional Slurm commands for starting jobs and applications.
 
@@ -29,16 +30,15 @@ sinteractive -p project_2011234 --time 48:00:00 --mem 8000 --tmp 100
 
 Available options for `sinteractive` are:
 
-|Option| Function | Default |
-| --- | --- | --- |
-|-t, --time | Run time reservation in minutes or in format d-hh:mm:ss. | 24:00:00 |
-|-m, --mem | Memory reservation in MB. | 1000 |
-|-j, --jobname | Job name. | interactive |
-|-c, --cores | Number of cores. |  1 |
-|-p, --project | Accounting project.|  $CSC_PRIMARY_PROJECT |
-|-d, --tmp  | Size of job specifinc $TMPDIR disk (in GiB). | 32 |
-|-g, --gpu  | Number of GPU:s to reserve (max 4) | 0 |
-
+| Option        | Function                                                 | Default              |
+| ------------- | -------------------------------------------------------- | -------------------- |
+| -t, --time    | Run time reservation in minutes or in format d-hh:mm:ss. | 24:00:00             |
+| -m, --mem     | Memory reservation in MB.                                | 1000                 |
+| -j, --jobname | Job name.                                                | interactive          |
+| -c, --cores   | Number of cores.                                         | 1                    |
+| -p, --project | Accounting project.                                      | $CSC_PRIMARY_PROJECT |
+| -d, --tmp     | Size of job specifinc $TMPDIR disk (in GiB).             | 32                   |
+| -g, --gpu     | Number of GPU:s to reserve (max 4)                       | 0                    |
 
 Note, that each user can have only one active session open in the `interactive` partition. 
 In the interactive partition you can reserve in maximum 1 core, 16 GB of 
@@ -51,7 +51,6 @@ you may need to wait some time before the requested resources become available a
 starts.
 
 All the `sinterative` sessions are executed in nodes that have [NVMe fast local disk area](/computing/running/creating-job-scripts/#local-storage) available. The environment variable `$TMPDIR` points to the local disk area of the job. This local disk area has high I/O capacity and thus it is ideal location for temporary files created by the application. Note however, that this disk area is erased when the interactive batch job session ends.
-
 
 ### Example: Running a Jupyter notebook server via sinteractive
 
@@ -70,7 +69,6 @@ your machine and the compute node. Note that you need to set up
 passwordless access using ssh keys to do so. After this you can access
 the Jupyter server by copy-pasting the web address into your local web browser.
 
-
 ### Example: RStudio in sinteractive session
 
 Open connection to Puhti with NoMachine.
@@ -80,10 +78,8 @@ In the Puhti terminal session, run commands:
 sinteractive -p <project> --mem 8000 --tmp 100
 module load r-env 
 module load rstudio
-export XDG_RUNTIME_DIR=$TMPDIR
 rstudio
 ```
-
 
 ## Explicit interactive shell without X11 graphics
 


### PR DESCRIPTION
- Updated interactive use sections in R + RStudio docs to reflect shift to `interactive` partition. The `r_interactive` and `rstudio_interactive` launch scripts are no longer needed (planning to remove them shortly). 
- The sinteractive launch example uses --account rather than --project:
`sinteractive --account <project> --mem 8000 --tmp 100`
- Modified RStudio example in interactive use doc (removed `export XDG_RUNTIME_DIR=$TMPDIR`). 
- Modified RStudio module file so that `XDG_RUNTIME_DIR` is no longer unset. While not explicitly defined, when RStudio is launched on the `interactive` partition this variable now defaults to a directory inside `TMPDIR` (/run/nvme/job_xxxxxx/tmp/...).

Other changes:
- Typo fixes + expanded Allas instructions