### PR TITLE
Revert "conda-docs-env"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ in [MkDocs documentation](http://www.mkdocs.org/#installation), or with
 [conda](https://docs.conda.io/en/latest/miniconda.html) by simply
 
 ```bash
-conda env create -f docs/support/tutorials/conda/conda-docs-env-0.1.yaml
+conda env create -f docs/support/tutorials/conda/conda-docs-env-1.0.yaml
 conda activate docs
 ```
 


### PR DESCRIPTION
Reverts CSCfi/csc-user-guide#440
Meant to comment, but accidentally merged.