### PR TITLE
Expand the oc client installation section. 

### DIFF
--- a/docs/cloud/rahti/usage/cli.md
+++ b/docs/cloud/rahti/usage/cli.md
@@ -4,6 +4,32 @@ Rahti can be used via the command line either with OpenShift's _oc_ tool
 or with the _kubectl_ tool from Kubernetes. Certain features specific to OpenShift
 are only available when using the oc tool.
 
+## How to install the `oc` tool
+
+The oc tool is a single binary that only needs to be included in your _path_. You may download it from the [latest release](https://github.com/openshift/origin/releases/latest) page in GitHub. The detailed instructions are:
+
+* Go to the aforementioned release page (<https://github.com/openshift/origin/releases/latest>). In the bottom you will see the list of clients. Download the "Openshift origin client" corresponding to your OS (Windows, Mac or Linux).
+* Once downloaded, extract the `oc` binary file.
+* Copy the file to a folder in your `$PATH` and make it executable. For Mac and Linux the steps are similar to the following:
+
+```
+$ echo $PATH
+/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:~/bin
+$ mkdir -p ~/bin
+$ cp oc ~/bin/
+$ chmod +x ~/bin/oc
+```
+
+In the example above, we are displaying the contents of the `$PATH` variable, choosing the bin folder in the home (~) folder, using `mkdir` just to be sure that the folder exist, copy the oc command (of course, we have to be in the folder `oc` was downloaded), and finally adding executable (`+x`) permissions to the `oc` binary. That is all.
+
+In order to test that it was properly installed, open a new terminal, go to any folder, and run:
+
+```
+$ oc --help
+```
+
+It should show the list of all available commands.
+
 ## The "Command Line Tools" page in the OpenShift web UI
 
 Instructions for downloading the oc tool and logging in via the command line
@@ -11,7 +37,7 @@ can be found in the "Command Line Tools" page in the web interface:
 
 ![Command line tools](img/cli_help_menu_3.7.png)
 
-The oc tool is a single binary that only needs to be included in your _path_. 
+The oc tool is a single binary that only needs to be included in your _path_.
 The oc login command to login can be found in one of the fields on the page. There is a
 button next to it for copying the command to the clipboard:
 


### PR DESCRIPTION
Even though most of the information is already there, the word "install" was not mentioned, and it relied on the costumer having already an account in Rahti. This way we can point costumers (present and future) to a specific section of the documentation with a clear list of steps.