### PR TITLE
Dummyindex

### DIFF
--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -1,0 +1,6 @@
+# Supporting materials
+
+## [Tutorials](tutorials/index.md)
+## [FAQ](faq/index.md)
+## [Training Materials](training-material.md)
+## [Contact us](contact.md)

--- a/tests/python_link_tests/whitelist
+++ b/tests/python_link_tests/whitelist
@@ -1,2 +1,3 @@
 docs/cloud/index.md
 docs/connecting/index.md
+docs/support/index.md


### PR DESCRIPTION
add an index page (hidden from navigation) which enables using also docs.csc.fi/support/ directly in browser url to get a page instead of forbidden 403