### PR TITLE
adding tsv-utils, removed version nr.

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -124,8 +124,9 @@
 
 ## Language Research and Other Digital Humanities and Social Sciences
 
+* [eBay's tsv-tools](http://urn.fi/urn:nbn:fi:lb-202006081) Utilities for manipulating large tabular data files
 * [finnish-parse](http://urn.fi/urn:nbn:fi:lb-2017030801) Dependency Parser for Finnish
-* [Finnish Tagtools](http://urn.fi/urn:nbn:fi:lb-201908161) Finnish Tagtools 1.4
+* [Finnish Tagtools](http://urn.fi/urn:nbn:fi:lb-201908161) Finnish Tagtools
 * [HFST](http://urn.fi/urn:nbn:fi:lb-20140730183) Helsinki Finite-State Transducer Technology
 * [HFST-fi](http://urn.fi/urn:nbn:fi:lb-201509034) Helsinki Finite-State Technology for Finnish
 * [HFST-sv](http://urn.fi/urn:nbn:fi:lb-201509035) Helsinki Finite-State Technology for Swedish


### PR DESCRIPTION
Note: URN works only from 10pm today, points to: http://metashare.csc.fi/repository/browse/ebays-tsv-utils/5d13cafea96211ea9940005056be118e53698c1e607e49e1a783a1eca429d61a/