### PR TITLE
Updated singularity instructions to use sinteractive and singularity_wrapper

### DIFF
--- a/docs/computing/containers/run-existing.md
+++ b/docs/computing/containers/run-existing.md
@@ -29,7 +29,7 @@ singularity build pytorch_20.03-py3.sif docker://nvcr.io/nvidia/pytorch:20.03-py
 
 Note that the Singularity image `.sif` files can easily be several GB in size, so they should not be stored in your home directory, but for example in the project application directory [projappl](/computing/disk). 
 
-To run a slurm batch job using a container you need to use the `singularity exec` command, and remember to bind all the neccessary paths with the `--bind` option.  As an alternative you can also use our `singularity_wrapper` command which automatically includes all the neccessary binds for CSC's environment.
+To run a slurm batch job using a container you need to use the `singularity exec` command, and remember to bind all the necessary paths with the `--bind` option.  As an alternative you can also use our `singularity_wrapper` command which automatically includes all the necessary binds for CSC's environment.
 
 For example, to a run a GPU job with the PyTorch image created above you could use the following script:
 

--- a/docs/computing/containers/run-existing.md
+++ b/docs/computing/containers/run-existing.md
@@ -7,7 +7,7 @@ If you find some image missing that you think could be generally useful, you can
 
 ## Converting Docker images for use with Puhti
 
-If you cannot find a suitable Singularity image among those provided by CSC's staff, you can convert it yourself from an existing Docker image.  For example NVIDIA has a library of container images for different GPU-enabled applications in their [NVIDIA GPU cloud (NGC)](https://ngc.nvidia.com/).
+If you cannot find a suitable Singularity image among those provided by CSC's staff, you can convert it yourself from an existing Docker image.  For example, NVIDIA has a library of container images for different GPU-enabled applications in their [NVIDIA GPU cloud (NGC)](https://ngc.nvidia.com/).
 
 Here is an example how to build a Singularity image from NVIDIA's PyTorch Docker image. We'll use `sinteractive` as heavy processing should not be done in the login nodes.
 

--- a/docs/computing/containers/run-existing.md
+++ b/docs/computing/containers/run-existing.md
@@ -7,44 +7,44 @@ If you find some image missing that you think could be generally useful, you can
 
 ## Converting Docker images for use with Puhti
 
-If you cannot find a suitable Singularity image among those provided by CSC's staff, you can convert it yourself from an existing Docker image.  For example Nvidia has a library of container images for different GPU-enabled applications in their [Nvidia GPU cloud (NGC)](https://ngc.nvidia.com/).
+If you cannot find a suitable Singularity image among those provided by CSC's staff, you can convert it yourself from an existing Docker image.  For example NVIDIA has a library of container images for different GPU-enabled applications in their [NVIDIA GPU cloud (NGC)](https://ngc.nvidia.com/).
 
-Here is an example how to build a Singularity image from Nvidia's PyTorch Docker image on a Puhti compute node:
+Here is an example how to build a Singularity image from NVIDIA's PyTorch Docker image. We'll use `sinteractive` as heavy processing should not be done in the login nodes.
 
 ```bash
-# We'll reserve 100GB NVME for fast temporary disk space
-srun -A <project> --gres=nvme:100 -t 1:00:00 --mem=16G --pty $SHELL
+# Let's start a 1 hour interactive job
+sinteractive --account <project> --time 1:00:00
 
-# Let's use the NVME space for temporary storage
+# Let's use the fast local drive for temporary storage
 export SINGULARITY_TMPDIR=$LOCAL_SCRATCH
 export SINGULARITY_CACHEDIR=$LOCAL_SCRATCH
 
 # This is just to avoid some annoying warnings
-unset XDG_RUNTIME_DIR PROMPT_COMMAND
+unset XDG_RUNTIME_DIR
 
 # Do the actual conversion
 # NOTE: the Docker image is downloaded straight from NGC
-singularity build pytorch_19.10-py3.sif docker://nvcr.io/nvidia/pytorch:19.10-py3
+singularity build pytorch_20.03-py3.sif docker://nvcr.io/nvidia/pytorch:20.03-py3
 ```
 
-Note that the Singularity image `.sif` files can easily be several GB in size, so they should not be stored in your home directory, but for example in the project appliction directory [projappl](/computing/disk). 
+Note that the Singularity image `.sif` files can easily be several GB in size, so they should not be stored in your home directory, but for example in the project application directory [projappl](/computing/disk). 
 
-To run a slurm batch job using a container you just need to add `singularity exec` to the place in your slurm script where you are executing the command.
+To run a slurm batch job using a container you need to use the `singularity exec` command, and remember to bind all the neccessary paths with the `--bind` option.  As an alternative you can also use our `singularity_wrapper` command which automatically includes all the neccessary binds for CSC's environment.
 
 For example, to a run a GPU job with the PyTorch image created above you could use the following script:
 
 ```bash
 #!/bin/bash
-#SBATCH --account=<project> 
+#SBATCH --account=<project>
 #SBATCH --cpus-per-task=10 
-#SBATCH --partition=gpu 
+#SBATCH --partition=gputest
 #SBATCH --gres=gpu:v100:1 
-#SBATCH --time=10
+#SBATCH --time=15
 #SBATCH --mem=16G  # Total amount of memory reserved for job
 
-srun singularity exec --nv --bind /projappl:/projappl --bind /scratch:/scratch \
-    /path/to/pytorch_19.10-py3.sif \
-    python3 myprog <options>
+module purge
+
+srun singularity_wrapper exec --nv /path/to/pytorch_20.03-py3.sif python3 myprog.py <options>
 ```
 
-Note that we use `--bind` to map `/projappl` and `/scratch` so that they are visible in the Singularity environment.  The `--nv` flag is only needed for GPU jobs.
+Note that the `module purge` is important as a loaded singularity-based module would override what image to use for the `singularity_wrapper` command.  The `--nv` flag is only needed for GPU jobs.


### PR DESCRIPTION
Updated computing/containers/run-existing.md so that:

- conversion example uses `sinteractive`
- run example uses `singularity_wrapper`