### PR TITLE
Add instructions for converting images

### DIFF
--- a/docs/cloud/pouta/adding-images.md
+++ b/docs/cloud/pouta/adding-images.md
@@ -278,7 +278,7 @@ image.
 As previously mentioned, the qcow2 format will store only the actual 
 customer data instead of storing a 1-to-1 copy of the root disk. If the 
 size of the customer data is considerably smaller than the total 
-capacity of the root disk, similarily the qcow2 image will be 
+capacity of the root disk, similarly the qcow2 image will be 
 considerably smaller than the raw image.
 
 7) Once the conversion is completed, the new image can be uploaded to 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,7 @@ nav:
             - Snapshots: cloud/pouta/snapshots.md
         - Images:
             - Basic information about images: cloud/pouta/images.md
-            - Creating, Uploading and Sharing virtual machine images: cloud/pouta/adding-images.md
+            - Creating, Converting, Uploading and Sharing virtual machine images: cloud/pouta/adding-images.md
         - Orchestration with Heat: cloud/pouta/heat-orchestration.md
         - Application Development Practises in Pouta: cloud/pouta/application-dev.md
         - Additional services in Pouta (email, dns): cloud/pouta/additional-services.md


### PR DESCRIPTION
Taking snapshot of virtual machine instances is a desired feature, but
the images obtained are in raw format, which quickly deplete the space
available for images. Alternative and more efficient formats do exist,
but customers do not have instructions on how to convert snapshots using
these formats, and thus saving space ultimately.

This commit will:
- add a section in the page about operations on images. This sections
describes a procedure for converting a snapshot from raw format to qcow2
and upload it to OpenStack.