### PR TITLE
Fixes broken section link

### DIFF
--- a/docs/computing/running/creating-job-scripts-mahti.md
+++ b/docs/computing/running/creating-job-scripts-mahti.md
@@ -50,7 +50,7 @@ parallelization can run multiple OpenMP threads per MPI task. In addition to the
 `--ntasks-per-node=X` on needs to set `--cpus-per-task=Y`. The default is one cpu
 (thread) per task. To use all physical cores
 in a Mahti node, choose `X * Y = 128`, or including virtual cores `X * Y = 256`, like
-in [this example](../example-job-scripts-mahti#mpi+openmp).
+in [this example](../example-job-scripts-mahti#mpi-openmp).
 
 
 <!-- FIXME how to enable hyperthreading? -->


### PR DESCRIPTION
`+` is an invalid character for mkdoc links, so the
title mpi+openmpi gets converted to mpi-openmpi in the html
anchor name