### PR TITLE
Improve tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,5 @@ script:
   - bash tests/check_long_slurm_flags.sh
   # There should be no FIXME entires present
   - bash tests/check_fixme.sh
+  # Test that no files are masked by folder/index.md
+  - bash tests/check_masked.sh

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -1,0 +1,3 @@
+# FAQ
+
+this file should create an error

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -1,3 +1,0 @@
-# FAQ
-
-this file should create an error

--- a/tests/check_masked.sh
+++ b/tests/check_masked.sh
@@ -15,6 +15,10 @@ while read -r file; do
         RET=1
         echo "File docs/$masked_md is masked by docs/$file"
     fi
-
 done<<<"$index_files"
-exit $RET
+if [[ $RET -eq 0 ]];then
+    echo "No masked files found"
+    exit 0 
+else
+    exit 1
+fi

--- a/tests/check_masked.sh
+++ b/tests/check_masked.sh
@@ -1,0 +1,20 @@
+
+
+# .md files can not have the same name as directory
+# on the same level in the hierarchy as they will be
+# Masked and not visible
+
+
+
+index_files=$(find docs/ -mindepth 2 -name "index.md")
+RET=0
+
+while read -r file; do
+    masked_md=$(echo $file | sed  's@/index@@g')
+    if [[ -f $masked_md ]];then
+        RET=1
+        echo "File docs/$masked_md is masked by docs/$file"
+    fi
+
+done<<<"$index_files"
+exit $RET

--- a/tests/python_link_tests/docs.py
+++ b/tests/python_link_tests/docs.py
@@ -182,7 +182,20 @@ class Internal_link:
         source=self.source_file.path
         source="site/"+source[5:]
 
-        
+        # Check that the md file exists
+        if(self.ends_with_md):
+            if(self.is_absolute):
+                path_to_md="docs/"+ft
+            else:
+                path_to_md=f.path+"/"+ft 
+            command="readlink -ev -- " +path_to_md
+            res=run_bash(command)
+            if(res.returncode==1):
+                return
+            
+
+
+
         if(not self.source_is_index):
             target="../"+target
             source=source+"/"+self.source_file.name


### PR DESCRIPTION
- `foldername.md` files will not have a page generated if a `foldername/index.md` file exists
The `check_masked.sh` tests for this.

-  The link test now checks links to non-existent .md files
    which resolve to valid paths

Resolves #291 