### PR TITLE
Upgrade versions of requirements

### DIFF
--- a/mkdocs_csc/base.html
+++ b/mkdocs_csc/base.html
@@ -88,7 +88,7 @@
         {{ lang.t('skip.link.title') }}
       </a> {% endif %} {% block header %} {% include "partials/header.html" %} {% endblock %}
         <div class="md-container">
-            {% block hero %} {% if page and page.meta and page.meta.hero %} {% include "partials/hero.html" with context %} {% endif %} {% endblock %} {% if feature.tabs %} {% include "partials/tabs.html" %} {% endif %}
+            {% block hero %} {% if page and page.meta and page.meta.hero %} {% include "partials/hero.html" with context %} {% endif %} {% endblock %}
             <main class="md-main" role="main">
                 <div class="md-main__inner md-grid" data-md-component="container">
                     {% block site_nav %} {% if nav %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # This is what we actually install
-mkdocs==1.0.4
+mkdocs==1.1.2
+mkdocs-material==6.1.0
 mdx-linkify==1.0
 mdx-environment==0.2.0
 yasha==4.1
-mkdocs-material==4.3.0
-pymdown-extensions==5.0
+pymdown-extensions==8.0.1
 mkdocs-windmill==1.0.0
 #mkdocs-rtd-dropdown==1.0.2
 
@@ -13,16 +13,25 @@ backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 bleach==3.1.4
 certifi==2017.11.5
-click==6.7
+click==7.1.2
+future==0.18.2
 html5lib==1.0.1
-Jinja2==2.10.1
-livereload==2.5.1
-#Markdown==2.6.10
-MarkupSafe==1.0
+importlib-metadata==2.0.0
+Jinja2==2.11.2
+joblib==0.17.0
+livereload==2.6.3
+lunr==0.5.8
+Markdown==3.3.2
+MarkupSafe==1.1.1
+nltk==3.5
+Pygments==2.7.1
 pytoml==0.1.14
-PyYAML==4.2b1
+PyYAML==5.3.1
+regex==2020.10.15
 singledispatch==3.4.0.3
-six==1.11.0
-tornado==5.1.1
+six==1.15.0
+tornado==6.0.4
+tqdm==4.50.2
 webencodings==0.5.1
 xmltodict==0.11.0
+zipp==3.3.1


### PR DESCRIPTION
Upgraded the versions of packages in `requirements.txt`. 

May need to make this change as well:
```
+++ b/mkdocs_csc/base.html
@@ -88,7 +88,7 @@
         {{ lang.t('skip.link.title') }}
       </a> {% endif %} {% block header %} {% include "partials/header.html" %} {% endblock %}
         <div class="md-container">
-            {% block hero %} {% if page and page.meta and page.meta.hero %} {% include "partials/hero.html" with context %} {% endif %} {% endblock %} {% if feature.tabs %} {% include "partials/tabs.html" %} {% endif %}
+            {% block hero %} {% if page and page.meta and page.meta.hero %} {% include "partials/hero.html" with context %} {% endif %} {% endblock %}
```
mkdocs was having problems to find `feature.tabs`.