### PR TITLE
Remove mail edit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.bak
 *~
 site/
+*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ script:
   # Checks all files for commonly misspelled English words with client9's misspell
   - bash tests/misspell.bash
 
-  # Testing if there are any warnings
-  - bash tests/checkwarnings.bash
   # Testing if the build works
   - bash tests/checkbuild.bash
 
@@ -42,7 +40,7 @@ script:
   # Valid partitions
   - bash tests/check_partitions.sh
   # Dont set mail on by default
-  - bash tests/check_mail_commented.sh
+  - bash tests/check_mail_commands.sh
   # Use long slurm flags
   - bash tests/check_long_slurm_flags.sh
   # There should be no FIXME entires present

--- a/docs/apps/comsol.md
+++ b/docs/apps/comsol.md
@@ -34,7 +34,7 @@ The preferred method to use COMSOL interactively is via [NoMachine](nomachine.md
 ```bash
 $ srun --ntasks=1 --time=00:10:00 --mem=1G --x11=first --pty \
   --account=<project> --partition=small --mail-type=BEGIN \
-  --mail-user=<your email address> bash
+   bash
 ```
 
 You have to specify the execution time and memory requirement corresponding your needs. Remember to add your billing project, too. You will get an email notification, when requested computing resources are available. After that you can start COMSOL.

--- a/docs/apps/gold.md
+++ b/docs/apps/gold.md
@@ -37,7 +37,7 @@ interactive session, finally GOLD.
 module load ccdc
 srun --ntasks=1 --time=00:10:00 --mem=1G --pty \
   --account=<project> --partition=small --mail-type=BEGIN \
-  --mail-user=<your email address> bash  # and wait for resources to be granted
+   bash  # and wait for resources to be granted
 gold
 ```
 

--- a/docs/apps/gpaw.md
+++ b/docs/apps/gpaw.md
@@ -52,8 +52,7 @@ A specific version can be initialized with `module load gpaw/version`, e.g.
 #SBATCH --nodes=2
 #SBATCH --mem-per-cpu=2GB
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 80 core (2 full nodes) gpaw job, requesting
 # 30 minutes time and 2 GB of memory for each core
@@ -73,8 +72,7 @@ srun gpaw-python input.py
 #SBATCH --ntasks-per-node=32
 #SBATCH --cpus-per-task=4
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 1280 core (10 full nodes) gpaw job, using hybrid
 # MPI/OpenMP parallelization with 4 OpenMP threads per node,
@@ -98,8 +96,7 @@ srun gpaw-python input.py
 #SBATCH --nodes=10
 #SBATCH --ntasks-per-node=128
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 1280 core (10 full nodes) gpaw job, using pure
 # MPI parallelization requesting 30 minutes time.

--- a/docs/apps/gromacs.md
+++ b/docs/apps/gromacs.md
@@ -68,8 +68,7 @@ test at the scaling limit, rather than run very long scaling tests in advance.
 #SBATCH --ntasks-per-node=40
 #SBATCH --nodes=2
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 80 core (2 full nodes) gromacs job, requesting 15 minutes time
 
@@ -93,8 +92,7 @@ srun gmx_mpi mdrun -s topol -maxh 0.2 -dlb yes
 #SBATCH --partition=small
 #SBATCH --ntasks=1
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 1 core gromacs job, requesting 15 minutes time
 
@@ -114,8 +112,7 @@ srun gmx_mpi mdrun -s topol -maxh 0.2 -dlb yes
 #SBATCH --time=00:10:00
 #SBATCH --partition=gpu
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 module load gromacs-env/2020-gpu
 
@@ -146,8 +143,7 @@ Submit the script with `sbatch script_name.sh`
 #SBATCH --ntasks-per-node=128
 #SBATCH --nodes=2
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 256 core (2 full nodes, no hyperthreading) gromacs job, requesting 15 minutes time
 
@@ -169,8 +165,7 @@ srun gmx_mpi mdrun -s topol -maxh 0.2 -dlb yes
 #SBATCH --cpus-per-task=2
 #SBATCH --nodes=2
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 # this script runs a 256 core (2 full nodes, no hyperthreading) gromacs job, requesting 15 minutes time
 # 64 tasks per node, each with 2 OpenMP threads

--- a/docs/apps/octave.md
+++ b/docs/apps/octave.md
@@ -39,8 +39,7 @@ Example about a serial batch script job on Puhti
 #SBATCH --partition=small
 #SBATCH --ntasks=1
 #SBATCH --account=<project>
-#SBATCH --mail-type=END
-##SBATCH --mail-user=your.email@your.domain  # edit the email and uncomment to get mail
+##SBATCH --mail-type=END #uncomment to get mail
 
 module load octave-env
 

--- a/docs/apps/paraview.md
+++ b/docs/apps/paraview.md
@@ -138,9 +138,8 @@ sbatch pvserver581-4GPU-node.sh
 #SBATCH --partition=gpu
 # fill in your project number (mandatory)
 #SBATCH --account=<project>
-# remove the extra # and fill in your email address, to receive email when job starts
-##SBATCH --mail-user=<email address>
-#SBATCH --mail-type=BEGIN
+# remove the extra # to receive email when job starts
+##SBATCH --mail-type=BEGIN
 ### Optionally, if queues are long, you may want to control when your job starts.
 ### To activate the SBATCH commands, remove the extra # so that only one remains.
 ### "Test-only" does not submit a job, but returns an estimate of the queuing time

--- a/docs/computing/running/creating-job-scripts-puhti.md
+++ b/docs/computing/running/creating-job-scripts-puhti.md
@@ -16,6 +16,7 @@ An example of a simple batch job script:
 #SBATCH --time=02:00:00
 #SBATCH --mem-per-cpu=2G
 #SBATCH --partition=small
+##SBATCH --mail-type=BEGIN #uncomment to enable mail
 
 module load myprog/1.2.3
 
@@ -75,6 +76,16 @@ The partition needs to be set according to the job requirements.
 !!! Note "Available partitions"
     [The available batch job partitions](batch-job-partitions.md).
 
+
+The user can be notified by email when the jobs starts by using the `--mail-type` option
+
+```
+##SBATCH --mail-type=BEGIN #uncomment to enable mail
+```
+
+Other useful arguments (multiple arguments are separated by a comma) are `END` and `FAIL`. 
+By default, the email will be sent to the email address of your csc account. 
+This can be overridden with the `--mail-user=` option. 
 
 After defining all required resources in the batch job script, set up the 
 environment. Note that for modules to be available for batch jobs, they need to be loaded in

--- a/docs/computing/running/example-job-scripts-puhti.md
+++ b/docs/computing/running/example-job-scripts-puhti.md
@@ -137,5 +137,5 @@ Note, as you may need to queue, it's convenient to ask for an email once the res
 ```
 srun --ntasks=1 --time=00:10:00 --mem=1G --x11=first --pty \
   --account=<project> --partition=small --mail-type=BEGIN \
-  --mail-user=<your email address> myprog
+  myprog
 ```

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -116,7 +116,7 @@ Note, as you may need to queue, it's convenient to ask for an email once the res
 ```
 srun --ntasks=1 --time=00:10:00 --mem=1G --pty \
   --account=<project> --partition=small --mail-type=BEGIN \
-  --mail-user=<your email address> bash
+   bash
 ```
 
 Once the resource has been granted, you can work normally in the shell.
@@ -137,7 +137,7 @@ The following will start the application `myprog`:
 ```
 srun --ntasks=1 --time=00:10:00 --mem=1G --x11=first --pty \
   --account=<project> --partition=small --mail-type=BEGIN \
-  --mail-user=<your email address> myprog
+   myprog
 ```
 
 Note, that you can replace `myprog` with `bash`, which will launch a terminal

--- a/docs/data/datasets.md
+++ b/docs/data/datasets.md
@@ -8,7 +8,7 @@ CSC hosts or provides access to several datasets on different platforms.
  
 ## Chemistry
 * [CSD](../apps/csd.md) Cambridge Crystallographic Database – organic and metallo-organic crystal structures and tools
-* [Molport 6M molecule database](../support/tutorial/gpu-shape.md) preprocessed for fast GPU screening with Schrödinger Shape
+* [Molport 6M molecule database](../support/tutorials/gpu-shape.md) preprocessed for fast GPU screening with Schrödinger Shape
 
 ## Geosciences
 * The main open Finnish spatial datasets are available in Puhti, located in `/appl/data/geo/` and in Allas.

--- a/docs/support/faq/email_not_working.md
+++ b/docs/support/faq/email_not_working.md
@@ -1,0 +1,6 @@
+# Sending email when a job starts/finishes is not working
+
+- Check that the option is correctly set in your batchscript `#SBATCH --mail-type=BEGIN`
+- Multiple arguments are separated by a comma `#SBATCH --mail-type=BEGIN,END`
+- The email is sent to the email address of your csc account.
+- If you are using the `--mail-user=` option, make sure the email set is valid.

--- a/docs/support/faq/index.md
+++ b/docs/support/faq/index.md
@@ -16,6 +16,7 @@
 * [How to estimate how much memory my job needs?](how-much-memory-my-job-needs.md)
 * [When will my batch job run?](when-will-my-job-run.md)
 * [How can I change which project is billed for my usage?](how-can-i-change-billing-project.md)
+* [Sending email when a job starts/finishes is not working](email_not_working.md )
 
 ## Accounts
 * [I cannot login. What to do?](i-cannot-login.md)

--- a/tests/check_mail_commands.sh
+++ b/tests/check_mail_commands.sh
@@ -1,0 +1,24 @@
+source tests/common_functions.sh
+
+regex="^\s*#SBATCH\s*--mail-type"
+pass_message="The --mail-type flag is commented out in all batch job scripts"
+fail_message="The --mail-type flag should not be active in examples."
+
+ret_code=0
+
+run_regex_test "$regex" "$pass_message" "$fail_message"
+if [[ ! $? -eq 0 ]];then
+    ret_code=1
+    echo -e ""
+fi
+
+regex="^\s*[#]*SBATCH\s*--mail-user"
+pass_message="The --mail-user is not present in any example script"
+fail_message="The --mail-user should not be present in any example script"
+
+run_regex_test "$regex" "$pass_message" "$fail_message"
+if [[ ! $? -eq 0 ]];then
+    ret_code=1
+fi
+
+exit $ret_code

--- a/tests/check_mail_commented.sh
+++ b/tests/check_mail_commented.sh
@@ -1,9 +1,0 @@
-source tests/common_functions.sh
-
-regex="^\s*#SBATCH\s*--mail-user"
-pass_message="The --mail-user flag is commented out in all batch job scripts"
-fail_message="The --mail-user flag should not be active in examples."
-
-
-run_regex_test "$regex" "$pass_message" "$fail_message"
-

--- a/tests/checkbuild.bash
+++ b/tests/checkbuild.bash
@@ -1,10 +1,24 @@
 
+
+
+
+
 build_out=$(mkdocs build 2>&1)
 res_val=$?
 
 if [ $res_val = 0 ]; then
+	
+    NUMBERS_OF_WARNINGS=$(echo "$build_out" |grep -i  WARNING |wc -l)
+    if [ $NUMBERS_OF_WARNINGS -ne 0 ]; then 
+        echo "BUILD COMPLETED WITH WARNINGS:"
+        echo "$build_out" |grep -i  WARNING
+    exit 1
+     else
 	echo "BUILD SUCCESSFUL"
-	exit 0
+    exit 0
+    fi
+
+
 else
 	echo "BUILD FAILED"
 	echo "$build_out"

--- a/tests/checkwarnings.bash
+++ b/tests/checkwarnings.bash
@@ -4,7 +4,7 @@ NUMBERS_OF_WARNINGS=$(mkdocs build 2>&1 |grep -i  WARNING |wc -l)
 
 if [ $NUMBERS_OF_WARNINGS -ne 0 ]; then 
     mkdocs build 2>&1 |grep -i  WARNING
-    echo "There are $NUMBERS_OF_WARNINGS numbers of WARNINGS"
+    echo "There are $NUMBERS_OF_WARNINGS WARNINGS"
     exit 1
 else
     echo "There were no warnings"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -6,11 +6,11 @@ NC='\033[0m' # No Color
 
 tests=$(cat .travis.yml | grep script -A 200 | grep "^\s*-" | cut -d "-" -f2 )
 
-which misspell 2>&1 1> /dev/null
+which misspell &> /dev/null
 
 if [[ $? -eq 1 ]];then
     echo -e "\nWARN: misspell not found, skipping spelling test"
-    tests=$(echo "$test" | grep -v misspell )
+    tests=$(echo "$tests" | grep -v misspell )
 fi
 
 TEST_LOG=tests/test.log

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,36 @@
+#run from top level 
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+tests=$(cat .travis.yml | grep script -A 200 | grep "^\s*-" | cut -d "-" -f2 )
+
+which misspell 2>&1 1> /dev/null
+
+if [[ $? -eq 1 ]];then
+    echo -e "\nWARN: misspell not found, skipping spelling test"
+    tests=$(echo "$test" | grep -v misspell )
+fi
+
+TEST_LOG=tests/test.log
+
+rm $TEST_LOG 
+touch $TEST_LOG
+echo -e "\nRUNNING TESTS, output in $TEST_LOG"
+echo    "--------------------------------------------"
+while IFS= read -r cmd; do
+    t_name=$(echo $cmd | rev |cut -d "/" -f 1 | rev | cut -d "." -f 1 )
+    STAT="${GREEN}OK${NC}"
+    LN=""
+    out=$(eval "$cmd")
+    if [[ ! $? -eq 0 ]];then
+    STAT="${RED}FAILED${NC}" 
+    LN=", see $TEST_LOG line $(($(cat $TEST_LOG | wc -l ) +2 ))"
+    fi
+    echo -e "\n--------------- $t_name" >> $TEST_LOG
+    echo "$out" >> $TEST_LOG
+    echo -e "$t_name  $STAT $LN"
+done <<< "$tests"
+
+


### PR DESCRIPTION
- `--mail-type` will now work without `--mail-user`. `--mail-user` can be used to override default email. 
- Removed  `--mail-user` from examples and commented out `--mail-type` (Also tests now check for this. )
- Short script to run tests locally, might require installing some small utilities like misspell. 
- FAQ entry about the mail