### PR TITLE
Merge link test to one file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,11 @@ script:
   # Testing if the build works
   - bash tests/checkbuild.bash
 
- #Testing link related things
- # Test if any links in the markdown point to no-existing files
-  - python3 tests/python_link_tests/check_broken_file_links.py
-  # Test if any section links (so file.md#section) in the markdown are invalid
-  - python3 tests/python_link_tests/check_broken_section_links.py
+  #Testing link related things
+  # Broken site and section links, hidden files
+  - python3 tests/python_link_tests/link_check.py
   # Test if any http urls point to docs.csc.fi
   - bash tests/check_internal_url.sh
-  # Check if there are any files which are not referenced at all.
-  - python3 tests/python_link_tests/check_hidden_files.py
 
 
   # Testing style-guide and slurm erros

--- a/tests/python_link_tests/link_check.py
+++ b/tests/python_link_tests/link_check.py
@@ -1,0 +1,11 @@
+from docs import *
+
+csc_docs=Docs()
+
+result_file_link = csc_docs.report_broken_file_links()
+result_section_link = csc_docs.report_broken_section_links()
+result_hidden_file = csc_docs.report_hidden_files()
+print(result_section_link[1])
+print(result_file_link[1])
+print(result_hidden_file[1])
+sys.exit(max(result_file_link[0],result_hidden_file[0],result_section_link[0]))

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,8 +1,16 @@
 #run from top level 
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NC='\033[0m' # No Color
+
+if [[ -z $1 ]];then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    NC='\033[0m' # No Color
+else
+    RED=""
+    GREEN=""
+    NC=""
+fi
+
 
 tests=$(cat .travis.yml | grep script -A 200 | grep "^\s*-" | cut -d "-" -f2 )
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,7 +1,12 @@
 #run from top level 
 
 
-if [[ -z $1 ]];then
+# Semi standard way of cheking
+# if the output is going to a terminal => enable colors
+
+# Or if it is being piped => no colors
+
+if [[ -t 1 ]];then
     RED='\033[0;31m'
     GREEN='\033[0;32m'
     NC='\033[0m' # No Color


### PR DESCRIPTION
Same action ( extracting and parsing all links ) was repeated 3 times 
which slowed down the test.

Also enables piping of the local test results by disabling colors