### PR TITLE
Interactive mpi-jobs in puhti

### DIFF
--- a/docs/apps/gromacs.md
+++ b/docs/apps/gromacs.md
@@ -180,12 +180,18 @@ srun gmx_mpi mdrun -s topol -maxh 0.2 -dlb yes
 
 ### Visualizing trajectories and graphs
 
-In addition to ngmx program in Gromacs, trajectory files can be
+In addition to `ngmx` program in Gromacs, trajectory files can be
 visualized with the following programs:
 
 -   [PyMOL] molecular modeling system.
--   [VMD] visualizing program for large biomolecular systems.
+-   [VMD](vmd.md) visualizing program for large biomolecular systems.
 -   [Grace](grace.md) plotting graphs produced with Gromacs tools
+
+!!! note
+    Please don't run visualization or heavy Gromacs tool scripts in
+    the login node (see [usage policy for details](../../computing/overview/#usage-policy)).
+    You can run the tools in the [interactive partition](../computing/running/interactive-usage.md)
+    by prepending your `gmx_mpi` command with `orterun -n 1`, e.g. `orterun -n 1 gmx_mpi msd -n index -s topol -f traj`).
 
 ## References
 
@@ -218,6 +224,7 @@ for methods applied in your setup.
 -   Gromacs home page: [http://www.gromacs.org/](http://www.gromacs.org/)
 -   [Tutorials on the Gromacs website]  
 -   [More tutorials] by Justin A. Lemkul
+-   [Yet more nice tutorials](https://www3.mpibpc.mpg.de/groups/de_groot/compbio/index.html) by Bert de Groot.
 -   [Lots of material at BioExcel EU project]
 -   [HOW-TO] section on the Gromacs pages
 -   Gromacs [documentation]
@@ -226,7 +233,6 @@ for methods applied in your setup.
 
   [documentation]: http://manual.gromacs.org/documentation
   [PyMOL]: http://www.pymol.org/
-  [VMD]: http://www.ks.uiuc.edu/Research/vmd/
   [Gromacs performance checklist]: http://www.gromacs.org/Documentation/Performance_checklist
   [Tutorials on the Gromacs website]: http://www.gromacs.org/Documentation/Tutorials
   [The PRODRG Server]: https://www.sites.google.com/site/vanaaltenlab/prodrg

--- a/docs/apps/gromacs.md
+++ b/docs/apps/gromacs.md
@@ -180,8 +180,8 @@ srun gmx_mpi mdrun -s topol -maxh 0.2 -dlb yes
 
 ### Visualizing trajectories and graphs
 
-In addition to `ngmx` program in Gromacs, trajectory files can be
-visualized with the following programs:
+In addition to `view` (not available at CSC, though) tool of Gromacs,
+trajectory files can be visualized with the following programs:
 
 -   [PyMOL] molecular modeling system.
 -   [VMD](vmd.md) visualizing program for large biomolecular systems.

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -109,7 +109,7 @@ start-rstudio-server
 ```
 For a detailed guide to launching RStudio Server, see our documentation on the [`r-env-singularity module`](../../apps/r-env-singularity.md).
 
-### Example: Running an mpi job in an interactive session
+### Example: Running an MPI job in an interactive session
 
 Since the shell started in the interactive session is already a job step in Slurm, more job steps can't be started.
 This will disable, e.g. running Gromacs tools, as `gmx_mpi` is a parallel program and normally needs `srun`.

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -109,6 +109,29 @@ start-rstudio-server
 ```
 For a detailed guide to launching RStudio Server, see our documentation on the [`r-env-singularity module`](../../apps/r-env-singularity.md).
 
+### Example: Running an mpi job in an interactive session
+
+Since the shell started in the interactive session is already a job step in Slurm, more job steps can't be started.
+This will disable, e.g. running Gromacs tools, as `gmx_mpi` is a parallel program and normally needs `srun`.
+In this case, in the interactive shell, `srun` must be replaced with `orterun -n 1`. Orterun does not know of the
+Slurm flags, so it needs to be told how many tasks/threads to use. The following example will run a
+[Gromacs](../../apps/gromacs.md) mean square displacement analysis for an existing trajectory.
+
+```bash
+sinteractive --account <project>
+module load gromacs-env
+orterun -n 1 gmx_mpi msd -n index.ndx -f traj.xtc -s topol.tpr
+```
+To use all requested cores in parallel, you need to add `--oversubscribe`.
+E.g. for 4 cores, a parallel interactive job
+(launched *from* the interactive session) can be run with
+
+```bash
+sinteractive --account <project> -c 4
+module load gromacs-env
+orterun -n 4 --oversubscribe gmx_mpi mdrun -s topol.tpr
+```
+
 ## Explicit interactive shell without X11 graphics
 
 If you don't want to use the `sinteractive` wrapper, it's possible


### PR DESCRIPTION
srun fails in an interactive batch job but it can be worked around by launching the app with orterun. This is needed e.g. for gmx_mpi tools as we don't want the heavy scripts to be run on logins.
Preview: https://csc-guide-preview.rahtiapp.fi/origin/interactive-gmx/computing/running/interactive-usage/
(also some gromacs specific updates at https://csc-guide-preview.rahtiapp.fi/origin/interactive-gmx/apps/gromacs/ )