### PR TITLE
instructions for csc-env run-base

### DIFF
--- a/docs/support/tutorials/index.md
+++ b/docs/support/tutorials/index.md
@@ -10,7 +10,7 @@
 * [How to run existing containers in Puhti](../../computing/containers/run-existing.md)
 * [Linux basics for CSC](env-guide/overview.md)
 * [Interactive and batch job hands-on in Puhti](cmdline-handson.md)
-* [Using csc-env](using_csc_env.md)
+* [Using csc-env command](using_csc_env.md)
 * [Developing scripts remotely](remote-dev.md)
 
 ## Performance

--- a/docs/support/tutorials/using_csc_env.md
+++ b/docs/support/tutorials/using_csc_env.md
@@ -1,4 +1,4 @@
-# csc-env
+# csc-env command
 
 `csc-env` is a command line tool for testing for common issues in the programming environment,
 and resetting the login- and ssh-settings on CSC supercomputers.

--- a/docs/support/tutorials/using_csc_env.md
+++ b/docs/support/tutorials/using_csc_env.md
@@ -136,6 +136,17 @@ See the next chapter for information on how to recover them.
 
 ### Advanced usage
 
+#### Running commands in a clean environment
+
+Using the command `csc-env run-base` the user can be dropped into a
+new shell where no user modifications are present. This is useful for testing and debugging
+without changes to any files. Running a command in a clean environment can be done with
+`csc-env run-base -- -c "command args"`
+
+Note that clean here means the default login settings (so default modules will be loaded)
+
+#### Manually creating and selecting saves 
+
 Each invocation of `csc-env reset` or `csc-env restore` automatically saves the current selected settings. 
 The command `csc-env list-saved` will list all saves:
 


### PR DESCRIPTION
Tool can be useful for end-users who want to run commands in a clean environment