### PR TITLE
Missing host information added

### DIFF
--- a/docs/data/Allas/allas-nextcloud.md
+++ b/docs/data/Allas/allas-nextcloud.md
@@ -151,6 +151,7 @@ This opens a definition menu here you need to file following parameters
 
 Folder name: display name for the allas bucket (2001234-nextcloud)
 Bucket: The bucket you just created  or some older bucket.
+Host: a3s.fi
 Port: 443
 Region: US
 Enable SSL


### PR DESCRIPTION
In Paragraph 3 of the Nextcloud part of the manual is the host information missing, maybe it is obvious what needs to be written there, but it took me some time to figure out what it is.