### PR TITLE
start an ad-hoc pod with non default command

### DIFF
--- a/docs/cloud/rahti/tutorials/oc-run.md
+++ b/docs/cloud/rahti/tutorials/oc-run.md
@@ -13,4 +13,4 @@ bash-4.2$
 * `--rm` will make the Pod to be deleted after the session is over.
 * `--image=bash` is the name of the image, in this case [library/bash](https://hub.docker.com/_/bash). It can be any given image, either public library image like `bash`, or a pourpose build private image.
 * `--restart=Never` will tell OpenShift to not restart the Pod when the session is over.
-
+* If you would like to start a Pod with a different command than its default, you can do so by adding `-- [COMMAND] [args...] [flags]` at the end (e.g. `oc run pod-name  -it --rm --image=python --restart=Never -- bash`). 


### PR DESCRIPTION
- Update the instruction to include how to start an ad-hoc pod with non default command specified under the container image.