### PR TITLE
Update compiler options

### DIFF
--- a/docs/computing/compiling-mahti.md
+++ b/docs/computing/compiling-mahti.md
@@ -42,7 +42,7 @@ performance has improved.
 | :----------------- | :---------------- | :--------------------------- | :----------- |
 | **Safe**           | -O2 -march=native | -O2 -fp-model precise | -O2 -march=native  |
 | **Intermediate**   | -O3 -march=native | -O2                    | -O3 -march=native |
-| **Aggressive**     | -O3 -march=native -ffast-math -funroll-loops | -O3 -fp-model fast=2 -no-prec-div -fimf-use-svml=true | -O3 -march=native -ffast-math -funroll-loops |
+| **Aggressive**     | -O3 -march=native -ffast-math -funroll-loops -mfma | -O3 -fp-model fast=2 -no-prec-div -fimf-use-svml=true | -O3 -march=native -ffast-math -funroll-loops -mfma |
 
 
 A detailed list of options for the Intel and GNU compilers can be found on the _man_

--- a/docs/computing/compiling-mahti.md
+++ b/docs/computing/compiling-mahti.md
@@ -42,7 +42,7 @@ performance has improved.
 | :----------------- | :---------------- | :--------------------------- | :----------- |
 | **Safe**           | -O2 -march=native | -O2 -fp-model precise | -O2 -march=native  |
 | **Intermediate**   | -O3 -march=native | -O2                    | -O3 -march=native |
-| **Aggressive**     | -O3 -march=native -ffast-math -funroll-loops -mfma | -O3 -fp-model fast=2 -no-prec-div -fimf-use-svml=true | -O3 -march=native -ffast-math -funroll-loops -mfma |
+| **Aggressive**     | -O3 -march=native -ffast-math -funroll-loops | -O3 -fp-model fast=2 -no-prec-div -fimf-use-svml=true | -O3 -march=native -ffast-math -funroll-loops |
 
 
 A detailed list of options for the Intel and GNU compilers can be found on the _man_

--- a/docs/computing/compiling-puhti.md
+++ b/docs/computing/compiling-puhti.md
@@ -39,7 +39,7 @@ correct and the program's performance has improved.
 | :----------------- | :--------------------------- | :---------------- |
 | **Safe**           | -O2 -xHost -fp-model precise | -O2 -march=native |
 | **Intermediate**   | -O2 -xHost                   | -O3 -march=native |
-| **Aggressive**     | -O3 -xHost -fp-model fast=2 -no-prec-div -fimf-use-svml=true | -O3 -march=native -ffast-math -funroll-loops |
+| **Aggressive**     | -O3 -xHost -fp-model fast=2 -no-prec-div -fimf-use-svml=true -qopt-zmm-usage=high| -O3 -march=native -ffast-math -funroll-loops -mprefer-vector-width=512|
 
 Please note that not all applications benefit from the AVX-512 vector set
 (`-xHost` or `-march=native`). It may be a good idea to also test AVX2 


### PR DESCRIPTION
Both Intel and GCC are **very** conservative for generating AVX512 instructions, thus additional flags are needed for them.