### PR TITLE
RAM requirement for standard.large is wrong

### DIFF
--- a/docs/cloud/pouta/vm-flavors-and-billing.md
+++ b/docs/cloud/pouta/vm-flavors-and-billing.md
@@ -59,7 +59,7 @@ flavors.
 |standard.tiny   |1|1 |80 |0 |80 |1  |![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|0.25 |
 |standard.small  |2|2 |80 |0 |80 |1  |![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|0.5  |
 |standard.medium |3|4 |80 |0 |80 |1.3|![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|1    |
-|standard.large  |4|7 |80 |0 |80 |1.8|![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|2    |
+|standard.large  |4|8 |80 |0 |80 |1.8|![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|2    |
 |standard.xlarge |6|15|80 |0 |80 |2.5|![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|4    |
 |standard.xxlarge|8|30|80 |0 |80 |3.8|![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|8    |
 |standard.3xlarge|8|60|80 |0 |80 |7.5|![](/img/circle_icons/p100.svg)![](/img/circle_icons/r100.svg)![](/img/circle_icons/n100.svg)|16   |


### PR DESCRIPTION
In standard.large flavor, amount of ram needed is 8GB but 7GB is
written instead.

Reviewer can check it by running command,
"openstack flavor show standard.large" and then check for ram.
Then compare it with https://docs.csc.fi/cloud/pouta/vm-flavors-and-billing/#standard-flavors.