### PR TITLE
Add tmole ricc2 remark

### DIFF
--- a/docs/apps/turbomole.md
+++ b/docs/apps/turbomole.md
@@ -5,7 +5,7 @@ It includes most standard and state of the art methods for ground state calculat
 
 ## Available
 
-*   Puhti: 7.5
+*   Puhti: 7.5, 7.5.1
 *   Mahti: 7.5
 
 ## License
@@ -70,6 +70,9 @@ jobex -ri -c 300 > jobex.out
 ``` 
     export TMPDIR=$TURBOTMPDIR
 ```
+
+!!! note
+    Second-order approximate coupled cluster calculations using the `ricc2` module have been reported to suffer from numerical errors resulting in crashed jobs. This applies for Turbomole versions 7.5 and older on Puhti. For reliable performance, we suggest running `ricc2` calculations using Turbomole 7.5.1 on Puhti or 7.5 on Mahti.
 
 !!! note
     Particularly some of the wavefunction-based electron correlation methods can be very disk I/O intensive. Such jobs benefit from using the fast local storage on Puhti. Using local disk for such jobs will also reduce the load on the Lustre parallel file system.


### PR DESCRIPTION
Note that ricc2 may encounter numerical errors with v7.5 and older on Puhti. Suggest running using v7.5.1 (or v7.5 on Mahti)