### PR TITLE
add new available opendronemap version 2.5.7

### DIFF
--- a/docs/apps/opendronemap.md
+++ b/docs/apps/opendronemap.md
@@ -6,6 +6,7 @@
 
 __OpenDroneMap__ is available in Puhti with following versions:
 
+* 2.5.7
 * 2.0.0
 * 0.9.1
 


### PR DESCRIPTION
Should here be also an indication which one is the default version linked to `opendronemap.sif`?