### PR TITLE
WIP: add other force version available

### DIFF
--- a/docs/apps/force.md
+++ b/docs/apps/force.md
@@ -7,6 +7,7 @@ FORCE (Framework for Operational Radiometric Correction for Environmental monito
 __FORCE__ is available in Puhti with the following versions:
 
 * 3.6.5 (Singularity container)
+* 3.5.1 (Singularity container)
 
 ## Usage 
 


### PR DESCRIPTION
* 3.5.1 seems to be the default version atm

@ktiits : Should default be updated to 3.6.5 or documentation show that 3.5.1 is default (and for what reason: is the finnhub issue the reason?)?