### PR TITLE
R / Jupyter Notebook tutorial update

### DIFF
--- a/docs/apps/r-env-singularity.md
+++ b/docs/apps/r-env-singularity.md
@@ -21,7 +21,7 @@ Current modules and supported versions:
 | r-env-singularity/4.0.3 | Dec 09 2020         | 3.12                 | 1.3.1093               | Intel® MKL 2020.0-088  | NA		      |
 | r-env-singularity/4.0.4 | Mar 19 2021		| 3.12		       | 1.4.1106		| Intel® MKL 2020.0-088  | TensorFlow 2.4.1   |
 | r-env-singularity/4.0.5 | Apr 20 2021		| 3.12		       | 1.4.1106		| Intel® oneMKL 2021.2.0 | TensorFlow 2.4.1   |
-| r-env-singularity/4.1.1 | Oct 05 2021		| 3.13		       | 1.4.1106		| Intel® oneMKL 2021.2.0 | TensorFlow 2.6.0   |
+| r-env-singularity/4.1.1 | Oct 05 2021		| 3.13		       | 1.4.1717		| Intel® oneMKL 2021.2.0 | TensorFlow 2.6.0   |
 
 Other software and libraries:
 
@@ -81,7 +81,7 @@ start-r
 
 The`r-env-singularity` module can be used to remotely launch RStudio Server on your web browser. For this, you have two options.
 
-**Option 1. Using the Puhti web interface**. This is by far the easiest way to launch RStudio on Puhti. For details, [see Puhti web interface documentation](../computing/webinterface/index.md).
+**Option 1. Using the Puhti web interface**. This is by far the easiest way to launch RStudio on Puhti. For details, [see the Puhti web interface documentation](../computing/webinterface/index.md).
 
 **Option 2. Using SSH tunneling**. This option requires authentication using a Secure Shell (SSH) key. Detailed instructions for this are provided in a [separate tutorial for using RStudio Server](../support/tutorials/rstudio-or-jupyter-notebooks.md) and our [documentation on setting up SSH keys on Windows, macOS and Linux](../../computing/connecting/#setting-up-ssh-keys).
 

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -18,9 +18,11 @@ SSH tunnelling requires that you have [set up SSH keys](../../computing/connecti
 ## The workflow for using RStudio or Jupyter Notebook in Puhti
 
 *Using the Puhti Web Interface*
+
 * For instructions on this, [see the Puhti web interface documentation](../computing/webinterface/index.md)
 
 *Using SSH tunneling*
+
 * Start interactive session
 * Load suitable modules and start RStudio or Jupyter Notebook server
 * Create SSH tunnel from your PC to Puhti compute node

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -5,7 +5,7 @@ The R or Python code is run on a compute node within an [interactive session](..
 
 There are two ways to esing RStudio Server or Jupyter Notebook on Puhti.
 
-1. The first (and easiest) option is to use [the Puhti web interface](../computing/webinterface/index.md).
+1. The first (and easiest) option is to use [the Puhti web interface](../../computing/webinterface/index.md).
 
 2. The second option is to create a SSH tunnel from a local PC to a compute node. As compute nodes are inaccessible via the Internet, 
 the tunnel needs to go through a login node. This is not possible with Windows PowerShell (it does not support jump servers), and therefore it is 
@@ -15,11 +15,11 @@ SSH tunnelling requires that you have [set up SSH keys](../../computing/connecti
 * With Linux, macOS and MobaXterm the SSH tunnelling works by default.
 * PuTTy requires filling in the settings to PuTTy tabs, so it is slower and more complicated, but possible.
 
-## The workflow for using RStudio or Jupyter Notebook in Puhti
+## Workflow for using RStudio or Jupyter Notebook in Puhti
 
 *Using the Puhti Web Interface*
 
-* For instructions on this, [see the Puhti web interface documentation](../computing/webinterface/index.md)
+* For instructions on this, [see the Puhti web interface documentation.](../computing/webinterface/index.md)
 
 *Using SSH tunneling*
 

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -3,7 +3,7 @@
 [RStudio](https://www.rstudio.com/) and [Jupyter notebooks](https://jupyter.org/) are convenient options for developing and running R or Python code. 
 The R or Python code is run on a compute node within an [interactive session](../../computing/running/interactive-usage.md), but the tools themselves are used via a local web browser. So, there is no need to use NoMachine.
 
-There are two ways to esing RStudio Server or Jupyter Notebook on Puhti.
+There are two ways to use RStudio Server or Jupyter Notebook on Puhti.
 
 1. The first (and easiest) option is to use [the Puhti web interface](../../computing/webinterface/index.md).
 
@@ -12,8 +12,7 @@ the tunnel needs to go through a login node. This is not possible with Windows P
 not suitable for RStudio or Jupyter Notebook in Puhti. 
 SSH tunnelling requires that you have [set up SSH keys](../../computing/connecting.md#setting-up-ssh-keys). 
 
-* With Linux, macOS and MobaXterm the SSH tunnelling works by default.
-* PuTTy requires filling in the settings to PuTTy tabs, so it is slower and more complicated, but possible.
+With Linux, macOS and MobaXterm the SSH tunnelling works by default. PuTTy requires filling in the settings to PuTTy tabs, so it is slower and more complicated, but possible.
 
 ## Workflow for using RStudio or Jupyter Notebook in Puhti
 

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -16,11 +16,11 @@ With Linux, macOS and MobaXterm the SSH tunnelling works by default. PuTTy requi
 
 ## Workflow for using RStudio or Jupyter Notebook in Puhti
 
-*Using the Puhti Web Interface*
+**Using the Puhti Web Interface**
 
 * For instructions on this, [see the Puhti web interface documentation.](../../computing/webinterface/index.md)
 
-*Using SSH tunneling*
+**Using SSH tunneling**
 
 * Start interactive session
 * Load suitable modules and start RStudio or Jupyter Notebook server

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -3,7 +3,11 @@
 [RStudio](https://www.rstudio.com/) and [Jupyter notebooks](https://jupyter.org/) are convenient options for developing and running R or Python code. 
 The R or Python code is run on a compute node within an [interactive session](../../computing/running/interactive-usage.md), but the tools themselves are used via a local web browser. So, there is no need to use NoMachine.
 
-Using RStudio or Jupyter Notebook involves creating a SSH tunnel from a local PC to a compute node. As compute nodes are inaccessible via the Internet, 
+There are two ways to esing RStudio Server or Jupyter Notebook on Puhti.
+
+1. The first (and easiest) option is to use [the Puhti web interface](../computing/webinterface/index.md).
+
+2. The second option is to create a SSH tunnel from a local PC to a compute node. As compute nodes are inaccessible via the Internet, 
 the tunnel needs to go through a login node. This is not possible with Windows PowerShell (it does not support jump servers), and therefore it is 
 not suitable for RStudio or Jupyter Notebook in Puhti. 
 SSH tunnelling requires that you have [set up SSH keys](../../computing/connecting.md#setting-up-ssh-keys). 
@@ -13,10 +17,18 @@ SSH tunnelling requires that you have [set up SSH keys](../../computing/connecti
 
 ## The workflow for using RStudio or Jupyter Notebook in Puhti
 
+*Using the Puhti Web Interface*
+* For instructions on this, [see the Puhti web interface documentation](../computing/webinterface/index.md)
+
+*Using SSH tunneling*
 * Start interactive session
 * Load suitable modules and start RStudio or Jupyter Notebook server
 * Create SSH tunnel from your PC to Puhti compute node
 * Open RStudio or Jupyter Notebook in local web browser
+
+More detailed information on the different steps to launch RStudio or Jupyter Notebook using SSH tunneling is provided in the following. 
+
+## Instructions for SSH tunneling
 
 ### 1. Start interactive session
 Start an interactive session, for example with `sinteractive -i`. For more options and maximum limits see the [interactive usage page.](../../computing/running/interactive-usage.md)

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -18,7 +18,7 @@ With Linux, macOS and MobaXterm the SSH tunnelling works by default. PuTTy requi
 
 *Using the Puhti Web Interface*
 
-* For instructions on this, [see the Puhti web interface documentation.](../computing/webinterface/index.md)
+* For instructions on this, [see the Puhti web interface documentation.](../../computing/webinterface/index.md)
 
 *Using SSH tunneling*
 


### PR DESCRIPTION
- The R/Jupyter Notebook tutorial now mentions OOD (while also retaining instructions on SSH tunneling)
- Fixed RStudio Server version in r-env-singularity documentation

https://csc-guide-preview.rahtiapp.fi/origin/r-notebook-update/support/tutorials/rstudio-or-jupyter-notebooks/