### PR TITLE
Added/updated OOD usage to GIS modules with GUI

### DIFF
--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -10,33 +10,23 @@ __GRASS__ is available in Puhti with following versions:
 
 ## Usage
 
-### Using GRASS GIS Command Line Interface 
+### GRASS GIS Command Line Interface 
 
-In Puhti, GRASS GIS is installed inside the [QGIS singularity installation](qgis.md)
+In Puhti, GRASS GIS is included in [QGIS module](qgis.md). GRASS GIS command line tools can be used in an [interactive session](../computing/running/interactive-usage.md) or [batch jobs](../computing/running/getting-started.md). For using GRASS GIS, see [exmples for using GRASS GIS commands in Puhti with GRASS bash scripting, Python scripting or PyGRASS](https://github.com/csc-training/geocomputing/tree/master/grass).
 
-It can be loaded with
+### GRASS GIS Graphical User Interface
+
+Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). 
+2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
+
+Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
 
 ```
 module load qgis
-```
-
-After loading the module you can use the GRASS GIS graphical user interface from an interactive session with 
-
-```
-sinteractive -i
 grass
 ```
-
-You can also use the command line tools that come in GRASS. See the [GRASS GIS manual](https://grass.osgeo.org/learn/manuals/) for more information. 
-
-[Exmples for using GRASS GIS commands in Puhti with GRASS bash scripting, Python scripting or PyGRASS](https://github.com/csc-training/geocomputing/tree/master/grass).
-
-### Using GRASS GIS Graphical User Interface
-
-The GRASS GIS Graphical User Interface is available via the Puhti web interface:
-
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
 ## License and citing
 

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -10,14 +10,7 @@ __GRASS__ is available in Puhti with following versions:
 
 ## Usage
 
-### Using GRASS GIS in Puhti web interface
-
-This is the new recommended way.
-
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
-
-### Alternative (old) use of GRASS GIS with NoMachine
+### Using GRASS GIS Command Line Interface 
 
 In Puhti, GRASS GIS is installed inside the [QGIS singularity installation](qgis.md)
 
@@ -36,11 +29,14 @@ grass
 
 You can also use the command line tools that come in GRASS. See the [GRASS GIS manual](https://grass.osgeo.org/learn/manuals/) for more information. 
 
-
-!!! note
-    The recommended way of using graphical interfaces in Puhti is through [NoMachine](nomachine.md) and an [interactive batch job](../computing/running/interactive-usage.md)
-
 [Exmples for using GRASS GIS commands in Puhti with GRASS bash scripting, Python scripting or PyGRASS](https://github.com/csc-training/geocomputing/tree/master/grass).
+
+### Using GRASS GIS Graphical User Interface
+
+The GRASS GIS Graphical User Interface is available via the Puhti web interface:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
 ## License and citing
 

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -10,7 +10,16 @@ __GRASS__ is available in Puhti with following versions:
 
 ## Usage
 
-In Puhti GRASS GIS is installed inside the [QGIS singularity installation](qgis.md)
+### Using GRASS GIS in Puhti web interface
+
+This is the new recommended way.
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
+
+### Alternative (old) use of GRASS GIS with NoMachine
+
+In Puhti, GRASS GIS is installed inside the [QGIS singularity installation](qgis.md)
 
 It can be loaded with
 

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -6,29 +6,28 @@ In Puhti, QGIS could be used for example to visualize the resulting files from o
 
 ## Available
 
-__QGIS__ has been installed in two different ways to Puhti. The Singularity installation is a container installation which makes it somewhat faster compared to the older conda installation. QGIS is available in Puhti with following versions:
+__QGIS__ is available in Puhti with following versions:
 
 * 3.16 in a singularity container: qgis module
-* 3.14 via conda in geoconda-3.8 module
-* 3.10 via conda in geoconda-3.7 module
 
 ## Usage
 
-### Using QGIS in Puhti web interface
+Using QGIS in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
 
-This is the new recommended way.
+1. Log in to [Puhti web interface](https://puhti.csc.fi). 
+2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS' 
-3. The QGIS GUI is started automatically when the Desktop is launched. To launch QGIS alternatively from the command line, use:
+Alternatively, especially if you want to use QGIS and some other GUI tool together or want to use data from Allas, QGIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
+
 ```
 module load qgis
 qgis
 ```
 
+
 ### PyQGIS
 
-It is also possible to access QGIS functionalities from Python without an graphical user interface with the [PyQGIS library](https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/). With `qgis module` use `python3` for accessing PyQGIS libraries.
+It is also possible to access QGIS functionalities from Python without an graphical user interface with the [PyQGIS library](https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/). Use `python3` for accessing PyQGIS libraries.
 
 
 ### QGIS and Allas

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -19,7 +19,12 @@ __QGIS__ has been installed in two different ways to Puhti. The Singularity inst
 This is the new recommended way.
 
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
+2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS' 
+3. The QGIS GUI is started automatically when the Desktop is launched. To launch QGIS alternatively from the command line, use:
+```
+module load qgis
+qgis
+```
 
 ### PyQGIS
 

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -8,9 +8,9 @@ In Puhti, QGIS could be used for example to visualize the resulting files from o
 
 __QGIS__ has been installed in two different ways to Puhti. The Singularity installation is a container installation which makes it somewhat faster compared to the older conda installation. QGIS is available in Puhti with following versions:
 
-* 3.16 in a singularity container
-* 3.14 via conda in geoconda-3.8
-* 3.10 via conda in geoconda-3.7
+* 3.16 in a singularity container: qgis module
+* 3.14 via conda in geoconda-3.8 module
+* 3.10 via conda in geoconda-3.7 module
 
 ## Usage
 
@@ -21,25 +21,8 @@ This is the new recommended way.
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-#### Singularity installation
-
-Load the module and start QGIS
-
-```
-module load qgis
-qgis
-```
-
-#### Conda installation
-
-QGIS is older older versions are included in the [geoconda](../apps/geoconda.md) module and can be started with
-
-```
-module load geoconda
-qgis
-```    
-
 ### PyQGIS
+
 It is also possible to access QGIS functionalities from Python without an graphical user interface with the [PyQGIS library](https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook/). With `qgis module` use `python3` for accessing PyQGIS libraries.
 
 

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -18,7 +18,7 @@ __QGIS__ has been installed in two different ways to Puhti. The Singularity inst
 
 This is the new recommended way.
 
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/index.md).
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
 ### Alternative (old) use of QGIS with NoMachine

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -21,16 +21,6 @@ This is the new recommended way.
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-### Alternative (old) use of QGIS with NoMachine
-
-1. Connect to Puhti with [NoMachine](nomachine.md). A SSH connection with __X11 forwarding__ should also work, but is likely slower.
-2. Start an [interactive session](../computing/running/interactive-usage.md)
-
-```
-sinteractive -i
-```
-
-
 #### Singularity installation
 
 Load the module and start QGIS

--- a/docs/apps/saga-gis.md
+++ b/docs/apps/saga-gis.md
@@ -1,64 +1,42 @@
 # SAGA GIS
 
-[Saga GIS](http://www.saga-gis.org/) (System for Automated Geoscientific Analyses) is a GIS application for spatial data editing and GIS analyses. It can be used with a graphical user interface, command line tools or through the R package `Rsagacmd` or `RSAGA`. Since the `RSAGA` package is no longer actively maintained and has not been tested on newer SAGA GIS versions, we recommend using `Rsagacmd` with SAGA GIS 7.9.0.
+[Saga GIS](http://www.saga-gis.org/) (System for Automated Geoscientific Analyses) is a GIS application for spatial data editing and GIS analyses. It can be used with a graphical user interface, command line tools or through the R package `Rsagacmd` or `RSAGA`. Since the `RSAGA` package is no longer actively maintained and has not been tested on newer SAGA GIS versions, we recommend using `Rsagacmd` with SAGA GIS 7.9.0 and higher.
 
 ## Available
 
-__SAGA GIS__ is available in Puhti with following versions:
-
-* 7.10.0 in `r-env-singularity/4.0.4` module
-* 7.9.0 in `r-env-singularity/4.0.2`, `r-env-singularity/4.0.3` and `r-env-singularity/4.0.5` modules
-* 7.3.0 in `r-env-singularity/3.6.3` module
-* 7.2.0 in `saga-gis` module
+__SAGA GIS__ is available in Puhti in [r-env-singularity module  with different versions](r-env-for-gis.md).
 
 ## Usage 
 
-### Using SAGA GIS command line interface
+### SAGA GIS command line interface
 
-In Puhti, SAGA GIS is available from the r-env-singularity module. It is a Singularity container which means the commands are slightly different compared to old installations.
+`r-env-singularity` is a Singularity container, which means the commands are slightly different compared normal installations, basically all commands need to have `singularity_wrapper exec` before the usual command.
 
-Before running anything, you should first start an [interactive session](../computing/running/interactive-usage.md) on a computing node and load `r-env-singularity ` module.
-
-```
-sinteractive -i
-module load r-env-singularity 
-```
+SAGA GIS command line tools can be used in an [interactive session](../computing/running/interactive-usage.md) or [batch jobs](../computing/running/getting-started.md).
 
 You can test that SAGA GIS loaded successfully and print the command line tools help information with
 
 ```
+module load r-env-singularity 
 singularity_wrapper exec saga_cmd -h
 ```
 
-If you have X11 enabled on your SSH connection or want to start SAGA GIS from the command line within the Puhti web interface, you can launch a graphical user interface with
-
-```
-singularity_wrapper exec saga_gui
-```
-
-!!! note
-    It is recommended to use the SAGA GIS Graphical User Interface via the Puhti web interface, see below.
-
-
 For more information on running R jobs on Puhti, please see the [`r-env-singularity` documentation](r-env-singularity.md).
 
-### Using SAGA GIS in Puhti web interface
+### SAGA GIS Graphical User Interface
 
-The SAGA GIS Graphical User Interface is available via the Puhti web interface:
+Using SAGA GIS in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
 
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
 2. Start SAGA GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'.
 
-## Usage with old saga-gis module
-
-Same commands for older SAGA GIS 7.2.0 version
+Alternatively, especially if you want to use SAGA GIS and some other GUI tool together, QGIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
 
 ```
-sinteractive -i
-module load gcc/9.1.0 saga-gis
-saga_cmd -h
-saga_gui
+module load r-env-singularity 
+singularity_wrapper exec saga_gui
 ```
+
 
 ## License and citing
 

--- a/docs/apps/saga-gis.md
+++ b/docs/apps/saga-gis.md
@@ -11,7 +11,18 @@ __SAGA GIS__ is available in Puhti with following versions:
 * 7.3.0 in `r-env-singularity/3.6.3` module
 * 7.2.0 in `saga-gis` module
 
-## Usage with r-env-singularity module
+## Usage 
+
+### Using SAGA GIS in Puhti web interface
+
+This is the new recommended way.
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start SAGA GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'.
+
+### Alternative (old) use of QGIS with NoMachine
+
+With r-env-singularity module
 
 SAGA GIS is installed in the general R module in Puhti. It is a Singularity container which means the commands are slightly different compared to old installations.
 

--- a/docs/apps/saga-gis.md
+++ b/docs/apps/saga-gis.md
@@ -13,18 +13,9 @@ __SAGA GIS__ is available in Puhti with following versions:
 
 ## Usage 
 
-### Using SAGA GIS in Puhti web interface
+### Using SAGA GIS command line interface
 
-This is the new recommended way.
-
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start SAGA GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'.
-
-### Alternative (old) use of QGIS with NoMachine
-
-With r-env-singularity module
-
-SAGA GIS is installed in the general R module in Puhti. It is a Singularity container which means the commands are slightly different compared to old installations.
+In Puhti, SAGA GIS is available from the r-env-singularity module. It is a Singularity container which means the commands are slightly different compared to old installations.
 
 Before running anything, you should first start an [interactive session](../computing/running/interactive-usage.md) on a computing node and load `r-env-singularity ` module.
 
@@ -39,13 +30,24 @@ You can test that SAGA GIS loaded successfully and print the command line tools 
 singularity_wrapper exec saga_cmd -h
 ```
 
-If you have connected with [NoMachine](nomachine.md) or have X11 enabled on your SSH connection, you can launch a graphical user interface with
+If you have X11 enabled on your SSH connection or want to start SAGA GIS from the command line within the Puhti web interface, you can launch a graphical user interface with
 
 ```
 singularity_wrapper exec saga_gui
 ```
 
+!!! note
+    It is recommended to use the SAGA GIS Graphical User Interface via the Puhti web interface, see below.
+
+
 For more information on running R jobs on Puhti, please see the [`r-env-singularity` documentation](r-env-singularity.md).
+
+### Using SAGA GIS in Puhti web interface
+
+The SAGA GIS Graphical User Interface is available via the Puhti web interface:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start SAGA GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'.
 
 ## Usage with old saga-gis module
 

--- a/docs/apps/snap.md
+++ b/docs/apps/snap.md
@@ -54,7 +54,16 @@ This scripts sets also Java temporary folder, it is set to be snap/temp subfolde
 ### Java memory settings
 __By default SNAP/8.0 in Puhti uses only up to 2 Gb memory for Java.__ To increase this, add `-J-xmx10G` or similar setting to `snap` or `gpt` command. `-J-xmx10G` extends the Java maximum memory to 10Gb. Adjust this according to your needs and job memory reservation. Compared to your job memory reservation use for Java a few Gb less.
 
-### Using SNAP with graphical user interface
+### Using SNAP with Graphical User Interface (GUI)
+
+#### Using Puhti web interface
+
+This is the new recommended way.
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start SNAP with Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'.
+
+#### Alternative (old) use of SNAP GUI with NoMachine
 
 If you have connected with [NoMachine](nomachine.md) or have X11 enabled on your SSH connection, you can launch a graphical user interface on an interactive batch job session
 
@@ -64,8 +73,6 @@ source snap_add_userdir $TMPDIR
 snap -J-xmx10G
 ```
 
-!!! note
-         We recommend using [NoMachine](nomachine.md) for launching graphical user interfaces on Puhti
 
 ### Using SNAP with Graph Processing Tool (gpt) command
 

--- a/docs/apps/snap.md
+++ b/docs/apps/snap.md
@@ -31,7 +31,23 @@ This loads the newest available version. You can load an older version with:
 
 `module load snap/<VERSION>`
 
-### SNAP userdir and Java temp dir configuration 
+### Using SNAP with Graphical User Interface (GUI) via Puhti web interface
+
+Using SNAP in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start SNAP with Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'
+3. The SNAP GUI is started automatically when the Desktop is launched. 
+ 
+
+Alternatively, especially if you want to use QGIS and some other GUI tool together, SNAP can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
+
+```
+source snap_add_userdir $TMPDIR
+snap -J-xmx10G
+```
+
+#### SNAP userdir and Java temp dir configuration 
 
 SNAP uses significant amount of storage space for cache and temporary files. By default these are written to your HOME directory and may easily fill your HOME. For avoiding that configure your [snap user directory](https://senbox.atlassian.net/wiki/spaces/SNAP/pages/15269950/SNAP+Configuration) and Java temporary folder. You should run this script every time you start using SNAP in Puhti or want to change the used folders. 
 
@@ -51,20 +67,8 @@ This scripts sets also Java temporary folder, it is set to be snap/temp subfolde
 !!! note
         The graphical user interface does not follow snap.userdir setting, but it notices the Java setting. Using SNAP GUI will create a __.snap__ folder inside your HOME directory and fill it. Empty it if you run out of space in your HOME directory.
 
-### Java memory settings
+#### Java memory settings
 __By default SNAP/8.0 in Puhti uses only up to 2 Gb memory for Java.__ To increase this, add `-J-xmx10G` or similar setting to `snap` or `gpt` command. `-J-xmx10G` extends the Java maximum memory to 10Gb. Adjust this according to your needs and job memory reservation. Compared to your job memory reservation use for Java a few Gb less.
-
-### Using SNAP with Graphical User Interface (GUI) via Puhti web interface
-
-This is the new recommended way.
-
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start SNAP with Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'
-3. The SNAP GUI is started automatically when the Desktop is launched. To launch SNAP alternatively from the command line, use:
-```
-source snap_add_userdir $TMPDIR
-snap -J-xmx10G
-```
 
 ### Using SNAP with Graph Processing Tool (gpt) command
 

--- a/docs/apps/snap.md
+++ b/docs/apps/snap.md
@@ -54,25 +54,17 @@ This scripts sets also Java temporary folder, it is set to be snap/temp subfolde
 ### Java memory settings
 __By default SNAP/8.0 in Puhti uses only up to 2 Gb memory for Java.__ To increase this, add `-J-xmx10G` or similar setting to `snap` or `gpt` command. `-J-xmx10G` extends the Java maximum memory to 10Gb. Adjust this according to your needs and job memory reservation. Compared to your job memory reservation use for Java a few Gb less.
 
-### Using SNAP with Graphical User Interface (GUI)
-
-#### Using Puhti web interface
+### Using SNAP with Graphical User Interface (GUI) via Puhti web interface
 
 This is the new recommended way.
 
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start SNAP with Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'.
-
-#### Alternative (old) use of SNAP GUI with NoMachine
-
-If you have connected with [NoMachine](nomachine.md) or have X11 enabled on your SSH connection, you can launch a graphical user interface on an interactive batch job session
-
+2. Start SNAP with Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'
+3. The SNAP GUI is started automatically when the Desktop is launched. To launch SNAP alternatively from the command line, use:
 ```
-sinteractive -i
 source snap_add_userdir $TMPDIR
 snap -J-xmx10G
 ```
-
 
 ### Using SNAP with Graph Processing Tool (gpt) command
 


### PR DESCRIPTION
WIP because of NoMachine way.

Should all NoMachine instructions be removed from these pages, @ktiits ?

For SAGA and GRASS GIS the Nomachine instructions are combined with interactive usage. Should the interactive usage part be kept or completely removed?