### PR TITLE
Add PCLpy information

### DIFF
--- a/docs/apps/pcl.md
+++ b/docs/apps/pcl.md
@@ -2,11 +2,15 @@
 
 [PCL](https://pointclouds.org/) (Point Cloud Library) is a standalone, large scale, open project for 2D/3D image and point cloud processing.
 
+[PCLpy](https://github.com/davidcaron/pclpy) adds Python bindings to PCL.
+
 ## Available
 
 __PCL__ is available in Puhti with following versions:
 
 * 1.9.1 
+
+This version includes __PCLpy__ version 0.12.0 with Python 3.8.
 
 PCL has been compiled with Boost, Eigen, FLANN and Qhull
 
@@ -21,6 +25,8 @@ PCL is included in the __pcl__ module and can be loaded with
 You can see all available binaries with the command
 
 `ls /appl/soft/geo/pcl/1.9.1/bin`
+
+Note, that not all PCL modules are available in PCLpy.
 
 ## License and citing
 


### PR DESCRIPTION
PCLpy version 0.12.0 was added to PCL module with Python 3.8.

PCLpy 0.12.0 with Python 3.6 is also available via 'module load pcl/1.9.1:3.6' but chose to not mention here, to avoid confusion in module naming. One person is using it at the moment and he knows how to load it. Will be removed once not used anymore.

