### PR TITLE
QGIS version update

### DIFF
--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -22,7 +22,12 @@ Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterf
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
-Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut.
+Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
+
+```
+module load qgis
+grass
+```
 
 ## License and citing
 

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -6,7 +6,8 @@
 
 __GRASS__ is available in Puhti with following versions:
 
-* GRASS 7.4
+* GRASS 7.8.5 with default qgis module
+* GRASS 7.4 with older qgis/3.16 module
 
 ## Usage
 
@@ -21,12 +22,7 @@ Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterf
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
-Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
-
-```
-module load qgis
-grass
-```
+Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut.
 
 ## License and citing
 

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -18,12 +18,7 @@ Using QGIS in [Puhti web interface with Desktop app](../computing/webinterface/d
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-Alternatively, especially if you want to use QGIS and some other GUI tool together or want to use data from Allas, QGIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
-
-```
-module load qgis
-qgis
-```
+Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop.
 
 
 ### PyQGIS

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -18,7 +18,12 @@ Using QGIS in [Puhti web interface with Desktop app](../computing/webinterface/d
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop.
+Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop or terminal with the commands: 
+
+```
+module load qgis
+qgis
+```
 
 
 ### PyQGIS

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -8,7 +8,8 @@ In Puhti, QGIS could be used for example to visualize the resulting files from o
 
 __QGIS__ is available in Puhti with following versions:
 
-* 3.16 in a singularity container: qgis module
+* 3.22 in a singularity container: qgis module
+* 3.16 in a singularity container: qgis/3.16 module
 
 ## Usage
 


### PR DESCRIPTION
* updated version to 3.22 -> new default QGIS
* removed module load instructions, since it does not actually work that way in Puhti web interface (needs host terminal?)
* updated availability of GRASS (7.8.5) and also removed the module load instructions there (same as above) for Puhti web interface
