### PR TITLE
Host terminal instructions to geospatial GUI software

### DIFF
--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -85,9 +85,21 @@ To check the exact packages and versions included in the loaded module:
  
 You can add more Python packages to `geoconda`, see instructions from [CSC Python page](python.md#installing-python-packages-to-existing-modules).
 
-!!! Note
+You can edit your Python code in Puhti with:
+* [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), 
+* [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or 
+* Spyder in [Puhti web interface with remote desktop](../computing/webinterface/desktop.md).
 
-    You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`
+To open Spyder in Puhti web interface with remote desktop:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi).
+2. Open Remote desktop: Apps -> Desktop, choose Desktop: `mate` or `xfce`. 
+3. After launcing the remote desktop open `Host Terminal` (Desktop icon) and start Spyder:
+
+```
+module geoconda
+spyder
+```
 
 ## Using Allas from Python
 

--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -79,17 +79,14 @@ By default the latest geoconda module is loaded. If you want a specific version 
 
 `module load geoconda/[VERSION]`
 
-For using the Spyder IDE give:
-
-`spyder`
-
 To check the exact packages and versions included in the loaded module:
 
 `list-packages`
  
 You can add more Python packages to `geoconda`, see instructions from [CSC Python page](python.md#installing-python-packages-to-existing-modules).
 
-!!! note
+!!! Note
+
 You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`.
 
 ## Using Allas from Python

--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -90,7 +90,7 @@ To check the exact packages and versions included in the loaded module:
 You can add more Python packages to `geoconda`, see instructions from [CSC Python page](python.md#installing-python-packages-to-existing-modules).
 
 !!! note
-You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md).
+You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`.
 
 ## Using Allas from Python
 

--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -87,7 +87,7 @@ You can add more Python packages to `geoconda`, see instructions from [CSC Pytho
 
 !!! Note
 
-    You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop] (../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`
+    You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`
 
 ## Using Allas from Python
 

--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -87,7 +87,7 @@ You can add more Python packages to `geoconda`, see instructions from [CSC Pytho
 
 !!! Note
 
-    You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop] (../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`.
+    You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop] (../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`
 
 ## Using Allas from Python
 

--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -87,7 +87,7 @@ You can add more Python packages to `geoconda`, see instructions from [CSC Pytho
 
 !!! Note
 
-You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop](../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`.
+    You can edit your Python code with [Visual Studio Code in Puhti web interface](../computing/webinterface/vscode.md), [Visual Studio Code on your local laptop] (../support/tutorials/remote-dev.md) or Spyder in Puhti web interface [remote desktop](../computing/webinterface/desktop.md) using the `Host Terminal` (Desktop icon) to load the `geoconda` module and start `spyder`.
 
 ## Using Allas from Python
 

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -6,7 +6,7 @@
 
 __GRASS__ is available in Puhti with following versions:
 
-* GRASS 7.8.5 with default qgis module
+* GRASS 7.8.5 with (default) qgis/3.22 module
 * GRASS 7.4 with older qgis/3.16 module
 
 ## Usage
@@ -22,7 +22,7 @@ Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterf
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
-Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
+Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface Desktop App (mate or xfce) from Desktop shortcut or with the ´host terminal´ (Desktop icon) with the commands:
 
 ```
 module load qgis

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -22,7 +22,7 @@ Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterf
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
-Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface Desktop App (mate or xfce) from Desktop shortcut or with the ´host terminal´ (Desktop icon) with the commands:
+Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface Desktop App (mate or xfce) from Desktop shortcut or from the ´host terminal´ (Desktop icon) with the commands:
 
 ```
 module load qgis

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -17,12 +17,17 @@ In Puhti, GRASS GIS is included in [QGIS module](qgis.md). GRASS GIS command lin
 
 ### GRASS GIS Graphical User Interface
 
-Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
+The easiest option for using GRASS GIS is to open it in [Puhti web interface as Desktop app](../computing/webinterface/desktop.md).
 
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
-2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
+2. Start SNAP: Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'
+3. GRASS GIS is started automatically when the Desktop is launched. 
 
-Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface Desktop App (mate or xfce) from Desktop shortcut or from the `Host Terminal` (Desktop icon) with the commands:
+Alternatively, especially if you want to use GRASS GIS together with some other GUI tool or want to user older version, GRASS GIS can be started in Puhti web interface with remote desktop:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi).
+2. Open Remote desktop: Apps -> Desktop, choose Desktop: `mate` or `xfce`. 
+3. After launcing the remote desktop open `Host Terminal` (Desktop icon) and start GRASS GIS:
 
 ```
 module load qgis

--- a/docs/apps/grass.md
+++ b/docs/apps/grass.md
@@ -22,7 +22,7 @@ Using GRASS GIS in [Puhti web interface with Desktop app](../computing/webinterf
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start GRASS GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'GRASS GIS'.
 
-Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface Desktop App (mate or xfce) from Desktop shortcut or from the ´host terminal´ (Desktop icon) with the commands:
+Alternatively, especially if you want to use GRASS GIS and some other GUI tool together, GRASS GIS can be started in Puhti web interface Desktop App (mate or xfce) from Desktop shortcut or from the `Host Terminal` (Desktop icon) with the commands:
 
 ```
 module load qgis

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -13,12 +13,18 @@ __QGIS__ is available in Puhti with following versions:
 
 ## Usage
 
-Using QGIS in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
+The easiest option for using QGIS is to open it in [Puhti web interface as Desktop app](../computing/webinterface/desktop.md).
 
-1. Log in to [Puhti web interface](https://puhti.csc.fi). 
-2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
+1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+2. Start SNAP: Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'
+3. QGIS is started automatically when the Desktop is launched. 
 
-Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop or from the `Host Terminal` (Desktop icon) with the commands:
+
+Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface with remote desktop:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi).
+2. Open Remote desktop: Apps -> Desktop, choose Desktop: `mate` or `xfce`. 
+3. After launcing the remote desktop open `Host Terminal` (Desktop icon) and start QGIS:
 
 ```
 module load qgis

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -15,7 +15,7 @@ __QGIS__ is available in Puhti with following versions:
 
 The easiest option for using QGIS is to open it in [Puhti web interface as Desktop app](../computing/webinterface/desktop.md).
 
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
+1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start SNAP: Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'
 3. QGIS is started automatically when the Desktop is launched. 
 

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -8,7 +8,7 @@ In Puhti, QGIS could be used for example to visualize the resulting files from o
 
 __QGIS__ is available in Puhti with following versions:
 
-* 3.22 in a singularity container: qgis module
+* 3.22 in a singularity container: qgis(/3.22 = default) module
 * 3.16 in a singularity container: qgis/3.16 module
 
 ## Usage
@@ -18,7 +18,7 @@ Using QGIS in [Puhti web interface with Desktop app](../computing/webinterface/d
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop or terminal with the commands: 
+Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop or from the ´host terminal´ (Desktop icon) with the commands:
 
 ```
 module load qgis

--- a/docs/apps/qgis.md
+++ b/docs/apps/qgis.md
@@ -18,7 +18,7 @@ Using QGIS in [Puhti web interface with Desktop app](../computing/webinterface/d
 1. Log in to [Puhti web interface](https://puhti.csc.fi). 
 2. Start QGIS with Apps -> Desktop, choose Desktop: 'None' and App: 'QGIS'.
 
-Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop or from the ´host terminal´ (Desktop icon) with the commands:
+Alternatively, especially if you want to use QGIS together with some other Graphical User Interface (GUI) tool or want to use data from Allas, QGIS can be started in Puhti web interface within mate or xfce Desktop App from the QGIS icon on the Desktop or from the `Host Terminal` (Desktop icon) with the commands:
 
 ```
 module load qgis

--- a/docs/apps/saga-gis.md
+++ b/docs/apps/saga-gis.md
@@ -30,7 +30,7 @@ Using SAGA GIS in [Puhti web interface with Desktop app](../computing/webinterfa
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
 2. Start SAGA GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'.
 
-Alternatively, especially if you want to use SAGA GIS and some other GUI tool together, QGIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
+Alternatively, especially if you want to use SAGA GIS and some other GUI tool together, QGIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or from the `Host Terminal` (Desktop icon) with the commands:
 
 ```
 module load r-env-singularity 

--- a/docs/apps/saga-gis.md
+++ b/docs/apps/saga-gis.md
@@ -25,18 +25,23 @@ For more information on running R jobs on Puhti, please see the [`r-env-singular
 
 ### SAGA GIS Graphical User Interface
 
-Using SAGA GIS in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
+The easiest option for using SAGA GIS is to open it in [Puhti web interface as Desktop app](../computing/webinterface/desktop.md).
 
-1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start SAGA GIS with Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'.
+1. Log in to [Puhti web interface](https://puhti.csc.fi). 
+2. Start SNAP: Apps -> Desktop, choose Desktop: 'None' and App: 'SAGA GIS'
+3. The SNAP GUI is started automatically when the Desktop is launched. 
 
-Alternatively, especially if you want to use SAGA GIS and some other GUI tool together, QGIS can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or from the `Host Terminal` (Desktop icon) with the commands:
+
+Alternatively, especially if you want to use SAGA GIS together with some other GUI tool or want to user older version, SAGA GIS can be started in Puhti web interface with remote desktop:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi).
+2. Open Remote desktop: Apps -> Desktop, choose Desktop: `mate` or `xfce`. 
+3. After launcing the remote desktop open `Host Terminal` (Desktop icon) and start SAGA GIS:
 
 ```
 module load r-env-singularity 
 singularity_wrapper exec saga_gui
 ```
-
 
 ## License and citing
 

--- a/docs/apps/snap.md
+++ b/docs/apps/snap.md
@@ -31,16 +31,20 @@ This loads the newest available version. You can load an older version with:
 
 `module load snap/<VERSION>`
 
-### Using SNAP with Graphical User Interface (GUI) via Puhti web interface
+### Using SNAP with Graphical User Interface (GUI) in Puhti web interface
 
-Using SNAP in [Puhti web interface with Desktop app](../computing/webinterface/desktop.md).
+The easiest option for using SNAP is to open it in [Puhti web interface as Desktop app](../computing/webinterface/desktop.md).
 
 1. Log in to [Puhti web interface](https://puhti.csc.fi). [Puhti web interface documentation](../computing/webinterface/desktop.md).
-2. Start SNAP with Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'
+2. Start SNAP: Apps -> Desktop, choose Desktop: 'None' and App: 'SNAP'
 3. The SNAP GUI is started automatically when the Desktop is launched. 
  
 
-Alternatively, especially if you want to use QGIS and some other GUI tool together, SNAP can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or or from the `Host Terminal` (Desktop icon) with the commands::
+Alternatively, especially if you want to use SNAP together with some other GUI tool, want to user older version of SNAP or want to increase the default Java memory allocaiton, SNAP can be started in Puhti web interface with remote desktop:
+
+1. Log in to [Puhti web interface](https://puhti.csc.fi).
+2. Open Remote desktop: Apps -> Desktop, choose Desktop: `mate` or `xfce`. 
+3. After launcing the remote desktop open `Host Terminal` (Desktop icon) and start SNAP:
 
 ```
 module load snap

--- a/docs/apps/snap.md
+++ b/docs/apps/snap.md
@@ -40,9 +40,10 @@ Using SNAP in [Puhti web interface with Desktop app](../computing/webinterface/d
 3. The SNAP GUI is started automatically when the Desktop is launched. 
  
 
-Alternatively, especially if you want to use QGIS and some other GUI tool together, SNAP can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or with terminal commands:
+Alternatively, especially if you want to use QGIS and some other GUI tool together, SNAP can be started in Puhti web interface desktop App (mate or xfce) from Desktop shortcut or or from the `Host Terminal` (Desktop icon) with the commands::
 
 ```
+module load snap
 source snap_add_userdir $TMPDIR
 snap -J-xmx10G
 ```


### PR DESCRIPTION
Updated the sentence to load these GUI modules in Puhti web interface from Host terminal:
-  GRASS
-  QGIS
-  SNAP
-  SAGA
-  geoconda (for Spyder) 