### PR TITLE
recommed to use contact page for servicedesk

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -78,8 +78,8 @@
       - Page has email, service times, phone, support request how-to
  
 ## Redirecting pages
- - If there's an url that is has been linked to from the outside a lot and it changes, a (temporary) redirect can be made
- - Create a file with the name-of-the-old-page`.html` (or index.html if it was done that way) and as the content put:
+ - If there's an url that has been linked to from the outside a lot and it changes (disappears), a (temporary) redirect can be made
+ - Create a file with the name-of-the-old-page`.html` (or index.html if it was done that way) and as the content:
 ```
 <!DOCTYPE html>
 <html>
@@ -92,7 +92,7 @@
 </html>
 ```
 
- - and edit `new-page` (and the anchor, if there, otherwise just remove) to match
+ - edit `new-page` (and the anchor, if there, otherwise just remove) to match
  - to pass the tests, add the page to `tests/python_link_tests/whitelist`, too
 
 ## Terminology

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -69,11 +69,31 @@
    Users tend to use these as default values.
  - For code sections (marked with three backticks,\`\`\`) Mkdocs will by default try to auto-guess the 
    language for syntax highlighting. It's probably best to specify the language explicitly, e.g.  \`\`\`bash or  \`\`\`python
+      - *Note!* Add a blank line _after_ the three-ticks-codeblock! (Also two whitespaces after ticks work, but that's unofficial dialect)
  - If you don't want any syntax highlighting, just use \`\`\`text
  - For a list of all supported languages see: http://pygments.org/docs/lexers/
  - Give commands, environment variables, command options, as well as partition 
    names between two backticks, i.e. \`srun\`, \`$LOCAL_SCRATCH\`, \`--gres\`, \`small\`
- - Format email addresses using `mailto:` as in `[servicedesk@csc.fi](mailto:servicedesk@csc.fi)`  
+ - Refer to servicedesk via the docs contact page: as in `[contact ServiceDesk](/support/contact/)`  
+      - Page has email, service times, phone, support request how-to
+ 
+## Redirecting pages
+ - If there's an url that is has been linked to from the outside a lot and it changes, a (temporary) redirect can be made
+ - Create a file with the name-of-the-old-page`.html` (or index.html if it was done that way) and as the content put:
+```
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="1; url='new-page/#anchor-on-that-page'" />
+  </head>
+  <body>
+    <p><a href="new-page/#anchor-on-that-page">Dataset content reorganized!</a>.</p>
+  </body>
+</html>
+```
+
+ - and edit `new-page` (and the anchor, if there, otherwise just remove) to match
+ - to pass the tests, add the page to `tests/python_link_tests/whitelist`, too
 
 ## Terminology
  - When referring collectively to compute servers, use term "CSC supercomputers". Puhti and Mahti should be used explicitly only

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -20,7 +20,7 @@ for academic purposes. Please consult the [EULA](https://www.schrodinger.com/mae
 for the exact definition. 
 Using Maestro means that you accept the EULA linked to above.
 The Maestro license consists of floating licenses and tokens.
-If licenses run out, contact Atte via [ServiceDesk](mailto:servicedesk@csc.fi).
+If licenses run out, contact Atte via [contact ServiceDesk](/support/contact/)
 
 ## Usage
 
@@ -134,5 +134,5 @@ Jaguar, version 7.6, Schrödinger, LLC, New York, NY, 2009.
    * [Short videos on 11 features](https://www.schrodinger.com/training/videos/maestro/all)
    * [Downloadable tutorials section](https://www.schrodinger.com/training/tutorials)
 * Search the [Schrödinger KnowledgeBase](https://www.schrodinger.com/kb) for solutions 
-* Issues on how to run Maestro on CSC environment: [servicedesk@csc.fi](mailto:servicedesk@csc.fi)
+* Issues on how to run Maestro on CSC environment: [contact ServiceDesk](/support/contact/)
 * Scientific questions related to Maestro modules: [help@schrodinger.com](mailto:help@schrodinger.com)

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -20,7 +20,7 @@ for academic purposes. Please consult the [EULA](https://www.schrodinger.com/mae
 for the exact definition. 
 Using Maestro means that you accept the EULA linked to above.
 The Maestro license consists of floating licenses and tokens.
-If licenses run out, contact Atte via [contact ServiceDesk](/support/contact/)
+If licenses run out, contact Atte via [ServiceDesk](/support/contact/)
 
 ## Usage
 


### PR DESCRIPTION
first improvements to STYLEGUIDE from seminar BoF implemented
* blank line after code block
* use the contact page for referring to servicedesk requests
* instructions on how to create individual redirects with a html page
