### PR TITLE
404 to mention datasets reorganization

### DIFF
--- a/mkdocs_csc/404.html
+++ b/mkdocs_csc/404.html
@@ -4,5 +4,5 @@
 {% extends "base.html" %}
 {% block content %}
   <h1>404 - Not found</h1>
-<p>If you have a # in your URL, try removing it. The navigation has been changed in 2020.1.20.</p>
+<p>Oops. Please retry looking for the content starting from the landing page: <a href="https://docs.csc.fi">docs.csc.fi</a>. </p> <p>The <i>Datasets</i> section has been reorganized into <i>Working with data</i> in 10th December 2021 changing those URLs and some incoming links may malfuction. </p>
 {% endblock %}

--- a/mkdocs_csc/404.html
+++ b/mkdocs_csc/404.html
@@ -4,5 +4,5 @@
 {% extends "base.html" %}
 {% block content %}
   <h1>404 - Not found</h1>
-<p>Oops. Please retry looking for the content starting from the landing page: <a href="https://docs.csc.fi">docs.csc.fi</a>. </p> <p>The <i>Datasets</i> section has been reorganized into <i>Working with data</i> in 10th December 2021 changing those URLs and some incoming links may malfuction. </p>
+<p>Oops. Please retry looking for the content starting from the landing page: <a href="https://docs.csc.fi">docs.csc.fi</a>. </p> <p>The <i>Datasets</i> section has been reorganized into <i>Working with data</i> in 10th December 2021 changing those URLs and some incoming links may malfunction. </p>
 {% endblock %}


### PR DESCRIPTION
There was a big reorganization under data. some incoming links may point to pages that no longer exist. we made one manual redirect, but to cover the rest, I've updated the 404 message to reflect this. It should now give:


404 - Not found

Oops. Please retry looking for the content starting from the landing page: docs.csc.fi.

The Datasets section has been reorganized into Working with data in 10th December 2021 changing those URLs and some incoming links may malfunction.


