### PR TITLE
add CSC Notebooks documentation

### DIFF
--- a/docs/cloud/csc_notebooks/concepts.md
+++ b/docs/cloud/csc_notebooks/concepts.md
@@ -1,0 +1,92 @@
+# Concepts
+
+This document defines terminology in CSC Notebooks service.
+
+CSC Notebooks is a CSC cloud service for interactive web based applications
+
+## Application template
+
+- Created by Admin
+- Defines Application container image and configuration
+- Defines resource limits (such as memory)
+- See [the source code for images](https://github.com/CSCfi/notebook-images/tree/master/builds){target="_blank"} 
+  for technical details
+
+## Application
+
+- Predefined content for one learning session
+- Based on a Docker container - either JupyterLab or RStudio
+- Created by Workspace manager based on Application template
+
+## Application session aka Session
+
+- One running copy of an Application
+- Started and managed by User
+- Has lifetime set by Application
+
+## Workspace
+
+- A container for Applications and Users
+- Tied to a Cluster
+- Has an Owner
+- May have Co-owners
+- Has a lifetime
+- May contain persistent folders (Workspace `shared`, Users' `my-work`). See [Storage in CSC Notebooks](data_persistence.md)
+- Has a maximum number of Applications (10 by default) 
+
+## My Work folder
+
+- Private directory per user per workspace, storing data between Application session launches
+- Available in the Application session (if enabled by Owner) as `$HOME/my-work`
+- Is tied to a Workspace
+- Has lifetime tied to a Workspace
+
+## Workspace shared folder
+
+- Shared directory available to all users in a Workspace
+- Is writable by Workspace manager
+- Is tied to a workspace
+- Has lifetime tied to a Workspace
+
+## Join code
+
+- Unique Code generated for each workspace
+- Workspace owner distributes this code for users to join the workspace
+
+## End user
+
+- A Workspace member or a user of public Applications
+- Is authenticated
+- May launch Application sessions
+- Has access to public Applications
+- May be part of Workspaces
+- Has access to Workspace Applications through membership
+
+## Workspace owner
+
+- User that owns Workspaces or has been assigned Quota to create Workspaces 
+- Principal of the Workspace
+- Creates Workspace and the content in the Workspace for the workspace members
+- May invite Users to become members in a workspace by sharing the Join code
+- May promote members to Co-owners
+- May demote Co-owners to members
+- May add Applications based on Applications templates
+
+## Workspace co-owner
+
+- Can create content in the Workspace
+- May promote members to Co-owners
+- May demote Co-owners to members
+- May invite users to become members in a workspace by sharing the join code
+- May add Applications based on Applications templates
+
+## Admin
+
+- System administrator at CSC
+- Has full rights in the system
+
+## Cluster
+
+- A resource for executing the Application sessions
+- In practice: some sort of Kubernetes cluster in CSC cloud
+- Configured by Admin

--- a/docs/cloud/csc_notebooks/data_persistence.md
+++ b/docs/cloud/csc_notebooks/data_persistence.md
@@ -1,0 +1,56 @@
+# Data persistence
+
+There are three types of storage in CSC Notebooks.
+
+* **Workspace shared folder**: persisted for workspace lifetime
+* **My-work folder**: persisted for workspace lifetime per user
+* **Home directory**: persisted only for session lifetime, survives application restarts in error situations
+
+!!!Note
+
+    `home` or `$HOME` folder refers to `home/jovyan` for Jupyter based applications and `/home/rstudio` for RStudio based 
+    applications.
+
+!!!Note
+
+    None of the persistent storage options are backed up. Always make sure you (and your users) make a copy outside 
+    CSC Notebooks of any data you cannot afford to lose. 
+
+## Workspace shared folder 
+
+* A shared volume is created per workspace. This volume is mounted in `$HOME/shared` for each session.
+* The default size of the volume is 20 GB.
+* Workspace owner and managers/co-owners will have full access to this folder. Every other user in the workspace will
+  have read-only access to this folder.
+* Shared folder is directly linked to the lifetime of workspace. When the workspace is deleted, shared folder will be
+  automatically deleted.
+* The backing volume for shared folder lives on NFS, thus the storage is not as fast as home directory.
+
+### Intended use
+
+Workspace owner and co-owners can create, modify and save course contents in the shared folder and workspace members 
+can directly read from them.
+
+## My-work folder
+
+* My-work folder is a workspace specific folder for each user, mounted to `$HOME/my-work`.
+* Workspace owner can enable or disable `my-work` folder per application.
+* If enabled, a volume will be automatically created for the user during the launch of the first session.
+  Other users or workspace owners in the workspace will not have any access to the individual users volume.
+* The default volume size is 1 GB.
+* My-work folder is persisted until the workspace expires.
+* The backing volume for my-work folder lives on NFS, thus the storage is not as fast as home directory.
+
+### Intended use
+
+Individual users can store and save their course data in this volume until the end of the workspace lifetime. Unlike
+session volume, this is not deleted when the session expires. The contents from the previous session are available when
+starting a new session. If the workspace has multiple applications, this folder will be mounted simultaneously to
+parallel sessions and thus can be also used for data transfer between for example Jupyter and RStudio.
+
+## Home directory
+
+* Data is preserved over session container restarts, for example in out-of-memory situations. In practice, a volume is
+  created and mounted on `$HOME` when the session is launched.
+* Data is hosted on a local, fast disk. The disk does not have any redundancy for hardware failures.
+* Data is deleted when the session is deleted by user or when the lifetime of session ends.

--- a/docs/cloud/csc_notebooks/getting_started.md
+++ b/docs/cloud/csc_notebooks/getting_started.md
@@ -1,0 +1,111 @@
+# Getting started
+
+Step-by-step instructions on using CSC Notebooks.
+
+## How to login to CSC Notebooks?
+
+CSC Notebooks can be accessed by anyone that has _Haka_, _Virtu_ or _CSC_ account.
+
+Check if your institution belongs to _Haka_ or _Virtu_ here :
+
+* [Haka institutions](https://wiki.eduuni.fi/pages/viewpage.action?pageId=27297776){target="_blank"}
+* [Virtu institutions](https://wiki.eduuni.fi/display/CSCVIRTU/Organisaatiot){target="_blank"}
+
+## Self-learning
+
+1. After logging in, you will be presented with a list of publicly accessible *applications*. The applications that 
+   have self-learning material included are marked with `self-learning` label.
+2. Start a session of any application by using the power control button on the right. A new tab is opened for
+   your session. If your browser blocks this pop-up, you can click on the power control again to enter the session.
+3. When you are finished, delete the application session using the power control button.
+4. The running application session will be deleted automatically if the session exceeds its lifetime. Lifetime is 
+   shown next to the power control button. The remaining time is visible in the power control button itself.
+
+!!!Note
+
+    Public applications do not support saving your session or data. If you want to keep your content, please download it
+    locally before your session ends.
+
+## How to host a course
+
+CSC Notebooks is built for hosting online courses. We support currently Jupyter and RStudio based content, with more
+options to come in the future. The intended workflow is that you create one workspace per course, and arrange your 
+exercises in one or more applications in that workspace.
+
+Here is a step-by-step guide for hosting a course on CSC Notebooks.
+
+### Becoming a workspace owner and creating a workspace
+
+1. Login to CSC Notebooks using your CSC account. Make note of your user account on the bottom of the left navigation
+   bar. If you don't have a CSC account yet, 
+   [see the instructions on how to create new user account](../../../accounts/how-to-create-new-user-account/).
+2. Send email to <notebooks@csc.fi> to request workspace owner rights. Please include your CSC user account in the mail. 
+   We will add the capability to create your own workspaces to your account.
+3. Once the access is given, a new entry *Manage workspaces* in the left navigation bar will appear. Use *Create
+   workspace* button to create a workspace.
+
+### Creating an application in the workspace
+
+Open *Manage workspaces* in the left navigation and select the workspace you want to work on. Create a new application 
+through *Application creation wizard* or *Use simple editor* -buttons.
+
+**Application template** Template provides the base features for your application. Most of the templates are based on
+container images maintained by Notebooks team. Take a look at the 
+[image sources in notebook-images repository.](https://github.com/CSCfi/notebook-images/tree/master/builds){target="_blank"}
+
+**Application name** Give a valid meaningful name.
+
+**Application description** Fill a detailed description to helps users to understand more about the application.
+
+**Container image** For advanced use cases. You can customize the container image the application uses by building 
+your own image, uploading it to a public image registry (such as docker-registry in Rahti, DockerHub or Quay.io)
+and pointing *Container image* to it.
+
+**Labels** Select the default labels or create custom labels. Labels are useful in searching applications. The icon for
+the application is also selected based on assigned labels.
+
+**Interface** JupyterLab or old Jupyter notebooks. Applicable only for Jupyter based applications.
+
+**Download Method** The location to download the course contents from. Choose *git clone* if you wish to clone a git
+repository. Choose *Download from url* if you have contents hosted in Allas or other HTTP accessible location and 
+provide the url.
+
+!!!Note
+
+    The external location should be publicly accessible. For example git repositories should be public.
+
+As an alternative, the course material can be provided through `shared` folder. Workspace owner can prepare the
+shared folder in advance. The folder is visible but read-only for normal workspace members.
+[See data persistence document for more information](data_persistence.md).
+
+**Work folder per user** Whether `my-work` folder is available for users in this application. 
+This is enabled by default.
+
+### Invite users
+
+Once the content is ready, you can invite users by sharing a workspace specific join code. The code can be found in
+*Manage workspaces* view, in workspace list or on the Info tab of each workspace.
+The users can enter the code by clicking *Join workspace* button located in the top bar. They can then see all published 
+applications on top of the application list on the *Applications* page, and under *My workspaces* page as well.
+
+### Promote users
+
+As workspace owner or co-owner, you can promote members of the workspace to be co-owners or demote co-owners to members.
+Co-owners can do everything the owner can, except demoting the owner or deleting the workspace. 
+
+## Using CSC Notebooks for collaboration
+
+A simple setup for collaboration can be achieved by following the 'How to host a course' instructions above and 
+promoting the collaborators as co-owners. The process is:
+
+1. Obtain workspace owner rights.
+2. Create a workspace.
+3. Invite the collaborators using the join code.
+4. Make collaborators co-owners, so they can also write to the shared folder in the workspace.
+
+## Security guidelines for Workspace owners
+
+- CSC Notebooks is not intended for sensitive data. Do not store sensitive data or data sets.
+- Share join code only with users you wish to join your workspace.
+- If you are creating custom images for your course, do not store any keys or sensitive data in the image.
+- Delete the workspace as soon as the course is over.

--- a/docs/cloud/csc_notebooks/index.md
+++ b/docs/cloud/csc_notebooks/index.md
@@ -1,0 +1,36 @@
+# CSC Notebooks
+
+[CSC Notebooks](https://notebooks.csc.fi){target="_blank"} offers web applications for self-learning, hosting courses 
+and collaboration. The applications are accessed through a web browser and run in CSC cloud. You can log
+in with your Haka/Virtu/CSC customer account. We support Jupyter and RStudio based applications, with more options to 
+come in the future.
+
+!!!Note 
+
+    This documentation describes the upcoming new release that is currently available as **public beta** at
+    [notebooks-beta.rahtiapp.fi](https://notebooks-beta.rahtiapp.fi){target="_blank"}
+
+## What can you use CSC Notebooks for?
+
+1. [Self-learning](getting_started.md#self-learning)
+2. [Hosting courses](getting_started.md#how-to-host-a-course)
+3. [Collaboration among teams and researchers](getting_started.md#using-csc-notebooks-for-collaboration)
+
+## Getting started
+
+Continue to [Getting started guide](getting_started.md) for step-by-step instructions on using CSC Notebooks.  
+
+## Concepts
+
+See the separate [concepts](concepts.md) document.
+
+## Data persistence
+
+See the separate [data persistence](data_persistence.md) document.
+
+## References
+
+* [Project Jupyter homepage](https://jupyter.org/){target="_blank"}
+* [Rocker RStudio GitHub repository](https://github.com/rocker-org/rocker){target="_blank"}
+* [CSC Rahti container cloud](../rahti/){target="_blank"}
+* [CSC Pouta IaaS cloud service](../pouta/){target="_blank"}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,11 @@ nav:
              - Known problems and limitations: cloud/pouta/known-problems.md
      - Grid computing:
         - The Grid Monitor: cloud/grid/grid-monitor.md
+     - CSC Notebooks:
+       - Overview: cloud/csc_notebooks/index.md
+       - Getting started: cloud/csc_notebooks/getting_started.md
+       - Concepts: cloud/csc_notebooks/concepts.md
+       - Data persistence: cloud/csc_notebooks/data_persistence.md
   - Data:
 #    - Datasets: data/datasets.md
      - Working with data:


### PR DESCRIPTION
Add first version of CSC Notebooks documentation under 'Cloud'.
The content is intended for the new beta release, this is also
mentioned in the overview page.