### PR TITLE
scrap support menu level

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,12 +185,11 @@ nav:
      - In alphabetic order: apps/alpha.md
      - By discipline: apps/index.md
      - By availability: apps/by_system.md
-  - Support:
-     - Tutorials: support/tutorials/index.md
-     - FAQ: support/faq/index.md
-     - Training material: support/training-material.md
-     - Contact: support/contact.md
-     - What's new: support/whats-new.md
+  - FAQ: support/faq/index.md
+  - Tutorials: support/tutorials/index.md
+  - Training material: support/training-material.md
+  - Contact: support/contact.md
+  - What's new: support/whats-new.md
 
 theme:
   name: material


### PR DESCRIPTION
FAQ and tutorials were too hard to find. They are made more visible by removing the "support" menu layer. See https://csc-guide-preview.rahtiapp.fi/origin/flatten-menu/