### PR TITLE
Ml deprecate conda

### DIFF
--- a/docs/apps/python-data.md
+++ b/docs/apps/python-data.md
@@ -4,8 +4,8 @@ Collection of Python libraries for data analytics and machine learning.
 
 !!! News
 
-    All recent and future Python Data installations are and will be based on
-    Singularity. This is due to the performance issues of Conda-based
+    **25.1.2022:** All recent and future Python Data installations are and will be
+    based on Singularity. This is due to the performance issues of Conda-based
     environments on shared file systems, causing long start-up delays and
     system-wide slowdowns when using Python scripts on CSC's supercomputers.
     **Conda-based installations are now deprecated** and may be removed in the

--- a/docs/apps/python-data.md
+++ b/docs/apps/python-data.md
@@ -4,12 +4,10 @@ Collection of Python libraries for data analytics and machine learning.
 
 !!! News
 
-    **25.1.2022:** All recent and future Python Data installations are and will be
-    based on Singularity. This is due to the performance issues of Conda-based
-    environments on shared file systems, causing long start-up delays and
-    system-wide slowdowns when using Python scripts on CSC's supercomputers.
-    **Conda-based installations are now deprecated** and may be removed in the
-    future. Please considering moving to a Singularity-based installation.
+    **4.2.2022** All old Python Data versions which were based on direct Conda
+    installations have been deprecated, and we encourage users to move to newer
+    versions. Read more on our separate [Conda deprecation page](../support/deprecate-conda.md).
+
 
 ## Available
 
@@ -28,9 +26,9 @@ are:
   loading times much faster. Thanks to wrapper scripts this change should be
   mostly invisible to users. If you still encounter any problems, don't hesitate
   to report them to [CSC's service desk](../support/contact.md).
-- (deprecated) `python-data/3.7.6-1` installed in June 2020, includes for example:
+- _(deprecated)_ `python-data/3.7.6-1` installed in June 2020, includes for example:
   Scikit-learn 0.23.1, Pandas 1.0.4 and JupyterLab 2.1.4.
-- (deprecated) `python-data/3.7.3-1` installed in July 2019.
+- _(deprecated)_ `python-data/3.7.3-1` installed in July 2019.
 
 Python-data tries to include a comprehensive selection of Python libraries for
 data analytics and machine learning, for example:

--- a/docs/apps/python-data.md
+++ b/docs/apps/python-data.md
@@ -2,6 +2,15 @@
 
 Collection of Python libraries for data analytics and machine learning.
 
+!!! News
+
+    All recent and future Python Data installations are and will be based on
+    Singularity. This is due to the performance issues of Conda-based
+    environments on shared file systems, causing long start-up delays and
+    system-wide slowdowns when using Python scripts on CSC's supercomputers.
+    **Conda-based installations are now deprecated** and may be removed in the
+    future. Please considering moving to a Singularity-based installation.
+
 ## Available
 
 Older versions of the `python-data` module are available on **Puhti only**.
@@ -19,9 +28,9 @@ are:
   loading times much faster. Thanks to wrapper scripts this change should be
   mostly invisible to users. If you still encounter any problems, don't hesitate
   to report them to [CSC's service desk](../support/contact.md).
-- `python-data/3.7.6-1` installed in June 2020, includes for example:
+- (deprecated) `python-data/3.7.6-1` installed in June 2020, includes for example:
   Scikit-learn 0.23.1, Pandas 1.0.4 and JupyterLab 2.1.4.
-- `python-data/3.7.3-1` installed in July 2019.
+- (deprecated) `python-data/3.7.3-1` installed in July 2019.
 
 Python-data tries to include a comprehensive selection of Python libraries for
 data analytics and machine learning, for example:

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -3,32 +3,34 @@
 Machine learning framework for Python.
 
 !!! News
-    
-    All recent and upcoming PyTorch installations are and will be based on
-    Singularity. This is mainly due to the performance issues of conda-based
-    environments on shared file systems, causing long start-up delays for Python
-    scripts on CSC's supercomputers. See below for more information.
+
+    All recent and future PyTorch installations are and will be based on
+    Singularity. This is due to the performance issues of Conda-based
+    environments on shared file systems, causing long start-up delays and
+    system-wide slowdowns when using Python scripts on CSC's supercomputers.
+    **Conda-based installations are now deprecated** and may be removed in the
+    future. Please considering moving to a Singularity-based installation.
 
 
 ## Available
 
 Currently supported PyTorch versions:
 
-| Version | Module              | Puhti | Mahti | Environ. | Horovod | Notes             |
-|:-------:|---------------------|:-----:|:-----:|----------|:-------:|-------------------|
-| 1.10.0  | `pytorch/1.10`      | X     | X     | Sing.    | X       | (default version) |
-| 1.9.0   | `pytorch/1.9`       | X     | X     | Sing.    | X       |                   |
-| 1.8.1   | `pytorch/1.8`       | X     | X     | Sing.    | X       |                   |
-| 1.7.1   | `pytorch/1.7`       | X     | -     | Sing.    | X       |                   |
-| 1.6.0   | `pytorch/1.6`       | X     | -     | Conda    | -       |                   |
-| 1.4.0   | `pytorch/1.4`       | X     | -     | Conda    | -       |                   |
-| 1.3.1   | `pytorch/1.3.1`     | X     | -     | Conda    | -       |                   |
-| -"-     | `pytorch/1.3.1-hvd` | X     | -     | Conda    | X       |                   |
-| 1.3.0   | `pytorch/1.3.0`     | X     | -     | Conda    | -       |                   |
-| 1.2.0   | `pytorch/1.2.0`     | X     | -     | Conda    | -       |                   |
-| 1.1.0   | `pytorch/1.1.0`     | X     | -     | Conda    | -       |                   |
-| 1.0.1   | `pytorch/1.0.1`     | X     | -     | Conda    | -       |                   |
-| 0.4.1   | `pytorch/0.4.1`     | X     | -     | Conda    | -       |                   |
+| Version | Module              | Puhti | Mahti | Environ. | Horovod | Notes           |
+|:-------:|---------------------|:-----:|:-----:|----------|:-------:|-----------------|
+| 1.10.0  | `pytorch/1.10`      | X     | X     | Sing.    | X       | default version |
+| 1.9.0   | `pytorch/1.9`       | X     | X     | Sing.    | X       |                 |
+| 1.8.1   | `pytorch/1.8`       | X     | X     | Sing.    | X       |                 |
+| 1.7.1   | `pytorch/1.7`       | X     | -     | Sing.    | X       |                 |
+| 1.6.0   | `pytorch/1.6`       | X     | -     | Conda    | -       | *deprecated*    |
+| 1.4.0   | `pytorch/1.4`       | X     | -     | Conda    | -       | *deprecated*    |
+| 1.3.1   | `pytorch/1.3.1`     | X     | -     | Conda    | -       | *deprecated*    |
+| -"-     | `pytorch/1.3.1-hvd` | X     | -     | Conda    | X       | *deprecated*    |
+| 1.3.0   | `pytorch/1.3.0`     | X     | -     | Conda    | -       | *deprecated*    |
+| 1.2.0   | `pytorch/1.2.0`     | X     | -     | Conda    | -       | *deprecated*    |
+| 1.1.0   | `pytorch/1.1.0`     | X     | -     | Conda    | -       | *deprecated*    |
+| 1.0.1   | `pytorch/1.0.1`     | X     | -     | Conda    | -       | *deprecated*    |
+| 0.4.1   | `pytorch/0.4.1`     | X     | -     | Conda    | -       | *deprecated*    |
 
 All modules include [PyTorch](https://pytorch.org/) and related libraries with
 GPU support via CUDA.

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -4,12 +4,9 @@ Machine learning framework for Python.
 
 !!! News
 
-    **25.1.2022:** All recent and future PyTorch installations are and will be based
-    on Singularity. This is due to the performance issues of Conda-based
-    environments on shared file systems, causing long start-up delays and
-    system-wide slowdowns when using Python scripts on CSC's supercomputers.
-    **Conda-based installations are now deprecated** and may be removed in the
-    future. Please considering moving to a Singularity-based installation.
+    **4.2.2022** All old PyTorch versions which were based on direct Conda
+    installations have been deprecated, and we encourage users to move to newer
+    versions. Read more on our separate [Conda deprecation page](../support/deprecate-conda.md).
 
 
 ## Available

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -4,8 +4,8 @@ Machine learning framework for Python.
 
 !!! News
 
-    All recent and future PyTorch installations are and will be based on
-    Singularity. This is due to the performance issues of Conda-based
+    **25.1.2022:** All recent and future PyTorch installations are and will be based
+    on Singularity. This is due to the performance issues of Conda-based
     environments on shared file systems, causing long start-up delays and
     system-wide slowdowns when using Python scripts on CSC's supercomputers.
     **Conda-based installations are now deprecated** and may be removed in the

--- a/docs/apps/rapids.md
+++ b/docs/apps/rapids.md
@@ -2,6 +2,14 @@
 
 Suite of libraries for data analytics and machine learning on GPUs.
 
+!!! News
+
+    All recent and upcoming RAPIDS installations are and will be based on
+    Singularity. This is mainly due to the performance issues of conda-based
+    environments on shared file systems, causing long start-up delays for Python
+    scripts on CSC's supercomputers. See below for more information.
+
+
 ## Available
 
 The `rapids` module is available on Puhti only.  Currently supported RAPIDS versions:
@@ -9,7 +17,7 @@ The `rapids` module is available on Puhti only.  Currently supported RAPIDS vers
 - 0.16 using Singularity: `0.16-sng`
 - 0.15 using Singularity: `0.15-sng`
 - 0.14 using Singularity: `0.14-sng`
-- 0.11
+- (deprecated) 0.11
 
 Contains the [RAPIDS](https://rapids.ai/) suite (including
 [cuDF](https://github.com/rapidsai/cudf),

--- a/docs/apps/rapids.md
+++ b/docs/apps/rapids.md
@@ -4,10 +4,11 @@ Suite of libraries for data analytics and machine learning on GPUs.
 
 !!! News
 
-    All recent and upcoming RAPIDS installations are and will be based on
-    Singularity. This is mainly due to the performance issues of conda-based
-    environments on shared file systems, causing long start-up delays for Python
-    scripts on CSC's supercomputers. See below for more information.
+    **25.1.2022:** All recent and upcoming RAPIDS installations are and will be
+    based on Singularity. This is mainly due to the performance issues of
+    conda-based environments on shared file systems, causing long start-up
+    delays for Python scripts on CSC's supercomputers. See below for more
+    information.
 
 
 ## Available

--- a/docs/apps/rapids.md
+++ b/docs/apps/rapids.md
@@ -4,11 +4,9 @@ Suite of libraries for data analytics and machine learning on GPUs.
 
 !!! News
 
-    **25.1.2022:** All recent and upcoming RAPIDS installations are and will be
-    based on Singularity. This is mainly due to the performance issues of
-    conda-based environments on shared file systems, causing long start-up
-    delays for Python scripts on CSC's supercomputers. See below for more
-    information.
+    **4.2.2022** All old RAPIDS versions which were based on direct Conda
+    installations have been deprecated, and we encourage users to move to newer
+    versions. Read more on our separate [Conda deprecation page](../support/deprecate-conda.md).
 
 
 ## Available
@@ -20,7 +18,7 @@ Puhti only. Currently supported RAPIDS versions:
 - 0.16 using Singularity: `0.16-sng` (Puhti only)
 - 0.15 using Singularity: `0.15-sng` (Puhti only)
 - 0.14 using Singularity: `0.14-sng` (Puhti only)
-- (deprecated) 0.11  (Puhti only)
+- _(deprecated)_ 0.11  (Puhti only)
 
 Contains the [RAPIDS](https://rapids.ai/) suite (including
 [cuDF](https://github.com/rapidsai/cudf),

--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -4,40 +4,41 @@ Deep learning framework for Python.
 
 !!! News
 
-    All recent and upcoming TensorFlow installations are and will be
-    based on Singularity. This is mainly due to the performance issues
-    of conda-based environments on shared file systems, causing long
-    start-up delays for Python scripts on CSC's supercomputers. See 
-    below for more information.
+    All recent and upcoming TensorFlow installations are and will be based on
+    Singularity. This is due to the performance issues of Conda-based
+    environments on shared file systems, causing long start-up delays and
+    system-wide slowdowns when using Python scripts on CSC's supercomputers.
+    **Conda-based installations are now deprecated** and may be removed in the
+    future. Please considering moving to a Singularity-based installation.
 
 ## Available
 
 Currently supported TensorFlow versions:
 
-| Version | Module                            | Puhti | Mahti | Environ. | Horovod | Notes                        |
-|:-------:|-----------------------------------|:-----:|:-----:|----------|:-------:|------------------------------|
-| 2.7.0   | `tensorflow/2.7`                  | X     | X     | Sing.    | X       | default version              |
-| 2.6.0   | `tensorflow/2.6`                  | X     | X     | Sing.    | X       |                              |
-| 2.5.0   | `tensorflow/2.5`                  | X     | X     | Sing.    | X       |                              |
-| 2.4.1   | `tensorflow/2.4`                  | X     | X     | Sing.    | X       |                              |
-| 2.4.0   | `tensorflow/2.4-hvd`              | X     | -     | Conda    | X       |                              |
-| 2.4.0   | `tensorflow/2.4-sng`              | X     | -     | Sing.    | -       |                              |
-| 2.3.1   | `tensorflow/nvidia-20.12-tf2-py3` | X     | -     | Sing.    | -       |                              |
-| 2.3.0   | `tensorflow/2.3`                  | X     | -     | Sing.    | -       |                              |
-| 2.2.0   | `tensorflow/nvidia-20.07-tf2-py3` | X     | -     | Conda    | X       | experimental Horovod support |
-| 2.2.0   | `tensorflow/2.2-hvd`              | X     | -     | Conda    | X       |                              |
-| 2.2.0   | `tensorflow/2.2`                  | X     | -     | Sing.    | -       |                              |
-| 2.1.0   | `tensorflow/nvidia-20.03-tf2-py3` | X     | -     | Sing.    | -       |                              |
-| 2.1.0   | `tensorflow/nvidia-20.02-tf2-py3` | X     | -     | Sing.    | -       |                              |
-| 2.0.0   | `tensorflow/nvidia-19.11-tf2-py3` | X     | -     | Sing.    | -       |                              |
-| 2.0.0:  | `tensorflow/2.0.0`                | X     | -     | Conda    | -       |                              |
-| 2.0.0   | `tensorflow/2.0.0-hvd`            | X     | -     | Conda    | X       |                              |
-| 1.15.5  | `tensorflow/1.15`                 | X     | -     | Sing.    | X       |                              |
-| 1.15.0  | `tensorflow/1.15-hvd`             | X     | -     | Conda    | X       |                              |
-| 1.14.0: | `tensorflow/1.14.0`               | X     | -     | Conda    | -       |                              |
-| 1.14.0  | `tensorflow/1.14.0-cpu`           | X     | -     | Conda    | -       | Optimized for CPU            |
-| 1.13.1: | `tensorflow/1.13.1`               | X     | -     | Conda    | -       |                              |
-| 1.13.1  | `tensorflow/1.13.1-hvd`           | X     | -     | Conda    | X       |                              |
+| Version | Module                            | Puhti | Mahti | Environ. | Horovod | Notes                           |
+|:-------:|-----------------------------------|:-----:|:-----:|----------|:-------:|---------------------------------|
+| 2.7.0   | `tensorflow/2.7`                  | X     | X     | Sing.    | X       | default version                 |
+| 2.6.0   | `tensorflow/2.6`                  | X     | X     | Sing.    | X       |                                 |
+| 2.5.0   | `tensorflow/2.5`                  | X     | X     | Sing.    | X       |                                 |
+| 2.4.1   | `tensorflow/2.4`                  | X     | X     | Sing.    | X       |                                 |
+| 2.4.0   | `tensorflow/2.4-hvd`              | X     | -     | Conda    | X       | *deprecated*                    |
+| 2.4.0   | `tensorflow/2.4-sng`              | X     | -     | Sing.    | -       |                                 |
+| 2.3.1   | `tensorflow/nvidia-20.12-tf2-py3` | X     | -     | Sing.    | -       |                                 |
+| 2.3.0   | `tensorflow/2.3`                  | X     | -     | Sing.    | -       |                                 |
+| 2.2.0   | `tensorflow/nvidia-20.07-tf2-py3` | X     | -     | Conda    | X       | experimental Horovod support    |
+| 2.2.0   | `tensorflow/2.2-hvd`              | X     | -     | Conda    | X       | *deprecated*                    |
+| 2.2.0   | `tensorflow/2.2`                  | X     | -     | Sing.    | -       |                                 |
+| 2.1.0   | `tensorflow/nvidia-20.03-tf2-py3` | X     | -     | Sing.    | -       |                                 |
+| 2.1.0   | `tensorflow/nvidia-20.02-tf2-py3` | X     | -     | Sing.    | -       |                                 |
+| 2.0.0   | `tensorflow/nvidia-19.11-tf2-py3` | X     | -     | Sing.    | -       |                                 |
+| 2.0.0:  | `tensorflow/2.0.0`                | X     | -     | Conda    | -       | *deprecated*                    |
+| 2.0.0   | `tensorflow/2.0.0-hvd`            | X     | -     | Conda    | X       | *deprecated*                    |
+| 1.15.5  | `tensorflow/1.15`                 | X     | -     | Sing.    | X       |                                 |
+| 1.15.0  | `tensorflow/1.15-hvd`             | X     | -     | Conda    | X       | *deprecated*                    |
+| 1.14.0: | `tensorflow/1.14.0`               | X     | -     | Conda    | -       | *deprecated*                    |
+| 1.14.0  | `tensorflow/1.14.0-cpu`           | X     | -     | Conda    | -       | *deprecated*,<br/> optimized for CPU |
+| 1.13.1: | `tensorflow/1.13.1`               | X     | -     | Conda    | -       | *deprecated*                    |
+| 1.13.1  | `tensorflow/1.13.1-hvd`           | X     | -     | Conda    | X       | *deprecated*                    |
 
 Includes [TensorFlow](https://www.tensorflow.org/) and
 [Keras](https://keras.io/) with GPU support via CUDA.

--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -4,12 +4,10 @@ Deep learning framework for Python.
 
 !!! News
 
-    **25.1.2022:** All recent and upcoming TensorFlow installations are and will be based on
-    Singularity. This is due to the performance issues of Conda-based
-    environments on shared file systems, causing long start-up delays and
-    system-wide slowdowns when using Python scripts on CSC's supercomputers.
-    **Conda-based installations are now deprecated** and may be removed in the
-    future. Please considering moving to a Singularity-based installation.
+    **4.2.2022** All old TensorFlow versions which were based on direct Conda
+    installations have been deprecated, and we encourage users to move to newer
+    versions. Read more on our separate [Conda deprecation page](../support/deprecate-conda.md).
+
 
 ## Available
 

--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -4,7 +4,7 @@ Deep learning framework for Python.
 
 !!! News
 
-    All recent and upcoming TensorFlow installations are and will be based on
+    **25.1.2022:** All recent and upcoming TensorFlow installations are and will be based on
     Singularity. This is due to the performance issues of Conda-based
     environments on shared file systems, causing long start-up delays and
     system-wide slowdowns when using Python scripts on CSC's supercomputers.


### PR DESCRIPTION
Add conda deprecation notices to all ML application pages. Notices point to new conda deprecation page.