### PR TITLE
Fix number of big mem nodes

### DIFF
--- a/docs/computing/systems-puhti.md
+++ b/docs/computing/systems-puhti.md
@@ -32,7 +32,7 @@ bandwidth in a non-blocking fat-tree topology.
 | L         |  92              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 384 GiB |            |
 | IO        |  40              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 384 GiB |  3600 GiB  |
 | XL        |  12              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 768 GiB |            |
-| BM        |  12              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 1,5 TiB |            |
+| BM        |  6               | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 1,5 TiB |            |
 | GPU       |  80              | Xeon Gold 6230<br>Nvidia V100  | 2 x 20 cores @ 2,1 GHz<br> 4 GPUs connected with NVLink | 384 GiB<br>4 x 32 GB |  3600 GiB  |
 
 In addition to the compute nodes above, Puhti has two login nodes with 40 cores and 2900 GiB


### PR DESCRIPTION
There are 6 bigmem (1.5 TiB) nodes, not 12.
