### PR TITLE
Rockylinux and new nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN yum -y install epel-release &&\
     yum -y install python3 &&\
     yum -y install python3-pip &&\
     yum -y install git &&\
+    yum -y install findutils &&\
     yum clean all
 
 RUN chgrp -R root ${ROOT_GROUP_DIRS} &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV ROOT_GROUP_DIRS='/var/run /var/log/nginx /var/lib/nginx'
 ARG repo_branch=master
 
 RUN yum -y install epel-release &&\
+    dnf module enable -y nginx:mainline &&\
     yum -y install nginx &&\
     yum -y install python3 &&\
     yum -y install python3-pip &&\


### PR DESCRIPTION
When activating in Rahti the new rocky linux build, some changes were necessary:

* Add the RPM findutils for the xargs command.
* Enable the nginx mainline module