### PR TITLE
Fix partition limits

### DIFF
--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -17,7 +17,7 @@ normal (CPU) nodes:
 | large           | 3 days        | 1040         |   26                     |  M, L, IO                    | 382 Gib  | 3600 GiB | 
 | longrun         | 14 days       | 40           |   1                      |  M, L, IO                    | 382 GiB  | 3600 GiB | 
 | hugemem         | 3 days        | 160          |   4                      |  XL, BM                      | 1534 GiB |         |
-| hugemem_longrun | 7 days       | 40           |   1                      |  XL, BM                      | 1534 GiB |         |
+| hugemem_longrun | 14 days       | 40           |   1                      |  XL, BM                      | 1534 GiB |         |
 
 The following partitions are available on GPU nodes. Note that for each GPU, you should reserve at most 10 cores/task.
 

--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -12,7 +12,7 @@ normal (CPU) nodes:
 | Partition       | Time<br>limit | Max<br>tasks | Max<br>nodes             | [Node types](../systems-puhti.md)   | Max<br>memory  | Max<br>local storage<br>[(nvme)](../creating-job-scripts-puhti/#local-storage) |  
 |-----------------|---------------|--------------|--------------------------|------------------------------|----------|----------|
 | test            | 15 minutes    | 80           |   2                      |  M                           | 190 GiB  |          |
-| [interactive](interactive-usage.md)     | 7 days        | 4            |   1                      |  IO  | 64 GiB   | 640 GiB  |
+| [interactive](interactive-usage.md)     | 7 days        | 8            |   1                      |  IO  | 64 GiB   | 640 GiB  |
 | small           | 3 days        | 40           |   1                      |  M, L, IO                    | 382 GiB  | 3600 GiB |
 | large           | 3 days        | 1040         |   26                     |  M, L, IO                    | 382 Gib  | 3600 GiB | 
 | longrun         | 14 days       | 40           |   1                      |  M, L, IO                    | 382 GiB  | 3600 GiB | 
@@ -54,7 +54,7 @@ scontrol show partition <partition_name>
 
 ## Mahti partitions
 
-The following partitions (aka queues) are currently available in **Mahti** on CPU nodes. 
+The following full-node partitions (aka queues) are currently available in **Mahti** on CPU nodes. When using these partitions, your jobs use all resources available on the node and won't share the node with other jobs.
 
 | Partition | Nodes       | Time<br>limit | Access           |
 |-----------|-------------|---------------|------------------|
@@ -62,7 +62,12 @@ The following partitions (aka queues) are currently available in **Mahti** on CP
 | medium    | 1-20        | 36 hours      | all              |
 | large     | 20-200      | 36 hours      | scalability test |
 | gc          | 200-700       | 36 hours      | Grand Challenge  |
-| interactive | 1         |  7 days       | all              |
+
+The following partition is available for allocation by resources in **Mahti** on CPU nodes. This means that you can request a sub-node allocation: you can request only part of the resources (cores and memory) available on the compute node. This also means that your job may share the node with other jobs.
+
+| Partition | Cores       | Time<br>limit | Access           |
+|-----------|-------------|---------------|------------------|
+| interactive |   32      |  7 days       | all              |
 
 The following partitions are available on GPU nodes.
 

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -57,7 +57,7 @@ Available options for `sinteractive` in Puhti are:
 
 ### sinteractive in Mahti
 
-In Mahti, users can have several interactive batch job sessions in the `interactive` partition. Other partitions don't support interactive batch jobs. Each interactive session can reserve 1-32 cores, but the total number of reserved cores shared with all user sessions cannot exceed 32. Thus a user can have for example 4 interactive sessions with 8 cores or one 32 core session. Each core reserved will provide 1.875 GB of memory and the only way to increase the memory reservation is to increase the number of cores reserved. The maximum memory, provided by 32 cores, is 60 GB.
+In Mahti, users can have up to 8 interactive batch job sessions in the `interactive` partition. Other partitions don't support interactive batch jobs. Each interactive session can reserve 1-32 cores, but the total number of reserved cores shared with all user sessions cannot exceed 32. Thus a user can have for example 4 interactive sessions with 8 cores or one 32 core session. Each core reserved will provide 1.875 GB of memory and the only way to increase the memory reservation is to increase the number of cores reserved. The maximum memory, provided by 32 cores, is 60 GB.
 
 For example, an interactive session with 6 cores, 11,25 GiB of memory and 48 h running time using project _project_2001234_
 can be launched with command:

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -57,7 +57,7 @@ Available options for `sinteractive` in Puhti are:
 
 ### sinteractive in Mahti
 
-In Mahti, users can have several interactive batch job sessions in the `interactive` partition. Other partitions don't support interactive batch jobs. Each interactive session can reserve 1-8 cores, but the total number of reserved cores shared with all user sessions cannot exceed 8. Thus a user can have for example 4 interactive sessions with 2 cores or one 8 core session. Each core reserved will provide 1.875 GB of memory and the only way to increase the memory reservation is to increase the number of cores reserved. The maximum memory, provided by 8 cores, is 15 GB.
+In Mahti, users can have several interactive batch job sessions in the `interactive` partition. Other partitions don't support interactive batch jobs. Each interactive session can reserve 1-32 cores, but the total number of reserved cores shared with all user sessions cannot exceed 32. Thus a user can have for example 4 interactive sessions with 8 cores or one 32 core session. Each core reserved will provide 1.875 GB of memory and the only way to increase the memory reservation is to increase the number of cores reserved. The maximum memory, provided by 32 cores, is 60 GB.
 
 For example, an interactive session with 6 cores, 11,25 GiB of memory and 48 h running time using project _project_2001234_
 can be launched with command:


### PR DESCRIPTION
- Update mahti interactive: 32 cores max (in total), 60 GiB mem and max 8 jobs
- Update  puhti interactive: 8 cores , 72 GiB, 2 jobs
- Update hugemem_longrun max 14d

https://csc-guide-preview.rahtiapp.fi/origin/fix-partition-limits/computing/running/batch-job-partitions/
https://csc-guide-preview.rahtiapp.fi/origin/fix-partition-limits/computing/running/interactive-usage/
