### PR TITLE
Fix python installing example

### DIFF
--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -93,7 +93,7 @@ by CSC, you can send an email to <servicedesk@csc.fi>.
 It is also possible to create your own Python environments. 
 
 ### Tykky
-The easiest option is to use [Tykky](../computing/containers/tykky/) for conda or pip installations.
+The easiest option is to use [Tykky](../computing/containers/tykky.md) for conda or pip installations.
 
 ### Custom Singularity container
 In some cases, for example if you know of a suitable ready-made Singularity or Docker container, also using custom Singularity container is an option. 

--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -76,7 +76,7 @@ Naturally, this also applies to slurm job scripts. For example:
 ```
 module load python-data
 export PYTHONPATH=/projappl/<your_project>/my-python-env/lib/python3.9/site-packages/
-python3 -c "import pyarrow"
+python3 -c "import pyarrow"  # this should now work!
 ```
 
 Alternatively you can create a separate virtual environment with

--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -90,12 +90,13 @@ by CSC, you can send an email to <servicedesk@csc.fi>.
 
 ## Creating your own Python environments
 
-It is also possible to create your own Python environments. The main options are
-conda and Singularity. Singularity should be preferred at least when you know of
-a suitable ready-made Singularity or Docker container. Conda is easy to use and
-flexible, but it might create a huge number of files which is inefficient with
-shared file systems. This can cause very slow library imports and in the worst
-case slowdowns in the whole file system.
+It is also possible to create your own Python environments. 
+
+### Tykky
+The easiest option is to use [Tykky](../computing/containers/tykky/) for conda or pip installations.
+
+### Custom Singularity container
+In some cases, for example if you know of a suitable ready-made Singularity or Docker container, also using custom Singularity container is an option. 
 
 Please, see our Singularity documentation:
 
@@ -103,11 +104,13 @@ Please, see our Singularity documentation:
    * [Creating Singularity containers](../computing/containers/creating.md),
      including how to convert Docker container to Singularity container.
 
-For Conda:
+### Conda
+Conda is easy to use and flexible, but it might create a huge number of files which is inefficient with
+shared file systems. This can cause very slow library imports and in the worst
+case slowdowns in the whole file system. **Therefore CSC has deprecated the use of Conda installations at CSC supercomputers.**
 
    * [CSC conda tutorial](../support/tutorials/conda.md) describes in detail
-     what conda is and how to use it.
-   * [Bioconda](bioconda.md) provides conda tools preinstalled.
+     what conda is and how to use it. (Some parts of this tutorial may be helful also for Tykky installations.)
 
 
 ## Python development environments

--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -65,6 +65,10 @@ export PYTHONUSERBASE=/projappl/<your_project>/my-python-env
 pip install --user pyarrow
 ```
 
+In the example, the package is now installed inside the `my-python-env`
+directory in the project's projappl directory. Run `unset PYTHONUSERBASE` if you
+wish to later install into your home directory again.
+
 When later using those libraries you need to remember to add the `site-packages`
 path to `PYTHONPATH` (or use the same `PYTHONUSERBASE` definition as above).
 Naturally, this also applies to slurm job scripts. For example:

--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -57,32 +57,35 @@ The packages are by default installed to your home directory under
 used). If you would like to change the installation folder, for example to make
 a project-wide installation instead of a personal one, you need to define the
 `PYTHONUSERBASE` environment variable with the new installation local. For
-example:
-
-`export PYTHONUSERBASE=/projappl/<your_project>/python3.7_pip`
-
-When later using those libraries you need to remember to add that path to
-`PYTHONPATH` or use the same `PYTHONUSERBASE` definition as above. Naturally,
-this also applies to slurm job scripts.
-
-Alternatively you can create a separate virtual environment with
-[venv](https://docs.python.org/3/library/venv.html), for example:
+example to add the package `pyarrow` to the `python-data` module:
 
 ```
 module load python-data
-python -m venv --system-site-packages my-venv
-source my-venv/bin/activate
-pip install my_package_to_install
+export PYTHONUSERBASE=/projappl/<your_project>/my-python-env
+pip install --user pyarrow
 ```
 
-With `venv`, you can keep separate environments for each program. The next time
-you wish to activate the environment you only need to run `source
-my-venv/bin/activate`. `venv` does not work with Python modules installed with Singularity.
+When later using those libraries you need to remember to add the `site-packages`
+path to `PYTHONPATH` (or use the same `PYTHONUSERBASE` definition as above).
+Naturally, this also applies to slurm job scripts. For example:
+
+```
+module load python-data
+export PYTHONPATH=/projappl/<your_project>/my-python-env/lib/python3.9/site-packages/
+python3 -c "import pyarrow"
+```
+
+Alternatively you can create a separate virtual environment with
+[venv](https://docs.python.org/3/library/venv.html), however this approach
+doesn't work with modules installed with Singularity, which is now the default
+approach at CSC.
 
 If you think that some important package should be included in a module provided
 by CSC, you can send an email to <servicedesk@csc.fi>.
 
+
 ## Creating your own Python environments
+
 It is also possible to create your own Python environments. The main options are
 conda and Singularity. Singularity should be preferred at least when you know of
 a suitable ready-made Singularity or Docker container. Conda is easy to use and


### PR DESCRIPTION
Using venv for adding packages to python-data doesn't work anymore as python-data is based on singularity. I instead added example of how to use PYTHONUSERBASE which works with singularity-based environments. (People always tend to copy-paste the example and not read the text very carefully...)

Here is preview for easy reading: https://csc-guide-preview.rahtiapp.fi/origin/fix-python-installing-example/apps/python/#installing-python-packages-to-existing-modules