### PR TITLE
Document new nvm disks

### DIFF
--- a/docs/computing/systems-puhti.md
+++ b/docs/computing/systems-puhti.md
@@ -31,7 +31,7 @@ bandwidth in a non-blocking fat-tree topology.
 | M         |  532             | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 192 GiB |            |
 | L         |  92              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 384 GiB |            |
 | IO        |  40              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 384 GiB |  3600 GiB  |
-| XL        |  12              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 768 GiB |            |
+| XL        |  12              | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 768 GiB |  1490 GiB  |
 | BM        |  6               | Xeon Gold 6230 | 2 x 20 cores @ 2,1 GHz | 1,5 TiB |            |
 | GPU       |  80              | Xeon Gold 6230<br>Nvidia V100  | 2 x 20 cores @ 2,1 GHz<br> 4 GPUs connected with NVLink | 384 GiB<br>4 x 32 GB |  3600 GiB  |
 


### PR DESCRIPTION
Puhti XL 768GB hugemem nodes now have 1490GB nvme