### PR TITLE
Add notes to python page on shebang issues with pip installed executables

### DIFF
--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -56,12 +56,12 @@ The packages are by default installed to your home directory under
 used). If you would like to change the installation folder, for example to make
 a project-wide installation instead of a personal one, you need to define the
 `PYTHONUSERBASE` environment variable with the new installation local. For
-example to add the package `pyarrow` to the `python-data` module:
+example to add the package `whatshap` to the `python-data` module:
 
 ```
 module load python-data
 export PYTHONUSERBASE=/projappl/<your_project>/my-python-env
-pip install --user pyarrow
+pip install --user whatshap
 ```
 
 In the example, the package is now installed inside the `my-python-env`
@@ -75,8 +75,26 @@ Naturally, this also applies to slurm job scripts. For example:
 ```
 module load python-data
 export PYTHONPATH=/projappl/<your_project>/my-python-env/lib/python3.9/site-packages/
-python3 -c "import pyarrow"  # this should now work!
+python3 -c "import whatshap"  # this should now work!
 ```
+
+Note that if the package you installed also contains executable files these may
+not work as they refer to the Python path internal to the container (and most of
+our Python modules are installed with containers):
+
+```
+$ whatshap --help
+whatshap: /CSC_CONTAINER/miniconda/envs/env1/bin/python3.9: bad interpreter: No such file or directory
+```
+
+You can fix this by either editing the first line of the executable to point to
+the real python interpreter (check with `which python3`) or by running it via
+the Python interpreter, for example:
+
+```
+$ python3 -m whatshap --help
+```
+
 
 Alternatively you can create a separate virtual environment with
 [venv](https://docs.python.org/3/library/venv.html), however this approach


### PR DESCRIPTION
Preview: https://csc-guide-preview.rahtiapp.fi/origin/python-bin-install-note/apps/python/#installing-python-packages-to-existing-modules