### PR TITLE
Check licenses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,6 @@ script:
   - bash tests/check_fixme.sh
   # Test that no files are masked by folder/index.md
   - bash tests/check_masked.sh
+  # Test that all apps have an entry for license
+  - bash tests/check_licenses.sh
+

--- a/docs/apps/ams-gui.md
+++ b/docs/apps/ams-gui.md
@@ -3,7 +3,13 @@
 [AMS](../apps/ams.md) comes with an integrated GUI (Graphical User Interface) that makes it easy to set up, run and analyze modelling tasks.
 You can test the GUI via the Puhti web interface, [www.puhti.csc.fi](../computing/webinterface/index.md), but for more extensive use we recommend to install the GUI on your own laptop/workstation.
 
-## Use via your browser
+## License
+
+See [the License section of AMS](ams.md#license).
+
+## Usage
+
+### Use via your browser
 
 Go to [puhti.csc.fi](https://puhti.csc.fi/) using a web browser and login using your CSC user account.
 
@@ -30,7 +36,7 @@ Please replace `<yourproject>` with a proper project name. You can use the same 
 
 Select the job you want to submit (`SCM-> Jobs`), the queue you want to use (`Queue`) and submit the job `Job-> Run`.  
 
-## Install your own GUI
+### Install your own GUI
 
 The AMS license acquired by CSC allows CSC's academic customers to install
 the AMS-GUI on their local computer.  In this way the user can conveniently build and setup a

--- a/docs/apps/rstudio.md
+++ b/docs/apps/rstudio.md
@@ -5,3 +5,7 @@ RStudio is an integrated development environment (IDE) for R. More information o
 ## Available
 
 For running R and RStudio on Puhti, please see the user documentation for [`r-env-singularity`](r-env-singularity.md).
+
+## License
+
+See [the Licenses section of `r-env-singularity`](r-env-singularity.md#licenses).

--- a/docs/apps/tmolex.md
+++ b/docs/apps/tmolex.md
@@ -9,6 +9,10 @@ Import or build/modify structures on your local desktop. Run TURBOMOLE jobs on e
 - Can be freely downloaded from
  [http://www.cosmologic.de/support-download/downloads/tmolex-client.html](http://www.cosmologic.de/support-download/downloads/tmolex-client.html)   
 
+## License
+
+TBD
+
 
 ## Usage
 

--- a/tests/check_licenses.sh
+++ b/tests/check_licenses.sh
@@ -1,0 +1,15 @@
+file_type="*.md"
+directory="docs/apps"
+regex="## License"
+
+APPS_WITHOUT_LICENSE=$(grep -rL --include "$file_type" --exclude index.md -- "$regex" $directory)
+
+if [ -n "$APPS_WITHOUT_LICENSE" ]; then
+    echo "Found application(s) with no entry for license:"
+    echo "$APPS_WITHOUT_LICENSE"
+    exit 1
+else
+    echo "all applications have an entry for license"
+    exit 0
+fi
+

--- a/tests/check_licenses.sh
+++ b/tests/check_licenses.sh
@@ -1,8 +1,16 @@
 file_type="*.md"
+regex="^#\{2,3\} Licenses\?"
 directory="docs/apps"
-regex="## License"
 
-APPS_WITHOUT_LICENSE=$(grep -rL --include "$file_type" --exclude index.md -- "$regex" $directory)
+
+APPS_WITHOUT_LICENSE=$(grep -r -L \
+    --include "$file_type" \
+    --exclude index.md \
+    --exclude alpha.md \
+    --exclude by_system.md \
+    -- \
+    "$regex" $directory)
+
 
 if [ -n "$APPS_WITHOUT_LICENSE" ]; then
     echo "Found application(s) with no entry for license:"


### PR DESCRIPTION
A test that every application page has a level 2 or 3 heading starting with the capitalized word 'License'. The check for the trailing 's' is redundant at the moment since the regex doesn't match end-of-line after '##(#) License(s)' anyway. For example "## License and acknowledgement" passes the test.

https://csc-guide-preview.rahtiapp.fi/origin/check-licenses/