### PR TITLE
fix multiple typos from rahti docs

### DIFF
--- a/docs/cloud/rahti/gpu.md
+++ b/docs/cloud/rahti/gpu.md
@@ -12,7 +12,7 @@ The Rahti GPU comes with an Nvidia driver which includes the low-level shared li
 
 As a first example let's create a pod which runs `nvidia-smi` command line utility that is designed to be used for managing and monitoring NVIDIA GPU devices. This is the simplest example that can be used to demonstrate the availability of GPU in your Rahti project.
 
-To run the example you need to login to Rahti and switch to the project that you have an approved GPU qouta as: 
+To run the example you need to login to Rahti and switch to the project that you have an approved GPU quota as: 
 
 ```bash
 oc login https://rahti.csc.fi:8443 --token=<your-token>

--- a/docs/cloud/rahti/images/keeping_docker_images_small.md
+++ b/docs/cloud/rahti/images/keeping_docker_images_small.md
@@ -8,7 +8,7 @@ The first way to keep an image small is to by simply not adding unnecessary file
 
 ## Keep data out of the image
 
-Images should only contain the application's runtime. This means that the data needed to run the application should not be added to the image. This way not only the image is smaller, but we avoid a rebuild when the data changes. The data can de stored in a [external volume](/cloud/rahti/storage/persistent/) (PVC) that will be attached to the Pod upon startup, or it can be stored in [Allas](/data/Allas/) and downloaded during the startup or on demand when needed. Storing the data in Allas requires an extra logic in the application (or in a pre-load script) that understands where the data is and how to retrieve it.
+Images should only contain the application's runtime. This means that the data needed to run the application should not be added to the image. This way not only the image is smaller, but we avoid a rebuild when the data changes. The data can be stored in a [external volume](/cloud/rahti/storage/persistent/) (PVC) that will be attached to the Pod upon startup, or it can be stored in [Allas](/data/Allas/) and downloaded during the startup or on demand when needed. Storing the data in Allas requires an extra logic in the application (or in a pre-load script) that understands where the data is and how to retrieve it.
 
 ## Reduce the number of layers
 

--- a/docs/cloud/rahti/images/overview.md
+++ b/docs/cloud/rahti/images/overview.md
@@ -16,7 +16,7 @@ First, in order to run a docker image one can use the docker client on the host 
 docker run -it centos
 ```
 
-This will, if the image is not cached localy, first pull (or download) the latest centos image, then look for the predefined entry point, and finally a container is run with an interactive session. The output will be something like:
+This will, if the image is not cached locally, first pull (or download) the latest centos image, then look for the predefined entry point, and finally a container is run with an interactive session. The output will be something like:
 
 ```sh
 Unable to find image 'centos:latest' locally

--- a/docs/cloud/rahti/storage/persistent.md
+++ b/docs/cloud/rahti/storage/persistent.md
@@ -9,7 +9,7 @@ new one is created dynamically and given to the pod to use.
 
 There are two storage classes available in Rahti:
 
- * *glusterfs-storage*. This kind of volume is a "Read Write Many" (RWX) type storage, this means multiple nodes can mount it in read nad write mode. This is the default class. It is the most flexible class, as allows any pod anywhere in the cluster to read and write files. The downside is a lower performance than the next class.
+ * *glusterfs-storage*. This kind of volume is a "Read Write Many" (RWX) type storage, this means multiple nodes can mount it in read and write mode. This is the default class. It is the most flexible class, as allows any pod anywhere in the cluster to read and write files. The downside is a lower performance than the next class.
  * *standard-rwo*. This kind is a "Read Write Once" (RWO), meaning that only one node can mount the volume (in read-write mode). It is faster than glusterfs, but it is limited to a single node.
 
 ![PersistentVolumeClaim](/cloud/rahti/img/pods-and-storage-pvc.drawio.svg)

--- a/docs/cloud/rahti/template-docs.md
+++ b/docs/cloud/rahti/template-docs.md
@@ -59,7 +59,7 @@ Deploys Apache Spark cluster with Jupyter Notebook/Lab. For more information reg
 
 ![Apache Airflow](img/airflow.png)
 
-Apache Airflow (or simply Airflow) is a platform to programmatically author, schedule, and monitor workflows. The worksflows are defined as code, so that they become more maintainable, versionable, testable, and collaborative. Airflow is used to author workflows as directed acyclic graphs (DAGs) of tasks. The Airflow scheduler executes your tasks on an array of workers while following the specified dependencies. The rich user interface makes it easy to visualize pipelines running in production, monitor progress, and troubleshoot issues when needed. The documentation is currently available at <https://github.com/CSCfi/airflow-openshift/>
+Apache Airflow (or simply Airflow) is a platform to programmatically author, schedule, and monitor workflows. The workflows are defined as code, so that they become more maintainable, versionable, testable, and collaborative. Airflow is used to author workflows as directed acyclic graphs (DAGs) of tasks. The Airflow scheduler executes your tasks on an array of workers while following the specified dependencies. The rich user interface makes it easy to visualize pipelines running in production, monitor progress, and troubleshoot issues when needed. The documentation is currently available at <https://github.com/CSCfi/airflow-openshift/>
 
 ### Rocket chat
 

--- a/docs/cloud/rahti/tutorials/configuration.md
+++ b/docs/cloud/rahti/tutorials/configuration.md
@@ -120,7 +120,7 @@ DATA_PROP_A=hello
 
 ## Secret
 
-Secrets behave much like ConfigMaps, with the differnce that once created they are stored in _base64_ encoded form, and their contents are not displayed by default in the command line or in the web interface.
+Secrets behave much like ConfigMaps, with the difference that once created they are stored in _base64_ encoded form, and their contents are not displayed by default in the command line or in the web interface.
 
 *`secret.yml`*:
 

--- a/docs/cloud/rahti/tutorials/elemental_tutorial.md
+++ b/docs/cloud/rahti/tutorials/elemental_tutorial.md
@@ -131,7 +131,7 @@ Pods can be deleted using the command `oc delete`:
 oc delete pod mypod
 ```
 
-Consequently, the pod should disapper from the OpenShift web console, but let us
+Consequently, the pod should disappear from the OpenShift web console, but let us
 keep this one running for now.
 
 ----

--- a/docs/cloud/rahti/tutorials/oc-run.md
+++ b/docs/cloud/rahti/tutorials/oc-run.md
@@ -11,6 +11,6 @@ bash-4.2$
 * `pod-name` can be any given name that does not exist already in the namespace.
 * `-it` tells  `oc` to create an interactive session.
 * `--rm` will make the Pod to be deleted after the session is over.
-* `--image=bash` is the name of the image, in this case [library/bash](https://hub.docker.com/_/bash). It can be any given image, either public library image like `bash`, or a pourpose build private image.
+* `--image=bash` is the name of the image, in this case [library/bash](https://hub.docker.com/_/bash). It can be any given image, either public library image like `bash`, or a purpose build private image.
 * `--restart=Never` will tell OpenShift to not restart the Pod when the session is over.
 * If you would like to start a Pod with a different command than its default, you can do so by adding `-- [COMMAND] [args...] [flags]` at the end (e.g. `oc run pod-name  -it --rm --image=python --restart=Never -- bash`). 

--- a/docs/cloud/rahti/tutorials/webhooks.md
+++ b/docs/cloud/rahti/tutorials/webhooks.md
@@ -1,6 +1,6 @@
 # Webhooks
 
-Webhooks are URLs that allow triggering actions in a system. Rahti supports webhooks to trigger rebuilds. This means that each BuildConfig is listong to a particular URL that includes a secret (more about that later), and that when this URL is called, a build will be triggered. There few types of formats supported: Generic, GitHub, GitLab and Bitbucket. This means that if the source code of the application is in Gitlab, the Gitlab URL type is the one that should be filled in in Gitlab's side.
+Webhooks are URLs that allow triggering actions in a system. Rahti supports webhooks to trigger rebuilds. This means that each BuildConfig is listening to a particular URL that includes a secret (more about that later), and that when this URL is called, a build will be triggered. There few types of formats supported: Generic, GitHub, GitLab and Bitbucket. This means that if the source code of the application is in Gitlab, the Gitlab URL type is the one that should be filled in in Gitlab's side.
 
 ![Triggers](/cloud/rahti/img/trigger.drawio.svg)
 


### PR DESCRIPTION
Fixed typos from Rahti docs:

* What is Rahti?
  * orchestation -> orchestration
* Rahti tutorials
  * disapper -> disappear
  * differnce -> difference
  * listong -> listening
  * pourpose -> purpose
* Storage in Rahti
  * read nad write -> read and write
* Images 
  * localy -> locally
  * can de stored -> can be stored
* GPU in Rahti
  * GPU qouta -> GPU quota
* Rahti templates
  * worksflows -> workflows