### PR TITLE
Tweak hyperqueue example

### DIFF
--- a/docs/support/tutorials/nextflow-hq.md
+++ b/docs/support/tutorials/nextflow-hq.md
@@ -60,9 +60,27 @@ while true; do
 done
 
 cd $wrkdir
-time nextflow -Dnxf.pool.maxThreads=5000 -Dnxf.pool.type=sync run main.nf
+nextflow run main.nf
+
+# Make sure we exit cleanly once nextflow is done
+hq worker stop all
 hq server stop
 ```
+Where `main.nf` would be the nextflow script you want to run. 
+Note that scripts creates a per job directory and copies the nextflow script there before starting. 
+
+```
+$ ls
+example_jobscript.sh main.nf 
+$ sbatch example_jobscript.sh
+Submitted batch job 137
+$ ls
+example_jobscript.sh main.nf WRKDIR-137
+$ ls WRKDIR-137
+main.nf work
+```
+
+
 
 ## More information
 

--- a/docs/support/tutorials/nextflow-hq.md
+++ b/docs/support/tutorials/nextflow-hq.md
@@ -66,8 +66,9 @@ nextflow run main.nf
 hq worker stop all
 hq server stop
 ```
-Where `main.nf` would be the nextflow script you want to run. 
-Note that scripts creates a per job directory and copies the nextflow script there before starting. 
+
+Where `main.nf` would be the nextflow script you want to run. Note that this batch script
+creates a per job directory and copies the nextflow script there before starting. 
 
 ```
 $ ls
@@ -79,8 +80,6 @@ example_jobscript.sh main.nf WRKDIR-137
 $ ls WRKDIR-137
 main.nf work
 ```
-
-
 
 ## More information
 


### PR DESCRIPTION
- Clean exit so that slurm does not report error.
- Remove extra JVM arguments which are really not needed. 
- Clarify workdirectory