### PR TITLE
Link well-formatted page to styleguide for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Docs CSC
 
-This repository contains master data for
-[Docs CSC](https://docs.csc.fi) which is in sync with 'master' branch.
-If you're looking for CSC user guides, click [here](https://docs.csc.fi).
+This repository contains master data for [Docs CSC](https://docs.csc.fi),
+which is in sync with "master" branch. If you're looking for CSC user guides,
+click [here](https://docs.csc.fi).
 
 ## Creating issues
 
@@ -10,13 +10,15 @@ If you find that anything is wrong, badly written or missing, please
 help us to fix it. We try to make this guide as good as possible. We
 appreciate your help.
 
-The easiest way to create issues is to go to a page that you want to
-create an issue about, and click 'File a bug report for this
-article'. More general issues can be submitted through GitHubs [Issues tab](https://github.com/CSCfi/csc-user-guide/issues)
+The easiest way to create issues is to go to the source file that you want
+to create an issue about, click the appropriate line number and select
+"Reference in new issue". Make sure you are displaying the "source blob",
+not the rendered version of the page. More general issues can be submitted
+through GitHub's [Issues tab](https://github.com/CSCfi/csc-user-guide/issues).
 Creating an Issue requires a GitHub account.
 
-[Contributing](CONTRIBUTING.md)
+## How to contribute
 
-[Style guide](STYLEGUIDE.md)
-
-[Frequently asked questions](FAQ.md)
+* [Contributing](CONTRIBUTING.md)
+* [Style guide](STYLEGUIDE.md)
+* [Frequently asked questions](FAQ.md)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -16,7 +16,9 @@
  - [Markdown syntax guide](https://www.markdownguide.org/tools/mkdocs/)
  - Also some special markup possible, e.g. admonitions (colored highlight boxes). Please look at Markdown source for examples, and use preview
  - When in doubt, check how other pages are formatted
-   - An example of a well-formatted page is the one on [disk areas](https://docs.csc.fi/computing/disk/) ([source file](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/disk.md)), including examples on code blocks, tables and admonitions
+   - An example of a well-formatted page is the one on [disk areas](https://docs.csc.fi/computing/disk/)
+    ([source file](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/disk.md)),
+    including examples on how to format code blocks, tables and admonitions
 
 ## Organizing content
  - Try to make standalone articles with a good name (user knows to select it from the left menu)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -19,6 +19,11 @@
    - An example of a well-formatted page is the one on [disk areas](https://docs.csc.fi/computing/disk/)
     ([source file](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/disk.md)),
     including examples on how to format code blocks, tables and admonitions
+ - Note that pages under a certain category may have a unified formatting that should be followed
+   - For example, application pages should have **Available** (which versions and on which systems),
+    **License** (free or somehow restricted), **Usage** (how to load module, example batch scripts),
+    **References** (what should be cited) and **More information** (links to e.g official documentation)
+    headers, in that order.
 
 ## Organizing content
  - Try to make standalone articles with a good name (user knows to select it from the left menu)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -14,8 +14,9 @@
 
 ## General help
  - [Markdown syntax guide](https://www.markdownguide.org/tools/mkdocs/)
- - Also some special markup possible, e.g. coloured highlight boxes (please look at Markdown source for examples, and use preview)
+ - Also some special markup possible, e.g. admonitions (colored highlight boxes). Please look at Markdown source for examples, and use preview
  - When in doubt, check how other pages are formatted
+   - An example of a well-formatted page is the one on [disk areas](https://docs.csc.fi/computing/disk/) ([source file](https://github.com/CSCfi/csc-user-guide/blob/master/docs/computing/disk.md)), including examples on code blocks, tables and admonitions
 
 ## Organizing content
  - Try to make standalone articles with a good name (user knows to select it from the left menu)
@@ -63,7 +64,7 @@
 ## Images, linked documents
  - [See FAQ for details](FAQ.md#how-to-add-an-image).
  - Put all images in `/img` folder in docs root
- - Put large files in Allas bucket docs-files (write access with `project_2001659`), e.g.  [https://a3s.fi/docs-files/README.md]( https://a3s.fi/docs-files/README.md)
+ - Put large files in Allas bucket docs-files (write access with `project_2001659`), e.g.  [https://a3s.fi/docs-files/README.md](https://a3s.fi/docs-files/README.md)
     - New files easy to share with `a-publish your-file.tgz -b docs-files` 
 
 ## Syntax highlighting

--- a/docs/computing/disk.md
+++ b/docs/computing/disk.md
@@ -1,83 +1,86 @@
 # Disk areas
 
-CSC supercomputers have three main disk areas: **home**, **projappl** and **scratch**. In addition to these disk areas visible to all compute and login nodes, each node has a **local temporary disk area** that is visible to the particular compute node during a batch job or shell session, only. Please familiarize yourself with the areas and their specific purposes.
-The disk areas for different supercomputers are separate, *i.e.*
-**home**, **projappl** and **scratch** in Puhti cannot be directly
-accessed from Mahti. Also [a more technical description of the Lustre 
-filesystem](lustre.md) used in these directories is available.
+CSC supercomputers have three main disk areas: **home**, **projappl** and **scratch**.
+In addition to these disk areas visible to all compute and login nodes, each node has a
+**local temporary disk area** that is visible to the particular compute node during a batch
+job or shell session, only. Please familiarize yourself with the areas and their specific
+purposes. The disk areas for different supercomputers are separate, *i.e.* **home**,
+**projappl** and **scratch** in Puhti cannot be directly accessed from Mahti. Also
+[a more technical description of the Lustre filesystem](lustre.md) used in these directories
+is available.
 
 !!! Note
-    None of the disk areas are automatically backed up by CSC! This means that data accidentally deleted by the user cannot be recovered in any way. To avoid unintended data loss, make sure to perform regular backups to, for example, [Allas](../data/Allas/index.md). See also the [allas-backup tool](../data/Allas/using_allas/a_backup.md).
+    None of the disk areas are automatically backed up by CSC! This means that data accidentally
+    deleted by the user cannot be recovered in any way. To avoid unintended data loss, make sure
+    to perform regular backups to, for example, [Allas](../data/Allas/index.md). See also the
+    [allas-backup tool](../data/Allas/using_allas/a_backup.md).
 
-|              |  Owner    | Environment variable | Path                                            | Cleaning                  | Automatic backup?    |
-| ------------ |  -------- | -------------------- | ----------------------------------------------- | ------------------------- | ------------- |
-| **home**     |  Personal | `${HOME}`            | <small>`/users/<user-name>`</small>             | No                        | No            |
-| **projappl** |  Project  | Not available        | <small>`/projappl/<project>`</small>            | No                        | No            |
-| **scratch**  |  Project  | Not available        | <small>`/scratch/<project>`</small>             | Not yet - will be 90 days | No            |
+|            |Owner   |Environment variable|Path                 |Cleaning                 |Automatic backup?|
+|------------|--------|--------------------|---------------------|-------------------------|-----------------|
+|**home**    |Personal|`${HOME}`           |`/users/<user-name>` |No                       |No               |
+|**projappl**|Project |Not available       |`/projappl/<project>`|No                       |No               |
+|**scratch** |Project |Not available       |`/scratch/<project>` |Not yet - will be 90 days|No               |
 
 These disk areas have quotas for both the amount of data and total number of files:
 
-|              | Capacity | Number of files      |
-| -------------| ---------|----------------      |
-| **home**     | 10 GiB   |  100 000 files       |
-| **projappl** | 50 GiB   |  100 000 files       |
-| **scratch**  | 1 TiB    |  1 000 000 files     |
+|            |Capacity|Number of files|
+|------------|--------|---------------|
+|**home**    |10 GiB  |100 000 files  |
+|**projappl**|50 GiB  |100 000 files  |
+|**scratch** |1 TiB   |1 000 000 files|
 
-See [Increasing Quotas](#increasing-quotas) for instructions on how to apply for increased quota.
+See [Increasing quotas](#increasing-quotas) for instructions on how to apply for increased quota.
 
 ## Home directory
 
-Each user has a home directory (`$HOME`) that can contain up to 10 GB of
-data.
+Each user has a home directory (`$HOME`) that can contain up to 10 GB of data.
 
-The home directory is the default directory where you begin after
-logging in to supercomputer. However, typically you should change to your
-project's _scratch_ directory when working because the
-**home directory is not intended for data analysis or computing**. Its
-purpose is to store configuration files and other minor personal
-data. A home directory exceeding its capacity causes various account
-problems.
+The home directory is the default directory where you begin after logging in to CSC supercomputers.
+However, typically you should change to your project's `scratch` directory when working because
+the **home directory is not intended for data analysis or computing**. Its purpose is to store
+configuration files and other minor personal data. A home directory exceeding its capacity
+causes various account problems.
 
 The home directory is the only user-specific directory in supercomputers. All other directories
-are project-specific. If you are a member of several projects, you also have access
-to several _scratch_ or _projappl_ directories, but still have only one home directory.
+are project-specific. If you are a member of several projects, you also have access to several
+`scratch` or `projappl` directories, but still have only one home directory.
 
 ## Scratch directory
 
-
 Each project has by default 1 TB of scratch disk space in the directory `/scratch/<project>`.
 
-This fast parallel scratch space is intended as temporary storage
-space for the data that is used in supercomputers. The scratch directory is not intended for
-long-term data storage. In the future, any files that have not been used for 90 days will
-be automatically removed, but this is not yet enabled.
+This fast parallel scratch space is intended as temporary storage space for the data that is
+used in the supercomputer. The scratch directory is not intended for long-term data storage. In
+the future, any files that have not been used for 90 days will be automatically removed, but
+this is not yet enabled.
 
-## ProjAppl directory
+## Projappl directory
 
 Each project has also a 50 GB project application disk space in the directory
 `/projappl/<project>`.
 
-It is intended for storing applications you have compiled yourself and libraries
-etc. that you are sharing within the project. It is not a personal storage space but it
-is shared with all members of the project team.
+It is intended for storing applications you have compiled yourself, libraries etc. that you
+are sharing within the project. It is not a personal storage space but it is shared with
+all members of the project team.
 
-It is not intended for running applications, so please run them in _scratch_ instead.
+It is not intended for running applications, so please run them in `scratch` instead.
 
-## Using Scratch and ProjAppl directories
+## Using scratch and projappl directories
 
-An overview of your directories in a supercomputer you are currently
-logged on can be displayed with:
+An overview of your directories in the supercomputer you are currently logged on can be
+displayed with:
 
-```text
+```bash
 csc-workspaces 
 ```
 
-The above command displays all _scratch_ and _projappl_ directories you have access to.
+The above command displays all `scratch` and `projappl` directories you have access to.
 
-For example, if you are member in two projects, with unix groups _project_2012345_
-and _project_3587167_, then you have access to two scratch and projappl directories:
+For example, if you are a member in two projects, with unix groups `project_2012345`
+and `project_3587167`, then you have access to two `scratch` and `projappl` directories:
 
-<pre>[kkayttaj@puhti ~]$ <b>csc-workspaces</b> 
+```text
+[kkayttaj@puhti ~]$ csc-workspaces 
 Disk area               Capacity(used/max)  Files(used/max)  Project description  
 ----------------------------------------------------------------------------------
 Personal home folder
@@ -93,114 +96,120 @@ Project scratch
 ----------------------------------------------------------------------------------
 /scratch/project_2012345        56G/1T         150.53k/1000k Ortotopology modeling
 /scratch/project_3587167       324G/1T         5.53k/1000k   Metaphysics methods
-</pre>
+```
 
-Moving to the scratch directory of project_2012345:
+Moving to the scratch directory of `project_2012345`:
 
-```text
+```bash
 cd /scratch/project_2012345
 ```
 
 Please note that not all CSC projects have Puhti/Mahti access, so you may not
-necessarily find a _scratch_ or _projappl_ directory for all your CSC projects.
+necessarily find a `scratch` or `projappl` directory for all your CSC projects.
 
+!!! Note
+    The `scratch` and `projappl` directories are shared by all the members of the
+    project. All new files and directories are also fully accessible for other
+    group members (including read, write and execution permissions).
 
-**The _scratch_ and _projappl_ directories are shared by all the members of the
-project**. All new files and directories are also fully accessible for other
-group members (including read, write and execution permissions). If you want
-to restrict access from your group members, you can reset the permissions with
-the _chmod_ command.
+If you want to restrict access from your group members, you can reset the permissions
+with the `chmod` command. Setting read-only permissions for your group members for
+the directory `my_directory`:
 
-Setting read-only permissions for your group members for the directory
-*my_directory*:
-
-```text
+```bash
 chmod -R g-w my_directory
 ```
 
-As mentioned earlier, the _scratch_ directory is only intended for processing data.
-Any data that should be preserved for a longer time should be copied to the
-_Allas_ storage server. Instructions for backing up files from CSC
-supercomputers to Allas can be found in the [Allas guide](../data/Allas/index.md).
+As mentioned earlier, the `scratch` directory is only intended for processing data.
+Any data that should be preserved for a longer time should be copied to the *Allas*
+object storage server. Instructions for backing up files from CSC supercomputers to
+Allas can be found in the [Allas guide](../data/Allas/index.md).
 
 ## Moving data between supercomputers
 
-Data can be moved between supercomputers via Allas by first uploading
-the data in one supercomputer and then downloading in another
-supercomputer. This is the recommended approach if the data should also
-be preserved for a longer time.
+Data can be moved between supercomputers via Allas by first uploading the data in
+one supercomputer and then downloading in another supercomputer. This is the
+recommended approach if the data should also be preserved for a longer time.
 
-Data can also be moved directly between the supercomputers with the
-_rsync_ command. For example, in order to copy *my_results* (which can be
-either file or directory) from
-Puhti to the directory */scratch/project_2002291* in Mahti, one can
-issue in Puhti the command: 
+Data can also be moved directly between the supercomputers with the `rsync` command.
+For example, in order to copy `my_results` (which can be either file or directory)
+from Puhti to the directory `/scratch/project_2002291` in Mahti, one can issue in
+Puhti the command:
 
 ```bash
 rsync -azP my_results yourcscusername@mahti.csc.fi:/scratch/project_2002291
 ```
 
-See [Using rsync](../data/moving/rsync.md) for more detailed instructions
-for *rsync*.
+See [Using rsync](../data/moving/rsync.md) for more detailed instructions for `rsync`.
 
-## Increasing Quotas
+## Increasing quotas
 
-You can use **MyCSC portal** to [manage quotas of the _scratch_ and _projappl_ directories](../accounts/how-to-increase-disk-quotas.md).
+You can use the **MyCSC portal** to [manage quotas of the `scratch` and `projappl`
+directories](../accounts/how-to-increase-disk-quotas.md).
 
-Remember that even after the quota is increased, the planned automatic cleaning
-process will continue removing idle files from the _scratch_ directory.
-Data that is not under active computing should be stored in the Allas
-storage service.
+Remember that even after the quota is increased, the planned automatic cleaning process
+will continue removing idle files from the `scratch` directory. Data that is not under
+active computing should be stored in the Allas storage service.
 
-Remember also, that you can increase these values only to some extent. 
-Especially in the case of number of files, you should reconsider your 
-data work flow, if it requires that tens of millions
-of files are stored to the _scratch_ area.
+Remember also that you can increase these values only to some extent. Especially regarding
+the number of files, you should reconsider your data workflow if it requires that tens
+of millions of files are stored in the `scratch` area.
 
 ## Temporary local disk areas
 
-If the application depends
-on the use of temporary files, the suitability of the filesystem may have a large effect
-on the performance of the application, see section "Mind your I/O - it can make a big
-difference" in the [Performance Checklist](running/performance-checklist.md). Please note that
-some applications use temporary files "behind the scenes." Usually these applications
-read some environment variable that points to a suitable disk area, such as `$TMPDIR`.
+If the application depends on the use of temporary files, the suitability of
+the filesystem may have a large effect on the performance of the application,
+see section *Mind your I/O - it can make a big difference* in the [Performance
+checklist](running/performance-checklist.md#mind-your-io---it-can-make-a-big-difference).
+Please note that some applications use temporary files "behind the scenes". Usually these
+applications read some environment variable that points to a suitable disk area, such as
+`$TMPDIR`.
 
-Some nodes have local disks that can be used to speed up your work when the temporary files 
-are only needed within a single login or compute node.
+Some nodes have local disks that can be used to speed up your work when the temporary files
+are only needed within a single login- or compute node.
 
 ### Login nodes
 
-Each of the login nodes have 2900 GiB of fast local storage. The storage
-is located under `$TMPDIR` and is separate for each login node.  
+Each of the login nodes have 2900 GiB of fast local storage. The storage is located under
+`$TMPDIR` and is separate for each login node.  
 
-The local storage is good for compiling applications and performing 
-pre- and post-processing that require heavy IO operations, for example packing and unpacking 
-archive files. 
+The local storage is good for compiling applications and performing pre- and post-processing
+that require heavy I/O operations, for example packing and unpacking archive files.
 
 !!! Note
     The local storage is meant for **temporary** storage and is cleaned frequently.
-    Remember to move your data to a shared disk area after completing your task. 
+    Remember to move your data to a shared disk area after completing your task.
 
-### Compute nodes with local SSD (nvme) disks
+### Compute nodes with local SSD (NVMe) disks
 
-Jobs running in the IO- and gpu-nodes in Puhti and gpu-nodes in Mahti have local fast storage available. In interactive batch jobs launched with [sinteractive](running/interactive-usage.md) this local disk area is defined with environment variable `$TMPDIR` and in normal batch jobs with `$LOCAL_SCRATCH`. The size of this storage space is defined in the batch job resource request. Different nodes have different amounts of disks, see [Puhti technical details](systems-puhti.md) for a detailed list of all node types. In normal compute nodes there are 1490 GiB and 3600 GiB disks. In big memory nodes there are 1490 GiB and 5960 GiB disks, and in GPU nodes there are 3600 GiB disks. To save resources, and to ensure your jobs do not queue for resources for too long it is a good idea to only reserve what you actually need.
+Jobs running in the I/O- and GPU-nodes in Puhti and GPU-nodes in Mahti have local fast storage
+available. In interactive batch jobs launched with [sinteractive](running/interactive-usage.md),
+this local disk area is defined with environment variable `$TMPDIR` and in normal batch jobs
+with `$LOCAL_SCRATCH`. The size of this storage space is defined in the batch job resource request.
+Different nodes have different amounts of disks, see [Puhti technical details](systems-puhti.md)
+for a detailed list of all node types. In normal compute nodes, there are 1490 GiB and 3600 GiB
+disks. In big memory nodes there are 1490 GiB and 5960 GiB disks, and in GPU-nodes there are
+3600 GiB disks. To save resources, and to ensure your jobs do not queue for resources for too
+long, it is a good idea to only reserve what you actually need.
 
-These local disk areas are designed to support I/O intensive computing tasks and cases where you need to process large amounts (over 100 000 files) of small files. These directories are cleaned once the batch job finishes. Thus, in the end of a batch job you must copy all the data that you want to preserve from these temporary disk areas to _scratch_ directory or to Allas.
+These local disk areas are designed to support I/O intensive computing tasks and cases where you
+need to process large amounts (over 100 000) of small files. These directories are cleaned once
+the batch job finishes. Thus, in the end of a batch job you must copy all the data that you want
+to preserve from these temporary disk areas to `scratch` directory or to Allas.
 
-For more information see: [creating job scripts](running/creating-job-scripts-puhti.md#local-storage). 
+For more information see [creating job scripts](running/creating-job-scripts-puhti.md#local-storage).
 
-### Compute nodes without local SSD (nvme) disks
+### Compute nodes without local SSD (NVMe) disks
 
-In Puhti we simply recommend using compute nodes with nvme disks (`$LOCAL_SCRATCH`) for the applications that
-require temporary local storage.
+In Puhti we simply recommend using compute nodes with NVMe disks (`$LOCAL_SCRATCH`) for the
+applications that require temporary local storage.
 
-In Mahti, with most compute nodes without local nvme disks, it is possible to store
-a relatively small amount of temporary files
-in memory. In practice the applications can use the directory `/dev/shm` for this, for example by
-setting `export TMPDIR=/dev/shm`. Plese note that the use of `/dev/shm` consumes memory, so less is
-left available for the applications. This may lead in applications running out of memory sooner than
-expected and failing in the compute node, but this usually does no other harm. The plus side is that
-if it works, it should be fast. In Puhti however, where applications from
-multiple users can share the same node, running out of memory by filling up `/dev/shm` will crash
-other users applications, too. It is recommended not to use `/dev/shm` in Puhti at all.
+In Mahti, with most compute nodes without local NVMe disks, it is possible to store a relatively
+small amount of temporary files in memory. In practice, the applications can use the directory
+`/dev/shm` for this, for example by setting `export TMPDIR=/dev/shm`. Please note that the use
+of `/dev/shm` consumes memory, so less is left available for the applications. This may lead to
+applications running out of memory sooner than expected and failing in the compute node, but
+this usually does no other harm. The plus side is that if it works, it should be fast. In Puhti
+however, where applications from multiple users can share the same node, running out of memory
+by filling up `/dev/shm` will crash other users applications, too. **It is thus not recommended to
+use `/dev/shm` in Puhti at all.**

--- a/docs/computing/disk.md
+++ b/docs/computing/disk.md
@@ -15,11 +15,11 @@ is available.
     to perform regular backups to, for example, [Allas](../data/Allas/index.md). See also the
     [allas-backup tool](../data/Allas/using_allas/a_backup.md).
 
-|            |Owner   |Environment variable|Path                 |Cleaning                 |Automatic backup?|
-|------------|--------|--------------------|---------------------|-------------------------|-----------------|
-|**home**    |Personal|`${HOME}`           |`/users/<user-name>` |No                       |No               |
-|**projappl**|Project |Not available       |`/projappl/<project>`|No                       |No               |
-|**scratch** |Project |Not available       |`/scratch/<project>` |Not yet - will be 90 days|No               |
+|            |Owner   |Environment variable|Path                 |Cleaning                 |Automatic backup|
+|------------|--------|--------------------|---------------------|-------------------------|----------------|
+|**home**    |Personal|`${HOME}`           |`/users/<user-name>` |No                       |No              |
+|**projappl**|Project |Not available       |`/projappl/<project>`|No                       |No              |
+|**scratch** |Project |Not available       |`/scratch/<project>` |Not yet - will be 90 days|No              |
 
 These disk areas have quotas for both the amount of data and total number of files:
 


### PR DESCRIPTION
There was a request in the SR-COMP seminar to link a well-formatted page to the style guide as an example. Added the disk areas page (after some polishing).
https://csc-guide-preview.rahtiapp.fi/origin/style-example/computing/disk/