### PR TITLE
Monospaced text inside headings

### DIFF
--- a/csc-overrides/assets/stylesheets/code.css
+++ b/csc-overrides/assets/stylesheets/code.css
@@ -11,3 +11,9 @@
 .md-clipboard:is(:focus, :hover) {
     color: var(--md-typeset-a-color);
 }
+
+.md-typeset :is(h1, h2, h3, h4, h5, h6) code {
+    font-size: inherit;
+    background-color: inherit;
+    padding: unset;
+}

--- a/csc-overrides/assets/stylesheets/content.css
+++ b/csc-overrides/assets/stylesheets/content.css
@@ -29,11 +29,7 @@
     font-weight: var(--csc-font-weight--regular);
 }
 
-.md-typeset h2,
-.md-typeset h3,
-.md-typeset h4,
-.md-typeset h5,
-.md-typeset h6 {
+.md-typeset :is(h2, h3, h4, h5, h6) {
     font-weight: var(--csc-font-weight--bold);
 }
 

--- a/docs/ref.md
+++ b/docs/ref.md
@@ -52,7 +52,7 @@ That one's a level 3. Here is some text under it.
 #### Now for a level 4 heading
 Some text _four_ it here.
 
-##### Level 5 heading
+##### Level 5 heading: `now with added monospace`
 No text this time.
 
 ###### Level 6


### PR DESCRIPTION
Monospaced text inside headings was rendering as it renders inside text blocks. These changes fix that and add the case in question to the reference card. Here's a page with a heading containing monospaced text:

https://csc-guide-preview.rahtiapp.fi/origin/monospace-in-headings/cloud/rahti/tutorials/connect-database-hpc/#option-2-using-the-oc-command-line-tool