### PR TITLE
Enabling Matomo web analytics

### DIFF
--- a/csc-overrides/404.html
+++ b/csc-overrides/404.html
@@ -1,4 +1,10 @@
 {% extends "base.html" %}
+{% block extrahead %}
+    {{ super () }}
+    {% if config.extra.mkdocs_env == "production" %}
+        {% include "partials/matomo.html" %}
+    {% endif %}
+{% endblock extrahead %}
 {% block content %}
   <nav class="csc-breadcrumbs">
     <a class="csc-breadcrumbs__link" href="{{ base_url }}">Docs CSC</a>


### PR DESCRIPTION
These changes are actually only for enabling Matomo on HTTP 404 pages. Everything else should already be in place.