### PR TITLE
Maestro rhel8 heads up

### DIFF
--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -14,10 +14,10 @@ Puhti: 2020.2, 2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1
 
 Mahti: 2021.4, 2022.1
 
-!!! info
+!!! info "Incompatibility issue with latest versions"
     
     Versions 2022.2 and later are incompatible with the RHEL8 operating system on Puhti and Mahti. If you intend
-    to run jobs at CSC, don't upgrade your local installation! We're looking for a workaround.
+    to run jobs at CSC, don't upgrade your local installation beyond 2022.1! We're looking for a workaround.
 
 ## License
 

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -13,6 +13,9 @@ for *drug design* and *Materials Science*. It can be used to build, edit, run an
 Puhti: 2020.2, 2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1
 Mahti: 2021.4, 2022.1
 
+!!! Note: Versions 2022.2 and later are incompatible with the RHEL8 operating system on Puhti and Mahti. If you intend
+          to run jobs at CSC, don't upgrade your local installation! We're looking for a workaround.
+
 ## License
 
 Maestro is available for all academic users in Finland: staff and students,
@@ -20,7 +23,7 @@ for academic purposes. Please consult the [EULA](https://www.schrodinger.com/mae
 for the exact definition. 
 Using Maestro means that you accept the EULA linked to above.
 The Maestro license consists of floating licenses and tokens.
-If licenses run out, contact Atte via [ServiceDesk](/support/contact/)
+If licenses run out, contact us via [ServiceDesk](/support/contact/)
 
 ## Usage
 

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -13,8 +13,10 @@ for *drug design* and *Materials Science*. It can be used to build, edit, run an
 Puhti: 2020.2, 2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1
 Mahti: 2021.4, 2022.1
 
-!!! Note: Versions 2022.2 and later are incompatible with the RHEL8 operating system on Puhti and Mahti. If you intend
-          to run jobs at CSC, don't upgrade your local installation! We're looking for a workaround.
+!!! info
+    
+    Versions 2022.2 and later are incompatible with the RHEL8 operating system on Puhti and Mahti. If you intend
+    to run jobs at CSC, don't upgrade your local installation! We're looking for a workaround.
 
 ## License
 

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -11,6 +11,7 @@ for *drug design* and *Materials Science*. It can be used to build, edit, run an
 ## Available
 
 Puhti: 2020.2, 2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1
+
 Mahti: 2021.4, 2022.1
 
 !!! info

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -12,12 +12,12 @@ for *drug design* and *Materials Science*. It can be used to build, edit, run an
 
 Puhti: 2020.2, 2020.4, 2021.1, 2021.2, 2021.3, 2021.4, 2022.1
 
-Mahti: 2021.4, 2022.1
+Mahti: 2021.4, 2022.1, 2022.2
 
 !!! info "Incompatibility issue with latest versions"
     
-    Versions 2022.2 and later are incompatible with the RHEL8 operating system on Puhti and Mahti. If you intend
-    to run jobs at CSC, don't upgrade your local installation beyond 2022.1! We're looking for a workaround.
+    Versions 2022.3 and later are incompatible with the RHEL8 operating system on Puhti and Mahti. If you intend
+    to run jobs at CSC, don't upgrade your local installation beyond 2022.2! We're looking for a workaround.
 
 ## License
 


### PR DESCRIPTION
Inform end users on the incompatibility of latest maestro versions and RHEL8.

https://csc-guide-preview.rahtiapp.fi/origin/maestro-rhel8-heads-up/apps/maestro/