### PR TITLE
Update tykky.md

### DIFF
--- a/docs/computing/containers/tykky.md
+++ b/docs/computing/containers/tykky.md
@@ -2,7 +2,7 @@
 
 ## Intro
 
-Tykky is a set of tools for easy installation of tools to HPC using Apptainer containers. 
+Tykky is a set of tools which make software installations to HPC easier using Apptainer/Singularity containers.
 
 Tykky use cases:
 


### PR DESCRIPTION
`Tykky is a set of tools for easy installation of tools to HPC using Apptainer containers. ` --> `Tykky is a set of tools which make software installations to HPC easier using Apptainer/Singularity containers.` 

Rewrite such that tools isn't mentioned twice. Consistent use of "Apptainer/Singularity"

Sorry this was missed in the original PR. 