### PR TITLE
Restricted content width

### DIFF
--- a/csc-overrides/assets/stylesheets/content.css
+++ b/csc-overrides/assets/stylesheets/content.css
@@ -1,3 +1,15 @@
+@media screen and (min-width: 60em) {
+    .md-grid>.md-content[data-md-component=content] {
+        display: grid;
+    }
+
+    .md-content[data-md-component=content]>article.md-content__inner.md-typeset {
+        max-width: 50rem;
+        min-width: min(90%, 50rem);
+        justify-self: center;
+    }
+}
+
 .md-main__inner {
     margin: unset;
     max-width: unset;

--- a/csc-overrides/assets/stylesheets/content.css
+++ b/csc-overrides/assets/stylesheets/content.css
@@ -4,8 +4,8 @@
     }
 
     .md-content[data-md-component=content]>article.md-content__inner.md-typeset {
-        max-width: 50rem;
-        min-width: min(90%, 50rem);
+        max-width: var(--csc-content-width);
+        min-width: min(100%, var(--csc-content-width));
         justify-self: center;
     }
 }

--- a/csc-overrides/assets/stylesheets/variables.css
+++ b/csc-overrides/assets/stylesheets/variables.css
@@ -36,6 +36,7 @@
 
     /* ...and some more: */
     --csc-header-height: 71px;
+    --csc-content-width: 48rem;
 
     --csc-border: 1px solid #E8E8E8;
     --csc-blockquote-border-left: 4px solid var(--csc-primary);


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/content-width/

Currently, line length on Docs can get awfully long when the width of the browser window grows.

For example, Accounts > Overview:
![content_on_the_loose](https://user-images.githubusercontent.com/50655931/196382081-548abdbc-3bf0-400b-92cb-696490840a01.png)

This PR adresses the issue by restricting content width, like so:
![content_tied_down](https://user-images.githubusercontent.com/50655931/196382381-972e48aa-7c6e-4db4-8bce-636be8b05a62.png)
