### PR TITLE
Using Stan with R

### DIFF
--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -151,7 +151,7 @@
 * [MATLAB](matlab.md) High-level technical computing language
 * [Octave](octave.md) High-level interpreted language for numerical computations.
 * [Python](python.md) programming language and its modules at CSC.
-* [r-env](r-env.md) R, RStudio Server, SAGA and TensorFlow (Singularity container)
+* [r-env](r-env.md) R, RStudio Server, SAGA and TensorFlow
 * [RStudio](rstudio.md) Integrated development environment for R
 * [SageMath](sagemath.md) Free open-source mathematics software system
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -21,7 +21,7 @@ Current modules and versions supported on Puhti:
 
 | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version  | TensorFlow version | CmdStan version |
 | ----------------------- | ------------------- | -------------------- | ---------------------- | ----------------| ------------------ | --------------- |
-| r-env/4.2.1             | June 29 2022        | 3.15                 | 2022.02.3-492          | 2022.1.0        | 2.9.1              | 2.30.1
+| r-env/421               | June 29 2022        | 3.15                 | 2022.02.3-492          | 2022.1.0        | 2.9.1              | 2.30.1
 
 Other software and libraries:
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -658,13 +658,13 @@ export APPTAINERENV_NVBLAS_CONFIG_FILE=~/nvblas/nvblas.conf
 
 The `r-env` module includes several packages that make use of [Stan](https://mc-stan.org/) for statistical modelling.
 
-*Multithreading and `rstan`*
+*Note on parallel jobs using `rstan`*
 
-The thread affinity variable `APPTAINERENV_OMP_PLACES=cores` has been found to interfere with jobs using the `rstan` package (it binds all R processes to a single core, rather than binding each thread to a single core). It is therefore currently recommended that this variable should not be used for parallel R jobs with Stan.
+The thread affinity variable `APPTAINERENV_OMP_PLACES=cores` has been found to interfere with parallel jobs using the `rstan` package. We currently recommend that this variable should not be used for parallel R jobs with Stan.
 
 *Using R with the CmdStan backend* 
 
-The `r-env` module comes with a separate [CmdStan] installation which is specific to each module version.
+The `r-env` module comes with a separate [CmdStan](https://github.com/stan-dev/cmdstan) installation that is specific to each module version.
 To use it, one must set the correct path to CmdStan using `cmdstanr`. For example, for `r-env/421` this would be done as follows:
 
 ```r

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -658,9 +658,8 @@ export APPTAINERENV_NVBLAS_CONFIG_FILE=~/nvblas/nvblas.conf
 
 The `r-env` module includes several packages that make use of [Stan](https://mc-stan.org/) for statistical modelling.
 
-*Note on parallel jobs using `rstan`*
-
-The thread affinity variable `APPTAINERENV_OMP_PLACES=cores` has been found to interfere with parallel jobs using the `rstan` package. We currently recommend that this variable should not be used for parallel R jobs with Stan.
+!!! note
+    The thread affinity variable `APPTAINERENV_OMP_PLACES=cores` has been found to interfere with parallel jobs using the `rstan` package. We currently recommend that this variable should not be used for parallel R jobs with Stan.
 
 *Using R with the CmdStan backend* 
 

--- a/docs/support/training-material.md
+++ b/docs/support/training-material.md
@@ -20,7 +20,7 @@ for self study.
  
 ## Learn R and Python:
 *   [R for Beginners](https://github.com/csc-training/R-for-beginners)
-*   [Data Analysis with R](https://github.com/csc-training/da-with-r)
+*   [Data Analysis with R](https://github.com/csc-training/da-with-r-remote)
 *   [Practical Machine Learning (using Python)](https://e-learn.csc.fi/course/view.php?id=14)
 *   [Python basic course for geoscientists](https://geo-python.github.io/site/)
 *   [Python in High Performance Computing](https://www.futurelearn.com/courses/python-in-hpc) PRACE MOOC


### PR DESCRIPTION
- New section on using Stan with `r-env`
- "Available" section lists [CmdStan](https://github.com/stan-dev/cmdstan) version
- Note on `APPTAINERENV_OMP_PLACES=cores` interfering with parallel `rstan` jobs
- Instructions on using the CmdStan backend with R
- Fixed Data Analysis with R course link in Training Material

Preview: [see here](https://csc-guide-preview.rahtiapp.fi/origin/rstan/apps/r-env/#using-r-env-with-stan)
 