### PR TITLE
Links to Gaussian+HyperQueue tutorial

### DIFF
--- a/docs/apps/gaussian.md
+++ b/docs/apps/gaussian.md
@@ -123,3 +123,4 @@ on Puhti. For this type of calculation Mahti isn't the optimal choice.
 
 - [Online Gaussian user reference](http://gaussian.com/man/)
 - [Using Gabedit as GUI for Gaussian jobs on Puhti](../support/tutorials/gabedit_gaussian.md)
+- [Farming Gaussian jobs with HyperQueue](https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html)

--- a/docs/apps/hyperqueue.md
+++ b/docs/apps/hyperqueue.md
@@ -227,3 +227,4 @@ how to use HyperQueue as an executor for Nextflow workflows.
     node-level granularity.
 
 * [Full documentation for HQ](https://it4innovations.github.io/hyperqueue/v0.11.0/)
+* [Farming Gaussian jobs with HyperQueue](https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html)

--- a/docs/computing/running/throughput.md
+++ b/docs/computing/running/throughput.md
@@ -166,6 +166,7 @@ graph TD
 * [Nextflow] singularity container-based bioinformatics pipelines on Puhti
 * [Data storage guide for machine learning] explains where to work with ML data
   and how to use the shared file system efficiently
+* [Farming Gaussian jobs with HyperQueue]
 
 ### Workflow tools integrated into common simulation software
 
@@ -214,3 +215,4 @@ workflows.
 [see usage policy]: ../overview.md#gpu-nodes
 [Fast disk areas in CSC computing environment]: https://csc-training.github.io/csc-env-eff/hands-on/disk-areas/disk-areas-tutorial-fastdisks.html
 [Nextflow workflows using HyperQueue as an executor]: ../../support/tutorials/nextflow-hq.md
+[Farming Gaussian jobs with HyperQueue]: https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html

--- a/docs/support/tutorials/index.md
+++ b/docs/support/tutorials/index.md
@@ -45,6 +45,7 @@
 * [Running your first job on Puhti](biojobs-on-puhti.md)
 
 ## Chemistry
+* [Farming Gaussian jobs with HyperQueue](https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html)
 * [Using Gabedit for Gaussian jobs on Puhti](gabedit_gaussian.md)
 
 ## Data analysis and machine learning


### PR DESCRIPTION
Translated old gaussian+greasy tutorial to use hyperqueue, https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html

Links to old tutorial were removed earlier, now added back.