### PR TITLE
add py6s to geoconda

### DIFF
--- a/docs/apps/geoconda.md
+++ b/docs/apps/geoconda.md
@@ -33,6 +33,7 @@ includes following python packages:
     OpenStreetMap's APIs. [Routing examples in CSC geocomputing Github](https://github.com/csc-training/geocomputing/tree/master/python/routing)
 -   [owslib](https://geopython.github.io/OWSLib/index.html) -  for retrieving data from Open Geospatial Consortium (OGC) web services
 -   [python-pdal](https://pdal.io/python.html) - PDAL Python extension for lidar data
+-   [Py6S](https://py6s.readthedocs.io/en/latest/index.html) - Python interface to the Second Simulation of the Satellite Signal in the Solar Spectrum (6S) atmospheric Radiative Transfer Model
 -   [pysal] - spatial analysis functions.    
 -   [pdal](https://pdal.io/) - for lidar data
 -   [pyntcloud](https://pyntcloud.readthedocs.io/) - for working with 3D point clouds. NEW 2022


### PR DESCRIPTION
no version update, but addition to 3.10.6

Geoconda also now includes jupyter git extension which means that geoconda depends on git module now.
Did not add that to the docs though.