### PR TITLE
Increase searchability of weekly support coffees

### DIFF
--- a/docs/support/contact.md
+++ b/docs/support/contact.md
@@ -6,13 +6,19 @@
 * Email: <mailto:servicedesk@csc.fi>
 * Phone: +358 9 457 2821
 * Open Monday to Friday from 8.30 a.m. to 4 p.m.
-* NEW! Weekly research support session Wednesdays at 2 p.m. More information and
-  connection details can be found on the [event page](https://ssl.eventilla.com/event/PP4WB)
+
+!!! info "Weekly research support coffees"
+    Does formulating your support request in writing feel cumbersome? Please consider
+    joining our weekly research support coffee sessions on Wednesdays at 2 p.m. where
+    you can directly discuss with our specialists!
+
+    !!! info-label
+        [See here for more information and connection details](https://ssl.eventilla.com/event/PP4WB).
 
 !!! info "LUMI User Support Team"
-
-    If your support request concerns the LUMI supercomputer, please [contact the LUMI User Support Team](https://docs.lumi-supercomputer.eu/helpdesk/).
+    If your support request concerns the LUMI supercomputer, please [contact the LUMI User
+    Support Team](https://docs.lumi-supercomputer.eu/helpdesk/).
 
 ## How to write good support requests
-* [13 point list to speed up resolving your issue](./support-howto.md)
 
+* [13 point list to speed up resolving your issue](./support-howto.md)

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -2,7 +2,7 @@
 
 ## Amber22 installed on Puhti, 16.11.2022
 
-[Amber](../../apps/maestro.md) version 22 has been installed on Puhti and set as the default
+[Amber](../../apps/amber.md) version 22 has been installed on Puhti and set as the default
 module. [See here for a list of major new features](https://ambermd.org/AmberMD.php).
 
 ## Maestro 2022.3 and 2022.4 installed on Puhti, 15.11.2022

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,8 +54,8 @@ theme:
   palette:
     scheme: csc
   font: false # No loading fonts from G****e
-  features:
-    - announce.dismiss
+#  features:
+#    - announce.dismiss
 
 extra_css:
   - assets/stylesheets/variables.css


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/coffee/support/contact/

Page can now be found by searching for 'coffee'. 

Also, the announcement bar cannot be dismissed anymore. Is this too intrusive? How the announcement bar works is a bit crude; either it can be dismissed and then it will not return unless the content is changed, or then it cannot be dismissed at all.