### PR TITLE
Quick update about FEGA launch and instructions for single registers

### DIFF
--- a/docs/data/sensitive-data/federatedega.md
+++ b/docs/data/sensitive-data/federatedega.md
@@ -1,6 +1,9 @@
 # Federated European Genome-phenome Archive (FEGA)
 
-Federated European Genome-phenome Archive (FEGA) is a service for storing and sharing human genetic and phenotypic data consented for research. The service is based on a European network of local repositories. CSC hosts Finnish FEGA. Please note, that this user guide is specific for Finnish FEGA service.
+Federated European Genome-phenome Archive (FEGA) is a service for storing and publishing human genetic and phenotypic data consented for research. The service is based on a European network of local repositories. CSC hosts Finnish FEGA. Please note, that this user guide is specific for Finnish FEGA service.
+
+!!! Note 
+    FEGA is still in the pilot phase, so no submissions can be made to the service. The expected launch of the service is in the beginning of year 2023. We will process submissions in the order we have received the support requests.
 
 You can use FEGA either to submit, apply or approve access to biomedical datasets. The service allows you to store sensitive research data under controlled access in Finland. At the same time, the public study information (metadata) is made internationally available in central [European Genome-phenome Archive](https://ega-archive.org/studies) (EGA). Each dataset is associated with a Data Access Committee (DAC), which evaluates data access applications and can grant or deny data access for re-use. If the application is approved, the applicant can directly access and analyse the sensitive data in a secure and private cloud workspace using CSC Sensitive Data Services for research. Choose the correct user guide below:
 

--- a/docs/data/sensitive-data/fega_submission.md
+++ b/docs/data/sensitive-data/fega_submission.md
@@ -1,5 +1,8 @@
 # Data submission
 
+!!! Note 
+    FEGA is still in the pilot phase, so no submissions can be made to the service. The expected launch of the service is in the beginning of year 2023. We will process submissions in the order we have received the support reguests. In addition to the legal agreements listed on this page, there needs to be service agreement between CSC and the data controller specific for FEGA service. Make sure before starting submitting any data that all these legal agreements are in place. This user guide is still preliminary, and changes to the instructions are expected before the launch of the service.
+
 <iframe width="280" height="155" srcdoc="https://www.youtube.com/embed/eg9YRFgT_5w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Submission process overview 

--- a/docs/data/sensitive-data/fega_submission.md
+++ b/docs/data/sensitive-data/fega_submission.md
@@ -1,7 +1,7 @@
 # Data submission
 
 !!! Note 
-    FEGA is still in the pilot phase, so no submissions can be made to the service. The expected launch of the service is in the beginning of year 2023. We will process submissions in the order we have received the support reguests. In addition to the legal agreements listed on this page, there needs to be service agreement between CSC and the data controller specific for FEGA service. Make sure before starting submitting any data that all these legal agreements are in place. This user guide is still preliminary, and changes to the instructions are expected before the launch of the service.
+    FEGA is still in the pilot phase, so no submissions can be made to the service. The expected launch of the service is in the beginning of year 2023. We will process submissions in the order we have received the support requests. In addition to the legal agreements listed on this page, there needs to be service agreement between CSC and the data controller specific for FEGA service. Make sure before starting submitting any data that all these legal agreements are in place. This user guide is still preliminary, and changes to the instructions are expected before the launch of the service.
 
 <iframe width="280" height="155" srcdoc="https://www.youtube.com/embed/eg9YRFgT_5w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/data/sensitive-data/fega_submission.md
+++ b/docs/data/sensitive-data/fega_submission.md
@@ -1,7 +1,7 @@
 # Data submission
 
 !!! Note 
-    FEGA is still in the pilot phase, so no submissions can be made to the service. The expected launch of the service is in the beginning of year 2023. We will process submissions in the order we have received the support requests. In addition to the legal agreements listed on this page, there needs to be service agreement between CSC and the data controller specific for FEGA service. Make sure before starting submitting any data that all these legal agreements are in place. This user guide is still preliminary, and changes to the instructions are expected before the launch of the service.
+    FEGA is still in the pilot phase, so no submissions can be made to the service. The expected launch of the service is in the beginning of year 2023. We will process submissions in the order we have received the support requests. In addition to the legal agreements listed on this page, there needs to be a service agreement between CSC and the data controller specific for FEGA service. Make sure before starting submitting any data that all these legal agreements are in place. This user guide is still preliminary, and changes to the technical instructions are expected before the launch of the service.
 
 <iframe width="280" height="155" srcdoc="https://www.youtube.com/embed/eg9YRFgT_5w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/docs/data/sensitive-data/index.md
+++ b/docs/data/sensitive-data/index.md
@@ -77,7 +77,7 @@ This guide, in CSC Docs, introduces CSC's Sensitive Data (SD) services. To navig
   
   
 ## [SD Desktop for secondary use of health and social data](./sd-desktop-audited.md)
-Access to this service requires a Findata permit. There are different [instructions](./single-register-submission.md) for single registers to submit secondary use data for research use in SD services.
+Access to this service requires a Findata permit. There are also [instructions](./single-register-submission.md) for single registers to submit secondary use data for research use in SD services.
   
   * [**Key features**](./sd-desktop-audited.md#key-features)
 

--- a/docs/data/sensitive-data/index.md
+++ b/docs/data/sensitive-data/index.md
@@ -77,7 +77,7 @@ This guide, in CSC Docs, introduces CSC's Sensitive Data (SD) services. To navig
   
   
 ## [SD Desktop for secondary use of health and social data](./sd-desktop-audited.md)
-Access to this service requires a Findata permit.
+Access to this service requires a Findata permit. There are different [instructions](./single-register-submission.md) for single registers to submit secondary use data for research use in SD services.
   
   * [**Key features**](./sd-desktop-audited.md#key-features)
 

--- a/docs/data/sensitive-data/single-register-submission.md
+++ b/docs/data/sensitive-data/single-register-submission.md
@@ -1,0 +1,33 @@
+# Submitting secondary use health and social data for research use via SD Apply
+
+These instructions are for data controllers who have issued a data permit for a research project and need to make their data available on SD Desktop.
+
+!!! Note 
+    The  first register data set must always be submitted in a collaboration with the CSC Sensitive Data (SD) services team. You can start a conversation with the SD services team by sending a message to the CSC service desk (servicedesk@csc.fi, subject: Sensitive Data).
+
+After the process is established for the first time, the data controller can manage the subsequent data submissions on their own. Help is always available via the service desk.
+
+## Submission process step by step:
+
+**1)** The representative of the data controller signs in to [SD Apply service](https://sd-apply.csc.fi/) using Haka credentials. After the first log in, CSC service desk can create an organizational profile, which will be used for all the data submissions coming from this organization, and assign the representative as an owner of the organizational profile. There can also be multiple owners for one organization.
+
+**2)** The owner can then create a workflow, forms and licenses for the organization in SD Apply. Workflow represents the data access management (defines who will accept the access applications in SD services). To forms, the owner can add the data permit information for each data submission. Licenses specify the terms of use for the data. For each of these, the Haka ePPN should be used as a title.
+
+**3)** Next, the representative of the data controller who will do the data submission logs in to [the user administration portal](https://admin.sd.csc.fi/) with Haka credentials. Here they must **1)** add the IP address from which the data submission will be done (IP address can be checked with [CSC’s My IP app](https://apps.csc.fi/myip/)) and **2)** add their public SSH key. With this information, the CSC service desk will make the necessary preparations for data submission from the SD service side.
+
+**4)** After the preparations are done, the representative of the data controller can test that the SFTP connection works with the command:
+
+```
+sftp -P 50527 username@eppn.fi@porin.lega.csc.fi
+exit
+```
+
+**5)** Before transfer, the data must be encrypted with [a CSC public key](https://admin.sd.csc.fi/publickey/?instance=single%20registry). CSC provides a convenience tool that encrypts and uploads data automatically. SDA Uploader tool is available on [GitHub](https://github.com/CSCfi/sda-uploader/releases). Encryption and upload can also be done manually with crypt4gh and SFTP.
+
+**6)** Now everything is ready for the data to be transferred to CSC. The representative of the data controller sends the encrypted data via SFTP to a directory which must be named according to the journal number from the data permit. The final dataset ID will be a combination of  the organization’s Haka ePPN and the journal number (e.g. eppn.fi/example_dataset_123). 
+
+```
+sdacli example_dataset_123 -host porin.lega.csc.fi -p 50527 -u username@eppn.fi -i ~/.ssh/id_rsa -pub registry.pub
+```
+
+**7)** After the data has been submitted successfully, it can be found in SD Apply with the dataset ID. The researcher who has received the data permit can contact the CSC service desk and ask for a CSC project with the data permit. After the project has been established, they can log in to SD Apply and apply for data access. The assigned representatives of the data controller will receive a notification of the application to their email. They can review and approve the application and set an end date for the data access in SD Apply. The permission can also be revoked manually in the future, but automated end date is preferred.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -272,6 +272,7 @@ nav:
         - Store with SD Connect: data/sensitive-data/sd_connect.md
         - Analyse with SD Desktop: data/sensitive-data/sd_desktop.md
         - SD Desktop for secondary use: data/sensitive-data/sd-desktop-audited.md
+#       - SD Apply for secondary use: data/sensitive-data/single-register-submission.md
 #       - Federated EGA: data/sensitive-data/federatedega.md
 #       - SD Apply: data/sensitive-data/sd-apply.md
 #       - Containers: data/sensitive-data/creating_containers.md


### PR DESCRIPTION
Added a note about FEGA launch on FEGA main page and submission instructions page. Created a page for single register submission instructions and added a hidden link to main menu and one sentence to Sensitive Data content page with the link to that page under SD Desktop for secondary use.