### PR TITLE
Updating r-env CmdStan information

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -681,7 +681,7 @@ SING_FLAGS="$SING_FLAGS -B /appl/soft/math/r-env/${RVER}-stan:/appl/soft/math/r-
 srun apptainer_wrapper exec Rscript --no-save script.R
 ```
 
-Other details on using the CmdStan backend are package-specific. As one example, one could use it for [within-chain parallelisation using `brms`](https://cran.r-project.org/web/packages/brms/vignettes/brms_threading.html): 
+Other details on using the CmdStan backend are package-specific. As one example, one could use it with the [`brms`](https://paul-buerkner.github.io/brms/) package:
 
 ```r
 library(brms)
@@ -692,6 +692,8 @@ fit_serial <- brm(
   chains = 4, cores = 4, backend = "cmdstanr"
 )
 ```
+
+Note that [within-chain parallelisation with `brms`](https://cran.r-project.org/web/packages/brms/vignettes/brms_threading.html) requires a project-specific installation of CmdStan. Please contact [servicedesk@csc.fi](mailto:servicedesk@csc.fi) for instructions.
 
 #### R package installations
 


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/helijuottonen-cmdstan-update/apps/r-env/#using-r-env-with-stan

Updating the information on within-chain parallelization with brsm and CmdStan: Example on the page refers to using CmdStan backend with brms. Within-chain parallelization (threading) requires a project-specific installation of CmdStan, because it wants to write in the write-protected CmdStan installation folder. Instructions for the CmdStan installation left out, because the installation requires a lot of memory and good enough instructions would take too much space on the page.