### PR TITLE
 Add SPF info to sending e-mail section

### DIFF
--- a/docs/cloud/pouta/additional-services.md
+++ b/docs/cloud/pouta/additional-services.md
@@ -32,8 +32,10 @@ attribute from the _From_ attribute.
 
 You might need to add CSC's SPF record included to your own domain existing DNS record if SPF is already configured in use. 
 Even if it isn't it should be considered as there are parties which have started to reject mails from domains where SPF isn't configured.
+
 It's good to know that taking SPF in use or just by modifying existing record incorrectly could affect whole domain email traffic functionality.
 Also it's good to understand that you may only add/edit SPF record on domain to which you have access to control DNS.
+
 Part which should be added to SPF record is include:hosted-at.csc.fi
 Your domain SPF record should look then something like this:
 ```

--- a/docs/cloud/pouta/additional-services.md
+++ b/docs/cloud/pouta/additional-services.md
@@ -36,7 +36,9 @@ It's good to know that taking SPF in use or just by modifying existing record in
 Also it's good to understand that you may only add/edit SPF record on domain to which you have access to control DNS.
 Part which should be added to SPF record is include:hosted-at.csc.fi
 Your domain SPF record should look then something like this:
+```
 domain.of.the.sending.email.address.    IN    TXT    "v=spf1 include:hosted-at.csc.fi ~all"
+```
 
 If you want to set up any services on cPouta that generate a large
 amount of SMTP traffic (e.g. public mailing lists), please contact

--- a/docs/cloud/pouta/additional-services.md
+++ b/docs/cloud/pouta/additional-services.md
@@ -30,21 +30,23 @@ such as your university e-mail address, since this will be validated by
 the SMTP server. Please note that this is a different e-mail header
 attribute from the _From_ attribute.
 
-You might need to add CSC's SPF record included to your own domain existing DNS record if SPF is already configured in use. 
-Even if it isn't it should be considered as there are parties which have started to reject mails from domains where SPF isn't configured.
+If you want to set up any services on cPouta that generate a large
+amount of SMTP traffic (e.g. public mailing lists), please contact
+the CSC Service Desk to coordinate this.
 
-It's good to know that taking SPF in use or just by modifying existing record incorrectly could affect whole domain email traffic functionality.
-Also it's good to understand that you may only add/edit SPF record on domain to which you have access to control DNS.
+### About Sender Policy Framework (SPF)
 
-Part which should be added to SPF record is include:hosted-at.csc.fi
+You might need to add CSC's SPF record to your own domain existing DNS record, if SPF is already configured in use. 
+Even if SPF is not configured, it should be anyway considered because some email domains reject emails from email domains where SPF is not configured.
+
+Please note that taking SPF in use, or just by modifying existing record incorrectly, affects the whole domain email traffic functionality.
+Also it's good to understand that you may only add/edit SPF record of a domain for which your organization manages its DNS records.
+
+The part which should be added to SPF record is "include:hosted-at.csc.fi".
 Your domain SPF record should look then something like this:
 ```
 domain.of.the.sending.email.address.    IN    TXT    "v=spf1 include:hosted-at.csc.fi ~all"
 ```
-
-If you want to set up any services on cPouta that generate a large
-amount of SMTP traffic (e.g. public mailing lists), please contact
-the CSC Service Desk to coordinate this.
 
 ## DNS services in cPouta
 

--- a/docs/cloud/pouta/additional-services.md
+++ b/docs/cloud/pouta/additional-services.md
@@ -30,6 +30,14 @@ such as your university e-mail address, since this will be validated by
 the SMTP server. Please note that this is a different e-mail header
 attribute from the _From_ attribute.
 
+You might need to add CSC's SPF record included to your own domain existing DNS record if SPF is already configured in use. 
+Even if it isn't it should be considered as there are parties which have started to reject mails from domains where SPF isn't configured.
+It's good to know that taking SPF in use or just by modifying existing record incorrectly could affect whole domain email traffic functionality.
+Also it's good to understand that you may only add/edit SPF record on domain to which you have access to control DNS.
+Part which should be added to SPF record is include:hosted-at.csc.fi
+Your domain SPF record should look then something like this:
+domain.of.the.sending.email.address.    IN    TXT    "v=spf1 include:hosted-at.csc.fi ~all"
+
 If you want to set up any services on cPouta that generate a large
 amount of SMTP traffic (e.g. public mailing lists), please contact
 the CSC Service Desk to coordinate this.


### PR DESCRIPTION
Add SPF info to sending e-mail section on additional services on pouta page

Documentation is lacking information about SPF and it might affect email traffic functionality.

https://csc-guide-preview.rahtiapp.fi/origin/CCCP-4071/cloud/pouta/additional-services/