### PR TITLE
Broken link fixed

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -589,7 +589,7 @@ Sys.getenv("LOCAL_SCRATCH")
 
 The `r-env` module supports GPU-accelerated TensorFlow jobs using the [R interface to TensorFlow](https://tensorflow.rstudio.com/). If you only require TensorFlow without access to R, please use one of the available [TensorFlow modules on Puhti](tensorflow.md). For general information on submitting GPU jobs, [see this tutorial](../support/tutorials/gpu-ml.md). Note that `r-env` includes CUDA and cuDNN libraries, so there is no need to load CUDA and cuDNN modules separately.
 
-To submit a GPU job using the R interface to TensorFlow, you need to use the GPU partition and specify the type and number of GPUs using the `--gres` flag. The rest is handled by the R script (see [this page for examples](https://keras.rstudio.com/articles/examples/index.html)). In the script below, we would reserve a single GPU and 10 CPUs in a single node:
+To submit a GPU job using the R interface to TensorFlow, you need to use the GPU partition and specify the type and number of GPUs using the `--gres` flag. The rest is handled by the R script (see [this page for examples](https://tensorflow.rstudio.com/examples/). In the script below, we would reserve a single GPU and 10 CPUs in a single node:
 
 ```bash
 #!/bin/bash -l


### PR DESCRIPTION
Broken link fixed under 'R interface to Tensorflow': https://keras.rstudio.com/articles/examples/index.html -> https://tensorflow.rstudio.com/examples/