### PR TITLE
A note about the oversubscribe error and the batch script

### DIFF
--- a/docs/apps/orca.md
+++ b/docs/apps/orca.md
@@ -125,11 +125,18 @@ rm -f  ${SLURM_SUBMIT_DIR}/mpirun
     Please remember to adjust %pal nproc in your input file according to the total number of
     requested MPI tasks (nodes * ntasks-per-node).
 
+
+- You should not use the SLURM parameter cpus-per-task in your batch job script. It is not intended for code parallelized with MPI. 
 - You can find a few additional example jobs in the directory:
 
 ```console
 /appl/soft/chem/orca
 ```
+
+!!! note
+    If you come across an error related to oversubscribed resources, you need to call your calculation as
+    
+    $ORCADIR/orca file.inp --oversubscribe > file.out
 
 ## References
 


### PR DESCRIPTION
Some users are getting an error about oversubscribing resources after the RHEL 8 update. 


```
A request was made to bind to that would result in binding more
processes than cpus on a resource:

   Bind to:     CORE
   Node:        r18c38
   #processes:  2
   #cpus:       1   

You can override this protection by adding the "overload-allowed"
option to your binding directive.
--------------------------------------------------------------------------
[file orca_tools/qcmsg.cpp, line 465]: 
  .... aborting the run 
```

It works if you allocate an X number of cores in the batch job script but give to orca X-1 cores. The reason for this problem was not identified. It did not occur prior to the update. The way to use X cores for the calculation is to use `--oversubscribe`. I have no benchmarking data to estimate whether oversubscribing hinders the performance. 

An additional note that cpus-per-task is not the right way to specify the number of cores in the batch script.