### PR TITLE
Fix logical error in Scratch cleaning check script

### DIFF
--- a/docs/support/tutorials/clean-up-data.md
+++ b/docs/support/tutorials/clean-up-data.md
@@ -111,7 +111,7 @@ If you want a quick, copy-pasteable solution, use the small script below:
 # Check all of the projects you belong to in one go:
 
 for g in $(/usr/bin/groups) ; do
-  if [ -d "/scratch/$g" ]; then
+  if [ -d "/scratch/$g" -a ! -L "/scratch/$g" ]; then
     dir="/scratch/purge_lists/$g" ;
   elif [ -d "/fmi/scratch/$g" ]; then
     dir="/fmi/scratch/purge_lists/$g";


### PR DESCRIPTION
- FMI projects sometimes have symlinks from /scratch to /fmi/scratch, so ensure that the "/scratch/$g" file isn't a symbolic link.