### PR TITLE
Remove broken breadcrumb

### DIFF
--- a/csc-overrides/partials/breadcrumbs.html
+++ b/csc-overrides/partials/breadcrumbs.html
@@ -15,7 +15,6 @@
         ],
         "/support/tutorials/gis/": [
             { "url": "/support/tutorials/", "title": "Tutorials" },
-            { "url": "/support/tutorials/gis/", "title": "Geoinformatics tutorials" }
         ],
         "/support/whats-new/": [
             { "url": "/support/whats-new/", "title": "What's new" }


### PR DESCRIPTION
The geoinformatics tutorials happen to be in their own subdirectory. In order for the breadcrumb removed in this PR to work, the directory would need to have an index.md, but since none of the other field-specific tutorials have such an index, the breadcrumb in question should just be removed for consistency.

https://csc-guide-preview.rahtiapp.fi/origin/geoinformatics-tutorials-breadcrumb/support/tutorials/#geoinformatics