### PR TITLE
Remove service break announcement

### DIFF
--- a/csc-overrides/partials/announcement.html
+++ b/csc-overrides/partials/announcement.html
@@ -1,5 +1,5 @@
 {# Put the announcement, in HTML, right under this comment! #}
-<p>🚧 Please note: The service break of Puhti has been postponed! New date is <b>Thursday March 9 from 8:00 to 17:00</b>. <a href="https://research.csc.fi/-/280351-58" target="_blank">Click here for more information.</a> 🚧</p>
+<p>You are cordially invited to our weekly research support coffee hour on Zoom. <a href="https://ssl.eventilla.com/event/PP4WB" target="_blank">Click here for more information!</a></p>
 {# Remember
   - to set the announcement_visible to true in mkdocs.yml
   - that the announcement bar has only been tested with <p> and <a>


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/remove-maintenance-announcement/