### PR TITLE
Web analytics reconfiguration

### DIFF
--- a/csc-overrides/404.html
+++ b/csc-overrides/404.html
@@ -2,12 +2,6 @@
 {% block htmltitle %}
   <title>Page not found - Docs CSC</title>
 {% endblock htmltitle %}
-{% block extrahead %}
-  {{ super () }}
-  {% if config.extra.mkdocs_env == "production" %}
-      {% include "partials/matomo.html" %}
-  {% endif %}
-{% endblock extrahead %}
 {% block content %}
   <nav class="csc-breadcrumbs">
     <a class="csc-breadcrumbs__link" href="{{ base_url }}">Docs CSC</a>

--- a/csc-overrides/main.html
+++ b/csc-overrides/main.html
@@ -1,10 +1,4 @@
 {% extends "base.html" %}
-{% block extrahead %}
-    {{ super () }}
-    {% if config.extra.mkdocs_env == "production" %}
-        {% include "partials/matomo.html" %}
-    {% endif %}
-{% endblock extrahead %}
 {% block announce %}
     {% if config.extra.announcement_visible is not true %}
     <style>

--- a/csc-overrides/partials/integrations/analytics/custom.html
+++ b/csc-overrides/partials/integrations/analytics/custom.html
@@ -1,16 +1,19 @@
-<!-- Matomo -->
 <script>
+  const MATOMO_SITE_ID = "{{ config.extra.analytics.matomo_site_id }}"
+  const MATOMO_URL = "{{ config.extra.analytics.matomo_url }}"
+
+  if (MATOMO_SITE_ID && MATOMO_URL) {
     var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(['disableCookies']);
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-        var u="//{{ config.extra.matomo_url }}/";
+        var u=`//${MATOMO_URL}/`;
         _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', {{ config.extra.matomo_site_id }}]);
+        _paq.push(['setSiteId', MATOMO_SITE_ID]);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
         g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
+  }
 </script>
-<!-- End Matomo Code -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,8 +9,8 @@ extra:
   breadcrumbs_debug: !ENV DEBUG # Renders a debug view for breadcrumbs navigation
   analytics:
     provider: custom
-    matomo_site_id: !ENV MATOMO_SITE_ID
-    matomo_url: !ENV MATOMO_URL
+    matomo_site_id: !ENV [MATOMO_SITE_ID, ""]
+    matomo_url: !ENV [MATOMO_URL, ""]
 
 plugins:
   - tags:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,10 +6,11 @@ site_description: Instructions and user guides for the CSC supercomputers, cloud
 
 extra:
   announcement_visible: true # Controls the visibility of the announcement bar
-  mkdocs_env: !ENV MKDOCS_ENV # Used when building on Rahti to enable Matomo web analytics
   breadcrumbs_debug: !ENV DEBUG # Renders a debug view for breadcrumbs navigation
-  matomo_url: "docs-design-matomo.rahtiapp.fi"
-  matomo_site_id: "1"
+  analytics:
+    provider: custom
+    matomo_site_id: !ENV MATOMO_SITE_ID
+    matomo_url: !ENV MATOMO_URL
 
 plugins:
   - tags:


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/web-analytics-reconfiguration/

Reconfigure web analytics to use Material's mechanism for custom web analytics instead of overriding the `extrahead` block. 

Also, move the hardcoded `MATOMO_SITE_ID` and `MATOMO_URL` from 'mkdocs.yml' to the build environment (this has already been set up in Rahti, where the variable `MKDOCS_ENV` can be removed after this PR is merged).