### PR TITLE
Remove mkdocs-section-plugin as redundant

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -47,8 +47,8 @@ If you intend to make substantial changes to the navigation menu, please communi
 ### SectionPage
 
 The first item under 'Accounts' above is a so-called SectionPage. It is a hybrid of Section and
-Page introduced by a plugin we use called
-[mkdocs-section-index](https://github.com/oprypin/mkdocs-section-index)
+Page introduced by a feature in Material for MkDocs we use called
+[Section index pages](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages)
 that makes the sections in the navigation sidebar clickable. Every section should have a
 SectionPage that acts as the index for the section. The breadcrumbs navigation on the top of every
 page relies on the existence of a SectionPage. Without it, a level of navigation will be missing
@@ -147,7 +147,7 @@ You can preview how the Docs CSC page would look like with your changes included
 * This user guide uses [MkDocs](https://www.mkdocs.org/) to generate documentation pages. You can install it on your local computer by following the instructions given in the [MkDocs documentation](https://www.mkdocs.org/user-guide/installation/), or with [Conda](https://docs.conda.io/en/latest/miniconda.html):
 
 ```bash
-conda env create -f docs/support/tutorials/conda/conda-docs-env-1.2.yaml
+conda env create -f docs/support/tutorials/conda/conda-docs-env-1.3.yaml
 conda activate docs-env
 ```
 

--- a/docs/support/tutorials/conda/conda-docs-env-1.3.yaml
+++ b/docs/support/tutorials/conda/conda-docs-env-1.3.yaml
@@ -1,0 +1,13 @@
+name: docs-env
+channels:
+  - conda-forge
+dependencies:
+  - python==3.8.12
+  - pip==19.3.1
+  - pip:
+      - Markdown==3.3.7
+      - mkdocs==1.3.1
+      - mkdocs-material==8.4.0
+      - mkdocs-material-extensions==1.0.3
+      - mkdocs-git-revision-date-localized-plugin==1.1.0
+      - mkdocs-redirects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,8 @@ theme:
   palette:
     scheme: csc
   font: false # No loading fonts from G****e
-#  features:
+  features:
+    - navigation.indexes
 #    - announce.dismiss
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ plugins:
         - apps/by_discipline.md
         - apps/by_system.md
         - apps/by_license.md
-  - section-index
   - redirects:
       redirect_maps:
         # renamed files:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ mkdocs-git-revision-date-localized-plugin==1.1.0
 mkdocs-material==8.4.0
 mkdocs-material-extensions==1.0.3
 mkdocs-redirects==1.2.0
-mkdocs-section-index==0.3.4
 
 # These are dependencies of the above
 Babel==2.10.3


### PR DESCRIPTION
The feature this plugin provides is already provided by Material for MkDocs and is also enabled by this PR.