### PR TITLE
Add search-boost feature

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -24,6 +24,7 @@ The [contributing guide](CONTRIBUTING.md) outlines the basic steps of starting c
   - [How do I use the announcement bar?](#how-do-i-use-the-announcement-bar)
   - [How do I add a license tag to an application page?](#how-do-I-add-a-license-tag-to-an-application-page)
   - [How do I make footnotes?](#how-do-i-make-footnotes)
+  - [How do I improve search results?](#how-do-i-improve-search-results)
 
 
 ## How to include my new page in the navigation panel?
@@ -299,3 +300,18 @@ The application will then be included on the Applications by license page automa
 
 Usage of the footnotes feature is described
 [here](https://squidfunk.github.io/mkdocs-material/reference/footnotes/#usage).
+
+## How do I improve search results?
+
+You can boost a page to be on top of the results by adding the following lines at the top of the Markdown file:
+```yaml
+---
+search:
+  boost: 2
+---
+
+# Document title
+...
+```
+Start with low values.  
+More information [here](https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#rank-up)

--- a/docs/accounts/billing.md
+++ b/docs/accounts/billing.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Billing
 
 CSC's services are free of charge for academic research, teaching or training for members of Finnish higher education institutions and state research institutes.

--- a/docs/accounts/how-to-create-new-project.md
+++ b/docs/accounts/how-to-create-new-project.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Creating a new project
 
 !!! Note

--- a/docs/accounts/how-to-create-new-user-account.md
+++ b/docs/accounts/how-to-create-new-user-account.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # How to create new user account
 
 There are three different types of CSC user accounts: ordinary accounts for general use (which you can get with or

--- a/docs/cloud/csc_notebooks/index.md
+++ b/docs/cloud/csc_notebooks/index.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # CSC Notebooks
 
 [CSC Notebooks](https://notebooks.csc.fi){target="_blank"} offers web applications for self-learning, hosting courses 

--- a/docs/cloud/pouta/pouta-what-is.md
+++ b/docs/cloud/pouta/pouta-what-is.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 ## What is Pouta?
 
 cPouta and ePouta are the IaaS cloud services at CSC. The cPouta

--- a/docs/cloud/rahti/rahti-what-is.md
+++ b/docs/cloud/rahti/rahti-what-is.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # What is Rahti
 
 ## What is Rahti?

--- a/docs/computing/quantum-computing/overview.md
+++ b/docs/computing/quantum-computing/overview.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 4
+---
+
 # Overview
 
 !!! success "Helmi Pilot Phase is now open!"

--- a/docs/computing/systems-mahti.md
+++ b/docs/computing/systems-mahti.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 4
+---
+
 # Technical details about Mahti
 
 ## Compute nodes

--- a/docs/computing/systems-puhti.md
+++ b/docs/computing/systems-puhti.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 2
+---
+
 # Technical details about Puhti
 
 ### Compute

--- a/docs/img/csc-quick-reference/README.md
+++ b/docs/img/csc-quick-reference/README.md
@@ -15,4 +15,4 @@ Simply `latexmk -pdf --shell-escape "csc-quick-reference.tex"`. Latexmk ships wi
 
 ## Word Doc
 
-Open the word doc (`.docx`) in Microsoft word, edit and save as pdf. 
+Open the word doc (`.docx`) in Microsoft word, edit and save as pdf.

--- a/docs/img/csc-quick-reference/README.md
+++ b/docs/img/csc-quick-reference/README.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.1
+---
+
 # CSC Quick Reference
 
 Contact: @attesillanpaa @JMuff22 @joonas-somero

--- a/docs/ref.md
+++ b/docs/ref.md
@@ -1,3 +1,8 @@
+---
+search:
+  boost: 0.1
+---
+
 # Reference card
 !!! default "Documentation"
 


### PR DESCRIPTION
Deployment of search boost feature (https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#rank-up) Example: Creating a new project webpage, if you start to type "new pro" (https://csc-guide-preview.rahtiapp.fi/origin/search-boost/)
- without feature: 6th result
- with feature: 1st result

This feature could be added to other pages as well