### PR TITLE
Broken link fixed.

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -395,7 +395,7 @@ plan(cluster, workers = cl)
 stopCluster(cl)
 ```
 
-For practical examples of jobs using `plan(cluster)` and `plan(multicore)` with raster data, [see this page](https://github.com/csc-training/geocomputing/tree/master/R/puhti/05_parallel_future). 
+For practical examples of jobs using `plan(cluster)` and `plan(multicore)` with raster data, [see this page](https://github.com/csc-training/geocomputing/tree/master/R/puhti/02_parallel_future). 
 
 *Jobs using `pbdMPI`*
 


### PR DESCRIPTION
Updated a broken link in parallel R instructions (using future with snow) pointing to geocomputing scripts on Github.  A folder name there had changed from '05_parallel_future' to '02_parallel_future'.