### PR TITLE
Separate sensitive data examples into a bullet list

### DIFF
--- a/docs/data/sensitive-data/intro.md
+++ b/docs/data/sensitive-data/intro.md
@@ -63,7 +63,8 @@ The following section of this manual provides an overview of permission manageme
 **Data Protection Impact Assessment (DPIA)**: A Data Protection Impact Assessment (DPIA) is required under the GDPR for operations that are 'likely to result in a high risk to the rights and freedoms of natural persons'. More information is provided [here](https://tietosuoja.fi/en/list-of-processing-operations-which-require-dpia) by the Finnish Office of the Data Protection Ombudsman and specific support by your home organization's legal office. 
 
 
-**Sensitive Data**: Sensitive data is data that needs to be protected against unauthorized access. Data protection may be required due to legal or ethical reasons, personal privacy, and proprietary considerations. Sensitive data includes * Personal sensitive data (e.g. health, genetic and personal information, racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade union membership, genetic data, biometric data for the purpose of uniquely identifying a natural person, data concerning health, data concerning a natural person's sex life or sexual orientation, data relating to criminal convictions and offenses or related security measures, data that may identify a person), * Ecological data (e.g. location of endangered species or other conservation efforts), * Confidential data (e.g. trade secrets), * Data that is otherwise deemed sensitive.
-
-
-
+**Sensitive Data**: Sensitive data is data that needs to be protected against unauthorized access. Data protection may be required due to legal or ethical reasons, personal privacy, and proprietary considerations. Sensitive data includes:
+* Personal sensitive data (e.g. health, genetic and personal information, racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade union membership, genetic data, biometric data for the purpose of uniquely identifying a natural person, data concerning health, data concerning a natural person's sex life or sexual orientation, data relating to criminal convictions and offenses or related security measures, data that may identify a person)
+* Ecological data (e.g. location of endangered species or other conservation efforts)
+* Confidential data (e.g. trade secrets)
+* Data that is otherwise deemed sensitive.

--- a/docs/data/sensitive-data/intro.md
+++ b/docs/data/sensitive-data/intro.md
@@ -63,7 +63,7 @@ The following section of this manual provides an overview of permission manageme
 **Data Protection Impact Assessment (DPIA)**: A Data Protection Impact Assessment (DPIA) is required under the GDPR for operations that are 'likely to result in a high risk to the rights and freedoms of natural persons'. More information is provided [here](https://tietosuoja.fi/en/list-of-processing-operations-which-require-dpia) by the Finnish Office of the Data Protection Ombudsman and specific support by your home organization's legal office. 
 
 
-**Sensitive Data**: Sensitive data is data that needs to be protected against unauthorized access. Data protection may be required due to legal or ethical reasons, personal privacy, and proprietary considerations. Sensitive data includes:
+**Sensitive Data**: Sensitive data is data that needs to be protected against unauthorized access. Data protection may be required due to legal or ethical reasons, personal privacy, and proprietary considerations. Sensitive data can include for example:
 * Personal sensitive data (e.g. health, genetic and personal information, racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade union membership, genetic data, biometric data for the purpose of uniquely identifying a natural person, data concerning health, data concerning a natural person's sex life or sexual orientation, data relating to criminal convictions and offenses or related security measures, data that may identify a person)
 * Ecological data (e.g. location of endangered species or other conservation efforts)
 * Confidential data (e.g. trade secrets)


### PR DESCRIPTION
The paragraph with an inline "bullet list" was somewhat difficult to read and grammatically problematic. I separated the items to a proper bullet list for easier reading.

I also softened the wording in the text leading to the bullet list so that it does not sound like everything in the list is always sensitive (e.g. "There are narcissus flowers at Esplanadi park" is ecological information, but hardly sensitive) and that nothing outside the list is.