### PR TITLE
Add Maestro 2023.2

### DIFF
--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -17,8 +17,8 @@ and run Desmond MD simulations easily.
 
 ## Available
 
-* Puhti: 2020.4, 2021.3, 2021.4, 2022.1, 2022.2, 2022.3, 2022.4, 2023.1
-* Mahti: 2021.4, 2022.1, 2022.2, 2022.3, 2022.4, 2023.1
+* Puhti: 2021.3, 2021.4, 2022.1, 2022.2, 2022.3, 2022.4, 2023.1, 2023.2
+* Mahti: 2021.4, 2022.1, 2022.2, 2022.3, 2022.4, 2023.1, 2023.2
 
 !!! info "Pay attention to efficiency on Mahti"
 
@@ -74,12 +74,6 @@ you're at the university or connected to it via VPN from home.
      Mahti, you must ensure that your jobs are able to utilize full nodes
      (128 CPU cores). Preferably, run only Desmond MD simulations on GPUs
      because most other jobs do not scale. If in doubt, [contact us](/support/contact/).
-
-!!! info "Use Maestro 2021.4 or older for Jaguar NBO analyses"
-
-    Due to changed license requirements, the NBO analysis feature of Jaguar does not currently
-    work with Maestro versions 2022.1 and later. Please use 2021.4 or older if you wish to run
-    NBO analyses using Jaguar.
 
 It is possible to run heavier computations on Puhti. Here, a brief overview is given.
 Additional details and some diagnostics tips are explained in our [Maestro power usage

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,11 @@
 # Applications
 
+## Schrödinger Maestro 2023.2, 25.5.2023
+
+Schrödinger Maestro version 2023.2 has been installed and set as the default module on
+Puhti and Mahti. See [release notes](https://www.schrodinger.com/releases/new-features/)
+for a list of new features and improvements.
+
 ## NoMachine will no longer be available on CSC's supercomputers, 9.5.2023
 
 The NoMachine remote desktop service will be discontinued on 25th May 2023, at the end of the


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/maestro-2023-2/

Added new version, hid the oldest on Puhti and removed old note about NBO not working (it now works with the new license).