### PR TITLE
Added R 4.2.2

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -751,7 +751,7 @@ To use R packages installed in `/projappl`, add the following to the beginning o
 .libPaths(c("/projappl/<project>/project_rpackages_<rversion>", .libPaths()))
 ```
 
-Alternatively, you can add the desired changes to an `.Renviron` file (only in non-interactive jobs or when using the R console):
+Alternatively, you can add the desired changes to an `.Renviron` file (only when not using RStudio):
 
 ```bash
 echo "R_LIBS=/projappl/<project>/project_rpackages_<rversion>" >> ~/.Renviron

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -21,6 +21,8 @@ Current modules and versions supported on Puhti:
 
 | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version  | TensorFlow version | CmdStan version |
 | ----------------------- | ------------------- | -------------------- | ---------------------- | ----------------| ------------------ | --------------- |
+| r-env/422               | March 06 2023       | 3.16                 | 2023.03.0-386          | 2023.1.0        | 2.9.1              | 2.32.1
+| ----------------------- | ------------------- | -------------------- | ---------------------- | ----------------| ------------------ | --------------- |
 | r-env/421               | June 29 2022        | 3.15                 | 2022.02.3-492          | 2022.1.0        | 2.9.1              | 2.30.1
 
 Other software and libraries:
@@ -664,17 +666,17 @@ The `r-env` module includes several packages that make use of [Stan](https://mc-
 *Using R with the CmdStan backend* 
 
 The `r-env` module comes with a separate [CmdStan](https://github.com/stan-dev/cmdstan) installation that is specific to each module version.
-To use it, one must set the correct path to CmdStan using `cmdstanr`. For example, for `r-env/421` this would be done as follows:
+To use it, one must set the correct path to CmdStan using `cmdstanr`. For example, for `r-env/422` this would be done as follows:
 
 ```r
-cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/421-stan/cmdstan-2.30.1")
+cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/422-stan/cmdstan-2.32.1")
 ```
 
 If you are using CmdStan in an interactive session, the above command will work directly. For non-interactive batch jobs, the path to CmdStan needs to be separately set in the batch job file. This is done by including the following commands further to your other batch job file contents: 
 
 ```r
 # Set R version
-export RVER=421
+export RVER=422
 
 # Launch R after binding CmdStan
 SING_FLAGS="$SING_FLAGS -B /appl/soft/math/r-env/${RVER}-stan:/appl/soft/math/r-env/${RVER}-stan"
@@ -749,7 +751,7 @@ To use R packages installed in `/projappl`, add the following to the beginning o
 .libPaths(c("/projappl/<project>/project_rpackages_<rversion>", .libPaths()))
 ```
 
-Alternatively, you can add the desired changes to an `.Renviron` file:
+Alternatively, you can add the desired changes to an `.Renviron` file (only in non-interactive jobs or when using the R console):
 
 ```bash
 echo "R_LIBS=/projappl/<project>/project_rpackages_<rversion>" >> ~/.Renviron
@@ -757,6 +759,17 @@ echo "R_LIBS=/projappl/<project>/project_rpackages_<rversion>" >> ~/.Renviron
 
 !!! note
     When using `r-env`, user-defined changes to R library paths must be specified inside an R session or in relation to an `.Renviron` file. Other changes (e.g. using `export` to modify environment variables) will not work due to the R installation running inside an Apptainer container. If your analysis would require changes that cannot be achieved through the above means, please contact us for a module-wide package installation.
+
+#### Pdf rendering
+
+If pdf rendering of an R Markdown or a Quarto document fails, run the following in R:
+
+```r
+tinytex::install_tinytex()
+```
+
+When prompted about an existing LaTeX distribution, answer `yes` to continue the installation anyway.
+
 
 ## Working with Allas
 

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,9 @@
 # Applications
 
+## R 4.2.2 in r-env, 26.5.2023
+	
+R version 4.2.2 is now available in `r-env` and is set as the default version. The new version will also be available in RStudio in the Puhti web interface shortly.
+
 ## Schrödinger Maestro 2023.2, 25.5.2023
 
 Schrödinger Maestro version 2023.2 has been installed and set as the default module on


### PR DESCRIPTION
Added R 4.2.2 to r-env documentation and a mention of the update to the front page. 
In addition in r-env documentation: 
1) Added a section for solving the markdown pdf problem.
2) Added a mention to 'R package installations' that modifying R_LIBS only works when not using RStudio (because in 4.2.2 .Renviron is in tmpdir, not in home directory).
3) Updated R version and CmdStan version in the CmdStan instructions.