### PR TITLE
r-env update for R 4.3.0

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -21,6 +21,7 @@ Current modules and versions supported on Puhti:
 
 | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version  | TensorFlow version | CmdStan version |
 | ----------------------- | ------------------- | -------------------- | ---------------------- | ----------------| ------------------ | --------------- |
+| r-env/430               | June 07 2023        | 3.17                 | 2023.06.0-421          | 2023.1.0        | 2.9.1              | 2.32.2          |
 | r-env/422               | March 06 2023       | 3.16                 | 2023.03.0-386          | 2023.1.0        | 2.9.1              | 2.32.1          |
 | r-env/421               | June 29 2022        | 3.15                 | 2022.02.3-492          | 2022.1.0        | 2.9.1              | 2.30.1          |
 
@@ -665,17 +666,17 @@ The `r-env` module includes several packages that make use of [Stan](https://mc-
 *Using R with the CmdStan backend* 
 
 The `r-env` module comes with a separate [CmdStan](https://github.com/stan-dev/cmdstan) installation that is specific to each module version.
-To use it, one must set the correct path to CmdStan using `cmdstanr`. For example, for `r-env/422` this would be done as follows:
+To use it, one must set the correct path to CmdStan using `cmdstanr`. For example, for `r-env/430` this would be done as follows:
 
 ```r
-cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/422-stan/cmdstan-2.32.1")
+cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/430-stan/cmdstan-2.32.2")
 ```
 
 If you are using CmdStan in an interactive session, the above command will work directly. For non-interactive batch jobs, the path to CmdStan needs to be separately set in the batch job file. This is done by including the following commands further to your other batch job file contents: 
 
 ```r
 # Set R version
-export RVER=422
+export RVER=430
 
 # Launch R after binding CmdStan
 SING_FLAGS="$SING_FLAGS -B /appl/soft/math/r-env/${RVER}-stan:/appl/soft/math/r-env/${RVER}-stan"

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,9 @@
 # Applications
 
+## R 4.3.0 in r-env, 20.6.2023
+	
+R version 4.3.0 is now available in `r-env` and is set as the default version. The new version will also be available in RStudio in the Puhti web interface shortly.
+
 ## Gromacs 2023.1 available on LUMI, 7.6.2023
 
 CPU and GPU versions of Gromacs 2023.1 have been installed on LUMI. Notably, the


### PR DESCRIPTION
R 4.3.0 added to r-env documentation (the version table at the top, rstan instructions). News on the new versio added to apps news page.

https://csc-guide-preview.rahtiapp.fi/origin/renv430update/apps/r-env/

https://csc-guide-preview.rahtiapp.fi/origin/renv430update/support/wn/apps-new/#r-430-in-r-env-2062023

