### PR TITLE
Bump pymdown-extensions version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 packaging==21.3
 Pygments==2.12.0
-pymdown-extensions==9.5
+pymdown-extensions==10.0.1
 pyparsing==3.0.9
 python-dateutil==2.8.2
 pytz==2022.2.1


### PR DESCRIPTION
Fixes this: https://github.com/CSCfi/csc-user-guide/security/dependabot/3

Deployed here: https://csc-user-guide-csc-user-guide-dev.rahtiapp.fi/