### PR TITLE
Pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ## PR checklist
 
-* [ ] Have you followed the instructions in the Contributing and Styleguide
+* [ ] Have you followed the instructions in the
+      [Contributing](../CONTRIBUTING.md) and [Styleguide](../STYLEGUIDE.md)
       documents?
 * [ ] Does your pull request pass all tests?
 * [ ] Have you requested a reviewer?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,14 @@
-## PR checklist
+## Describe your changes
 
-* [ ] Have you followed the instructions in the
+Briefly describe the changes you've made here. Remember to add a link to the
+[preview page](https://csc-guide-preview.rahtiapp.fi/origin/) of your branch.
+
+## Checklist before requesting a review
+
+- [ ] I have followed the instructions in the
       [Contributing](../CONTRIBUTING.md) and [Styleguide](../STYLEGUIDE.md)
-      documents?
-* [ ] Does your pull request pass all tests?
-* [ ] Have you requested a reviewer?
-* [ ] Have you included a link to the appropriate
+      documents.
+- [ ] My pull request passes all tests.
+- [ ] I have included a link to the appropriate
       [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select
       your branch from the list)?
-
-## Description of proposed changes
-
-Briefly describe the changes you've made.
-
-Link to preview page:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## PR checklist
+
+* [ ] Have you followed the instructions in the Contributing and Styleguide
+      documents?
+* [ ] Does your pull request pass all tests?
+* [ ] Have you requested a reviewer?
+* [ ] Have you included a link to the appropriate
+      [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select
+      your branch from the list)?
+
+## Description of proposed changes
+
+Briefly describe the changes you've made.
+
+Link to preview page:


### PR DESCRIPTION
Adds a simple pull request template for docs. It is not possible to automatically add a "dynamic" link to the correct preview page, but at least this one would encourage/remind about adding it (+other reminders). Opinions?