### PR TITLE
Add specification pouta ephemeral storage

### DIFF
--- a/docs/cloud/pouta/ephemeral-storage.md
+++ b/docs/cloud/pouta/ephemeral-storage.md
@@ -7,7 +7,8 @@ This storage **does not** get saved when you create a snapshot of an
 image. It is not copied along with resizes or migrations. It is
 especially important to note regarding the io.\* flavors that the
 storage is based on RAID0 arrays optimized for performance, providing
-no redundancy whatsoever.
+no redundancy whatsoever. Regarding io.2.\* flavors, the storage is based on RAID1, offering
+more security, avoiding the loss of files.
 
 The ephemeral storage is visible as an additional disk to the virtual
 machine (usually /dev/vdb). Depending on the image and metadata chosen

--- a/docs/cloud/pouta/ephemeral-storage.md
+++ b/docs/cloud/pouta/ephemeral-storage.md
@@ -8,7 +8,7 @@ image. It is not copied along with resizes or migrations. It is
 especially important to note regarding the io.\* flavors that the
 storage is based on RAID0 arrays optimized for performance, providing
 no redundancy whatsoever. Regarding io.2.\* flavors, the storage is based on RAID1, offering
-more security, avoiding the loss of files.
+more safety, avoiding the loss of files.
 
 The ephemeral storage is visible as an additional disk to the virtual
 machine (usually /dev/vdb). Depending on the image and metadata chosen


### PR DESCRIPTION
## Proposed changes

In ephemeral storage for Pouta, a mention was added to specify the type of storage technology used for io.2.* flavors.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes all tests.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).

https://csc-guide-preview.rahtiapp.fi/origin/pouta-ephemeral-storage/cloud/pouta/ephemeral-storage/