### PR TITLE
Added instructions for adding customised script in vm creation phase

### DIFF
--- a/docs/cloud/pouta/command-line-tools.md
+++ b/docs/cloud/pouta/command-line-tools.md
@@ -107,7 +107,7 @@ useradd -m boss
 echo 'boss ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/boss
 ```
 
-The script file can contain any arbitary command, so some cautioness is recommended.
+The script file can contain any arbitrary command, so some cautioness is recommended.
 
 !!! Note
     Please note that the example does not contain addition of user authentication (public SSH key).

--- a/docs/cloud/pouta/command-line-tools.md
+++ b/docs/cloud/pouta/command-line-tools.md
@@ -89,6 +89,29 @@ functioning virtual machine.
     is not used when connecting to the virtual machine. The virtual 
     machine allows access to a user only if the user uses SSH keys.
 
+##### Customize the virtual machine before launch
+
+    openstack server create --flavor <flavor> --image <image id> --key-name <key name> --user-data user-data.sh <name for machine>
+
+The `user-data.sh` file can have extra commands to be executed automatically after the instance has been launched.
+
+Below is an example content of the script file that would add a custom user in to the flavor and giving it the `sudo` rights:
+
+``` bash
+#!/bin/sh
+
+# Add a new user called boss
+useradd -m boss
+
+# Add the user to sudoers. No password is needed for sudo.
+echo 'boss ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/boss
+```
+
+The script file can contain any arbitary command, so some cautioness is recommended.
+
+!!! Note
+    Please note that the example does not contain addition of user authentication (public SSH key).
+
 ##### List instances
 
     openstack server list


### PR DESCRIPTION
## Proposed changes

Added an example of including a script for adding an extra user to the launched image via user data and openstack cli command. Here's the [preview page](https://csc-guide-preview.rahtiapp.fi/origin/add-custom-user-pouta-vm/cloud/pouta/command-line-tools/#customize-the-virtual-machine-before-launch) of your branch.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes all tests.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/add-custom-user-pouta-vm/cloud/pouta/command-line-tools/#customize-the-virtual-machine-before-launch)
