### PR TITLE
Update resize I/O flavors

### DIFF
--- a/docs/support/faq/how-to-resize-in-pouta.md
+++ b/docs/support/faq/how-to-resize-in-pouta.md
@@ -7,7 +7,7 @@ You can find more information about snapshot [here](../../cloud/pouta/snapshots.
 
 ### Using the resize functionality 
 !!! Warning    
-    I/O flavors [cannot be resized](../../cloud/pouta/vm-flavors-and-billing.md#io-flavors_2) to a different family flavors. Currently resizing I/O flavors to another I/O flavor is not supported. We recommend to use [snapshots](../../cloud/pouta/snapshots#launching-an-instance-from-a-volume-snapshot).
+    I/O flavors [cannot be resized](../../cloud/pouta/vm-flavors-and-billing.md#io-flavors_2) to a different family flavors. Currently resizing I/O flavors to another I/O flavor is not supported. We recommend to use [snapshots](../../cloud/pouta/snapshots.md#launching-an-instance-from-a-volume-snapshot).
 
 !!! Warning  
     It's possible to resize from a `standard` flavor *family* to a `hpc` flavor *family*. Nothing will prevent you to do that but it's **highly not recommended!**  

--- a/docs/support/faq/how-to-resize-in-pouta.md
+++ b/docs/support/faq/how-to-resize-in-pouta.md
@@ -7,9 +7,11 @@ You can find more information about snapshot [here](../../cloud/pouta/snapshots.
 
 ### Using the resize functionality 
 !!! Warning    
-    I/O flavors [cannot be resized](../../cloud/pouta/vm-flavors-and-billing.md#io-flavors_2) to a different family flavors.  
+    I/O flavors [cannot be resized](../../cloud/pouta/vm-flavors-and-billing.md#io-flavors_2) to a different family flavors. Currently resizing I/O flavors to another I/O flavor is not supported. We recommend to use [snapshots](../../cloud/pouta/snapshots#launching-an-instance-from-a-volume-snapshot).
+
+!!! Warning  
     It's possible to resize from a `standard` flavor *family* to a `hpc` flavor *family*. Nothing will prevent you to do that but it's **highly not recommended!**  
-    You may lose data during the process and CSC is not responsible. We recommend to only resize to the flavors of the same *family*
+    You may lose data during the process and CSC is not responsible. We recommend to only resize to the flavors of the same *family* (except for I/O flavors, see above).
 
 In the **Actions** menu of your instance, choose **Resize** to begin the process:  
 


### PR DESCRIPTION
## Proposed changes

Feedback from Pouta team:
> Moro! We probably need to update the documentation (but will need to change soon) related to resizing IO flavors because those need to be done via Snapshots. I reset the VM and the customer should be able to start it again (as the old flavor).
snapshot, turn off the instance, start a new instance using the snapshot with the new flavor (so it's a copy, not a resize)

https://csc-guide-preview.rahtiapp.fi/origin/resize-io-flavors/support/faq/how-to-resize-in-pouta/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes all tests.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
