### PR TITLE
Links to gmx workshop

### DIFF
--- a/docs/apps/amber.md
+++ b/docs/apps/amber.md
@@ -118,7 +118,7 @@ srun paramfit -i Job_Control.in -p prmtop -c mdcrd -q QM_data.dat
 !!! info "Note"
     `pmemd.cuda` and `pmemd.hip` are way faster than `pmemd.MPI`, so use a
     CPU-version only in case you cannot use the GPU-version. If Amber performance
-    is not fast enough, consider using [Gromacs](gromacs.md), which is typically
+    is not fast enough, consider using [GROMACS](gromacs.md), which is typically
     able to scale further (*i.e.* make use of more CPU and/or GPU resources).
     
     Consider also whether you really need speed or just a lot of sampling. Accelerated
@@ -235,7 +235,7 @@ documentation.
 
 ### High-throughput computing with Amber
 
-Similar to [Gromacs multidir](../support/tutorials/gromacs-throughput.md),
+Similar to [GROMACS multidir](../support/tutorials/gromacs-throughput.md),
 Amber has a built-in "multi-pmemd" functionality, which allows you to run multiple
 MD simulations within a single Slurm allocation. This is an efficient option in cases
 where you want to run many similar, but independent, simulations. Typical use cases

--- a/docs/apps/by_discipline.md
+++ b/docs/apps/by_discipline.md
@@ -29,7 +29,7 @@
 * [Freebayes](freebayes.md) Genetic variant detector
 * [GOLD](gold.md) Protein Ligand Docking Software
 * [Grace](grace.md) Plotting tool for xvg-files in particular
-* [Gromacs](gromacs.md) Fast and versatile classical molecular dynamics
+* [GROMACS](gromacs.md) Fast and versatile classical molecular dynamics
 * [HMMER](hmmer.md) Toolkit to create and use sequence profile hidden Markov models
 * [HUMAnN](humann.md) Profiling microbial pathways with metagenomic data
 * [Illumina BaseSpace](bs.md) Command line client for retrieving data from the Illumina BaseSpace environment
@@ -81,7 +81,7 @@
 * [Gaussian](gaussian.md) Versatile computational chemistry package
 * [GOLD](gold.md) Protein Ligand Docking Software
 * [GPAW](gpaw.md) Versatile DFT package
-* [Gromacs](gromacs.md) Fast and versatile classical molecular dynamics
+* [GROMACS](gromacs.md) Fast and versatile classical molecular dynamics
 * [LAMMPS](lammps.md) Fast molecular dynamics engine with large force field selection
 * [Maestro](maestro.md) Versatile drug discovery and materials modeling suite
 * [Materials Studio](materialsstudio.md) Versatile materials modeling suite

--- a/docs/apps/grace.md
+++ b/docs/apps/grace.md
@@ -5,7 +5,7 @@ tags:
 
 # Grace
 
-Grace is foremost a plotting tool, and e.g. Gromacs produces tailored input for
+Grace is foremost a plotting tool, and e.g. GROMACS produces tailored input for
 it, but Grace can also be used for some numerical analyses.
 
 ## Available

--- a/docs/apps/gromacs.md
+++ b/docs/apps/gromacs.md
@@ -3,9 +3,9 @@ tags:
   - Free
 ---
 
-# Gromacs
+# GROMACS
 
-Gromacs is a very efficient engine to perform molecular dynamics
+GROMACS is a very efficient engine to perform molecular dynamics
 simulations and energy minimizations particularly for proteins. However,
 it can also be used to model polymers, membranes and e.g. coarse grained
 systems. It also comes with plenty of analysis scripts.
@@ -54,7 +54,7 @@ systems. It also comes with plenty of analysis scripts.
     |2023.2   |`gromacs/2023.2`<br>`gromacs/2023.2-gpu`|GPU-enabled module available
     |2023.3   |`gromacs/2023.3`<br>`gromacs/2023.3-gpu`|GPU-enabled module available
 
-    [^1]: This module is unvalidated, unmaintained and unsupported by the Gromacs team. Use at your own risk!
+    [^1]: This module is unvalidated, unmaintained and unsupported by the GROMACS team. Use at your own risk!
 
 - Puhti and Mahti have also `gromacs-env/<year>` modules for loading the recommended
   latest minor version from each year (replace `<year>` accordingly).
@@ -69,11 +69,11 @@ systems. It also comes with plenty of analysis scripts.
 
 ## License
 
-Gromacs is a free software available under LGPL, version 2.1.
+GROMACS is a free software available under LGPL, version 2.1.
 
 ## Usage
 
-Initialize recommended version of Gromacs on Puhti or Mahti like this:
+Initialize recommended version of GROMACS on Puhti or Mahti like this:
 
 ```bash
 module purge
@@ -116,7 +116,7 @@ The most important aspects to consider (in addition to avoiding `-v`) are:
   for more information.
 
 For a more complete description, consult the [mdrun performance checklist] on the
-Gromacs page.
+GROMACS page.
 
 A scaling test with a very large system (1M+ particles) may take a while to
 load balance optimally. Rather than running very long scaling tests in advance,
@@ -329,14 +329,14 @@ srun --cpu-bind=$CPU_BIND ./select_gpu gmx_mpi mdrun -s topol -nb gpu -bonded gp
     [LUMI-G examples](https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/lumig-job/),
     [GPU binding](https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/distribution-binding/#gpu-binding)
 
-Below is a comparison of the performance of Gromacs 2023.1 on Mahti (CPUs and GPUs)
+Below is a comparison of the performance of GROMACS 2023.1 on Mahti (CPUs and GPUs)
 and LUMI-G using the STMV benchmark (1067k atoms). This is a large system which scales
 very well also on GPUs. The performance on a single LUMI GCD (half a GPU) is almost as
 good as on a full Nvidia A100 GPU on Mahti, and much better than on a single 128-core CPU
 node. Importantly, the amount of GPU nodes on LUMI is massively larger than on Mahti
 (2560 vs. 24).
 
-![Gromacs scaling on GPUs on Mahti and LUMI](../img/stmv.png 'Gromacs scaling on GPUs on Mahti and LUMI')
+![GROMACS scaling on GPUs on Mahti and LUMI](../img/stmv.png 'GROMACS scaling on GPUs on Mahti and LUMI')
 
 !!! info "Small systems on LUMI-G and high-throughput simulations"
     While medium-sized and large systems (100k–1M+ atoms) such as the STMV benchmark
@@ -344,8 +344,8 @@ node. Importantly, the amount of GPU nodes on LUMI is massively larger than on M
     (less than 100k atoms) are typically best run on just a single GCD. A good way
     to increase the GPU utilization and efficiency of small simulations is to run
     many trajectories per GCD. This can be accomplished using the built-in multidir
-    feature of Gromacs. For more details about GPU-sharing and aggregate sampling, see our
-    [tutorial on high-throughput simulations with Gromacs](../support/tutorials/gromacs-throughput.md).
+    feature of GROMACS. For more details about GPU-sharing and aggregate sampling, see our
+    [tutorial on high-throughput simulations with GROMACS](../support/tutorials/gromacs-throughput.md).
 
 #### PME decomposition
 
@@ -364,15 +364,15 @@ be a reasonable starting point. So for 16 LUMI-G nodes, use `-npme 16` or `-npme
 
 ### Visualizing trajectories and graphs
 
-In addition to the `view` tool of Gromacs (not available at CSC),
+In addition to the `view` tool of GROMACS (not available at CSC),
 trajectory files can be visualized with the following programs:
 
 - [VMD](vmd.md) visualization program for large biomolecular systems
-- [Grace](grace.md) plotting data produced with Gromacs tools
+- [Grace](grace.md) plotting data produced with GROMACS tools
 - [PyMOL](https://pymol.org/2/) molecular modeling system (not available at CSC)
 
 !!! warning "Note"
-    Please don't run visualization or heavy Gromacs tool scripts on
+    Please don't run visualization or heavy GROMACS tool scripts on
     the login node (see [usage policy for details](../../computing/usage-policy)).
     You can run the tools in the [interactive partition](../computing/running/interactive-usage.md)
     by prepending your `gmx_mpi` command with `orterun -n 1`, e.g.:
@@ -419,19 +419,19 @@ for methods applied in your setup.
 
 ## More information
 
-- [Gromacs home page](https://www.gromacs.org/) and [documentation](https://manual.gromacs.org/current/index.html)
+- [GROMACS home page](https://www.gromacs.org/) and [documentation](https://manual.gromacs.org/current/index.html)
 - [mdrun performance checklist](https://manual.gromacs.org/current/user-guide/mdrun-performance.html)
 - [Materials at the BioExcel website](https://bioexcel.eu/software/gromacs/)
-- [Gromacs community forum](https://gromacs.bioexcel.eu/)
+- [GROMACS community forum](https://gromacs.bioexcel.eu/)
 - **Training materials:**
-    - [Running Gromacs efficiently on LUMI workshop materials (2024)](https://zenodo.org/records/10610643)
-    - [Advanced Gromacs Workshop materials (2022)](https://enccs.github.io/gromacs-gpu-performance/)
+    - [Running GROMACS efficiently on LUMI workshop materials (2024)](https://zenodo.org/records/10610643)
+    - [Advanced GROMACS Workshop materials (2022)](https://enccs.github.io/gromacs-gpu-performance/)
 - **Tutorials:**
     - [GROMACS tutorial home page](https://tutorials.gromacs.org/)
     - [Hands-on tutorials by Justin A. Lemkul](https://www.mdtutorials.com/gmx/)
     - [Tutorials by Bert de Groot group](https://www3.mpibpc.mpg.de/groups/de_groot/compbio/index.html)
-    - [Short How-To guides in the Gromacs manual](https://manual.gromacs.org/documentation/current/how-to/index.html)
-    - [High-throughput computing with Gromacs](../support/tutorials/gromacs-throughput.md)
+    - [Short How-To guides in the GROMACS manual](https://manual.gromacs.org/documentation/current/how-to/index.html)
+    - [High-throughput computing with GROMACS](../support/tutorials/gromacs-throughput.md)
 - Example `.tpr` files for testing:
     - [Alcohol dehydrogenase (96k atoms)](https://a3s.fi/gromacs-inputs/adh.tpr)
     - [Satellite tobacco mosaic virus (1067k atoms)](https://a3s.fi/gromacs-inputs/stmv.tpr)

--- a/docs/apps/gromacs.md
+++ b/docs/apps/gromacs.md
@@ -369,7 +369,7 @@ trajectory files can be visualized with the following programs:
 
 - [VMD](vmd.md) visualization program for large biomolecular systems
 - [Grace](grace.md) plotting data produced with Gromacs tools
-- [PyMOL] molecular modeling system (not available at CSC)
+- [PyMOL](https://pymol.org/2/) molecular modeling system (not available at CSC)
 
 !!! warning "Note"
     Please don't run visualization or heavy Gromacs tool scripts on
@@ -385,48 +385,53 @@ trajectory files can be visualized with the following programs:
 
 Cite your work with the following references:
 
-- GROMACS 4: Algorithms for Highly Efficient, Load-Balanced, and
-    Scalable Molecular Simulation. Hess, B., Kutzner, C., van der
-    Spoel, D. and Lindahl, E. J. Chem. Theory Comput., 4, 435-447
-    (2008).
-- GROMACS: Fast, Flexible and Free. D. van der Spoel, E. Lindahl, B.
-    Hess, G. Groenhof, A. E. Mark and H. J. C.Berendsen, J. Comp. Chem.
-    26 (2005) pp. 1701-1719
-- *GROMACS: High performance molecular simulations through multi-level
-    parallelism from laptops to supercomputers*
-    M. J. Abraham, T. Murtola, R. Schulz, S. Páll, J. C. Smith, B. Hess, E.
-    Lindahl *SoftwareX* 1 (2015) pp. 19-25
-- *Tackling Exascale Software Challenges in Molecular Dynamics Simulations with
-    GROMACS* In S. Markidis & E. Laure (Eds.), Solving Software Challenges for Exascale
-    S. Páll, M. J. Abraham, C. Kutzner, B. Hess, E. Lindahl 8759 (2015) pp. 3-27
-- *GROMACS 4.5: a high-throughput and highly parallel open source molecular
-    simulation toolkit* S. Pronk, S. Páll, R. Schulz, P. Larsson, P. Bjelkmar, R. Apostolov, M. R.
-    Shirts, J. C. Smith, P. M. Kasson, D. van der Spoel, B. Hess, and E. Lindahl
-    Bioinformatics 29 (2013) pp. 845-54
+> * S. Páll, A. Zhmurov, P. Bauer, M. J. Abraham, M. Lundborg, A. Gray, B.
+    Hess, E. Lindahl. Heterogeneous parallelization and acceleration of
+    molecular dynamics simulations in GROMACS. J. Chem. Phys. 153 (2020) pp.
+    134110.
+  * M. J. Abraham, T. Murtola, R. Schulz, S. Páll, J. C. Smith, B. Hess, E.
+    Lindahl. GROMACS: High performance molecular simulations through
+    multi-level parallelism from laptops to supercomputers. SoftwareX 1 (2015)
+    pp. 19-25.
+  * S. Páll, M. J. Abraham, C. Kutzner, B. Hess, E. Lindahl. Tackling Exascale
+    Software Challenges in Molecular Dynamics Simulations with GROMACS. In S.
+    Markidis & E. Laure (Eds.), Solving Software Challenges for Exascale 8759
+    (2015) pp. 3-27.
+  * S. Pronk, S. Páll, R. Schulz, P. Larsson, P. Bjelkmar, R. Apostolov, M. R.
+    Shirts, J. C. Smith, P. M. Kasson, D. van der Spoel, B. Hess, and E.
+    Lindahl. GROMACS 4.5: a high-throughput and highly parallel open source
+    molecular simulation toolkit. Bioinformatics 29 (2013) pp. 845-54.
+  * B. Hess and C. Kutzner and D. van der Spoel and E. Lindahl. GROMACS 4:
+    Algorithms for highly efficient, load-balanced, and scalable molecular
+    simulation. J. Chem. Theory Comput. 4 (2008) pp. 435-447.
+  * D. van der Spoel, E. Lindahl, B. Hess, G. Groenhof, A. E. Mark and H. J. C.
+    Berendsen. GROMACS: Fast, Flexible and Free. J. Comp. Chem. 26 (2005) pp.
+    1701-1719.
+  * E. Lindahl and B. Hess and D. van der Spoel. GROMACS 3.0: A package for
+    molecular simulation and trajectory analysis. J. Mol. Mod. 7 (2001) pp.
+    306-317.
+  * H. J. C. Berendsen, D. van der Spoel and R. van Drunen. GROMACS: A
+    message-passing parallel molecular dynamics implementation. Comp. Phys.
+    Comm. 91 (1995) pp. 43-56.
 
 See your simulation log file for more detailed references
 for methods applied in your setup.
 
 ## More information
 
-- Gromacs home page: [http://www.gromacs.org/](http://www.gromacs.org/)
-- [Hands-on tutorials] by Justin A. Lemkul, on [GROMACS tutorial home](https://tutorials.gromacs.org/)
-  and by [Bert de Groot group](https://www3.mpibpc.mpg.de/groups/de_groot/compbio/index.html)
-- [Lots of material at BioExcel EU project]
-- [How-To](https://manual.gromacs.org/documentation/current/how-to/index.html) section in the
-  Gromacs manual
-- Gromacs [documentation] and [mdrun performance checklist]
-- [The PRODRG Server] for online creation of small molecule topologies
-- [Advanced Gromacs Workshop materials](https://enccs.github.io/gromacs-gpu-performance/)
-- [High-throughput computing with Gromacs](../support/tutorials/gromacs-throughput.md)
+- [Gromacs home page](https://www.gromacs.org/) and [documentation](https://manual.gromacs.org/current/index.html)
+- [mdrun performance checklist](https://manual.gromacs.org/current/user-guide/mdrun-performance.html)
+- [Materials at the BioExcel website](https://bioexcel.eu/software/gromacs/)
+- [Gromacs community forum](https://gromacs.bioexcel.eu/)
+- **Training materials:**
+    - [Running Gromacs efficiently on LUMI workshop materials (2024)](https://zenodo.org/records/10610643)
+    - [Advanced Gromacs Workshop materials (2022)](https://enccs.github.io/gromacs-gpu-performance/)
+- **Tutorials:**
+    - [GROMACS tutorial home page](https://tutorials.gromacs.org/)
+    - [Hands-on tutorials by Justin A. Lemkul](https://www.mdtutorials.com/gmx/)
+    - [Tutorials by Bert de Groot group](https://www3.mpibpc.mpg.de/groups/de_groot/compbio/index.html)
+    - [Short How-To guides in the Gromacs manual](https://manual.gromacs.org/documentation/current/how-to/index.html)
+    - [High-throughput computing with Gromacs](../support/tutorials/gromacs-throughput.md)
 - Example `.tpr` files for testing:
     - [Alcohol dehydrogenase (96k atoms)](https://a3s.fi/gromacs-inputs/adh.tpr)
     - [Satellite tobacco mosaic virus (1067k atoms)](https://a3s.fi/gromacs-inputs/stmv.tpr)
-
-  [mdrun performance checklist]: https://manual.gromacs.org/current/user-guide/mdrun-performance.html
-  [documentation]: http://manual.gromacs.org/documentation
-  [PyMOL]: http://www.pymol.org/
-  [The PRODRG Server]: https://www.sites.google.com/site/vanaaltenlab/prodrg
-  [Lots of material at BioExcel EU project]: http://bioexcel.eu/software/gromacs/
-  [Hands-on tutorials]: http://www.mdtutorials.com/gmx/
-  [official Gromacs documentation]: https://manual.gromacs.org/documentation/current/user-guide/mdrun-features.html#running-multi-simulations

--- a/docs/apps/plumed.md
+++ b/docs/apps/plumed.md
@@ -36,7 +36,7 @@ On LUMI, you need to first load the CSC module tree into use with `module use /a
 
 If you want to run molecular dynamics with plumed, either compile your MD engine of
 choice with plumed (see [selection e.g. here](https://www.plumed.org/)), or use e.g.
-[Gromacs](gromacs.md), which is available at CSC.
+[GROMACS](gromacs.md), which is available at CSC.
 
 ## References
 

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -86,10 +86,10 @@ See the [Using RStudio or Jupyter notebook tutorial](../../support/tutorials/rst
 ### Example: Running an MPI job in an interactive session
 
 Since the shell started in the interactive session is already a job step in Slurm, more job steps can't be started.
-This will disable, e.g. running Gromacs tools, as `gmx_mpi` is a parallel program and normally needs `srun`.
+This will disable, e.g. running GROMACS tools, as `gmx_mpi` is a parallel program and normally needs `srun`.
 In this case, in the interactive shell, `srun` must be replaced with `orterun -n 1`. Orterun does not know of the
 Slurm flags, so it needs to be told how many tasks/threads to use. The following example will run a
-[Gromacs](../../apps/gromacs.md) mean square displacement analysis for an existing trajectory.
+[GROMACS](../../apps/gromacs.md) mean square displacement analysis for an existing trajectory.
 
 ```bash
 sinteractive --account <project>

--- a/docs/computing/running/performance-checklist.md
+++ b/docs/computing/running/performance-checklist.md
@@ -106,7 +106,7 @@ consider the following items to mitigate potential bottlenecks:
   [AI batch job example](../../support/tutorials/ml-data.md#fast-local-drive-puhti-and-mahti-only)
 * Investigate if you can choose how your application does I/O (e.g. OpenFoam
   can use the collated file format) and don't write unnecessary information
-  on disk or do it too often (e.g. Gromacs with the `-v` flag should not be
+  on disk or do it too often (e.g. GROMACS with the `-v` flag should not be
   used at CSC).
 * One way to avoid a large number of (small) files is to set up your complex
   python or R based software in a singularity container. This also helps with

--- a/docs/computing/running/throughput.md
+++ b/docs/computing/running/throughput.md
@@ -28,7 +28,7 @@ To enable high-throughput computing while avoiding the above issues, jobs and jo
 steps should be packed so that they can be executed with minimal invocations of
 `sbatch` and `srun`. The first and best option is to check whether the software
 you're using comes with a [built-in option for farming-type workloads]. This
-applies for applications such as [CP2K][cp2k], [Gromacs][gmx],  [LAMMPS][lmp], Python and R.
+applies for applications such as [CP2K][cp2k], [GROMACS][gmx], [LAMMPS][lmp], Python and R.
 
 If integrated support for farming-type workloads is unavailable in your software,
 another option is to use external tools such as [HyperQueue] or [GNU Parallel].
@@ -53,7 +53,7 @@ regarding how to implement your workflow.
 ```mermaid
 %%{init: {'theme': 'default', 'themeVariables': { 'fontSize': '0.6rem'}}}%%
 graph TD
-    C(Does your software have a built-in HTC option?) -->|Yes| D("Use if suitable for use case:<br><a href='/support/tutorials/gromacs-throughput/'>Gromacs</a>, <a href='/apps/cp2k/#high-throughput-computing-with-cp2k'>CP2K</a>, <a href='/apps/lammps/#high-throughput-computing-with-lammps'>LAMMPS</a>, <a href='/apps/amber/#high-throughput-computing-with-amber'>Amber</a>,<br> Python, R ")
+    C(Does your software have a built-in HTC option?) -->|Yes| D("Use if suitable for use case:<br><a href='/support/tutorials/gromacs-throughput/'>GROMACS</a>, <a href='/apps/cp2k/#high-throughput-computing-with-cp2k'>CP2K</a>, <a href='/apps/lammps/#high-throughput-computing-with-lammps'>LAMMPS</a>, <a href='/apps/amber/#high-throughput-computing-with-amber'>Amber</a>,<br> Python, R ")
     C -->|No| E(Serial or parallel subtasks?)
     E -->|Serial| F(<a href='/support/tutorials/many/'>GNU Parallel</a><br><a href='/computing/running/array-jobs/'>Array jobs</a><br><a href='/apps/hyperqueue/'>HyperQueue</a>)
     E -->|Parallel| G(Single- or multinode subtasks?)
@@ -175,7 +175,7 @@ within a single Slurm job step. If you're using any of the applications below,
 please consider these as the first option for implementing your high-throughput
 workflows.
 
-* [Gromacs multidir option][gmx]
+* [GROMACS multidir option][gmx]
 * [FARMING mode of CP2K][cp2k] (supports dependencies between subjobs)
 * [LAMMPS multi-partition switch][lmp]
 * [Amber multi-pmemd][amber-multi-pmemd]

--- a/docs/support/training-material.md
+++ b/docs/support/training-material.md
@@ -53,9 +53,11 @@ and platforms by CSC and partners!
 
 ## Chemistry
 
-* [Spring School in Computational Chemistry course materials](https://ssl.eventilla.com/sscc-2023)
+* [Spring School in Computational Chemistry course materials](https://a3s.fi/sscc/sscc-notes-2023.html)
 * [Jupyter Machine Learning in Chemistry](https://notebooks.csc.fi) (Notebook requires Haka, Virtu or CSC account)
-* [Advanced GROMACS workshop 2021 materials](https://a3s.fi/advanced_gmx/PRACE_CSC_BioExcelWorkshop-GROMACS_workflows_and_advanced_topics.html)
+* [How to run GROMACS efficiently on LUMI workshop materials (2024)](https://zenodo.org/records/10610643)
+* [Advanced GROMACS workshop materials (2022)](https://enccs.github.io/gromacs-gpu-performance/)
+* [Advanced GROMACS workshop materials (2021)](https://a3s.fi/advanced_gmx/PRACE_CSC_BioExcelWorkshop-GROMACS_workflows_and_advanced_topics.html)
 
 ## Data management
 

--- a/docs/support/tutorials/gromacs-throughput.md
+++ b/docs/support/tutorials/gromacs-throughput.md
@@ -1,4 +1,4 @@
-# High-throughput computing with Gromacs
+# High-throughput computing with GROMACS
 
 !!! info "Note"
     High-throughput simulations can easily produce *a lot* of data, so please
@@ -6,7 +6,7 @@
     beforehead. Don't hesitate to [contact CSC Service Desk](../contact.md) if
     you're unsure about any aspect of your workflow.
 
-Gromacs comes with a built-in `multidir` functionality, which allows users to run
+GROMACS comes with a built-in `multidir` functionality, which allows users to run
 multiple concurrent simulations within one Slurm allocation. This is an excellent
 option for high-throughput use cases, where the aim is to run several similar, but
 independent, jobs. Notably, multiple calls of `sbatch` or `srun` are not needed,
@@ -129,7 +129,7 @@ srun --cpu-bind=$CPU_BIND ./select_gpu gmx_mpi mdrun -s topol -nb gpu -bonded gp
 Note that the number of MPI tasks you request should be a multiple of the number of independent
 inputs, in this case 1 task per input. Since there are only 63 cores available per LUMI-G
 node, we use just a single thread per task. For details on the CPU-GPU binding, see the
-[Gromacs application page](../../../apps/gromacs/#example-batch-script-for-lumi-full-gpu-node)
+[GROMACS application page](../../../apps/gromacs/#example-batch-script-for-lumi-full-gpu-node)
 as well as [LUMI Docs](https://docs.lumi-supercomputer.eu/runjobs/scheduled-jobs/distribution-binding/).
 
 The plot below shows the total combined throughput obtained when running multiple
@@ -143,5 +143,5 @@ scale this use case to a huge number of nodes for maximal throughput.
 
 ## More information
 
-* [Gromacs application page](../../apps/gromacs.md)
-* [Official Gromacs documentation: Running multi-simulations](https://manual.gromacs.org/current/user-guide/mdrun-features.html#running-multi-simulations)
+* [GROMACS application page](../../apps/gromacs.md)
+* [Official GROMACS documentation: Running multi-simulations](https://manual.gromacs.org/current/user-guide/mdrun-features.html#running-multi-simulations)

--- a/docs/support/tutorials/index.md
+++ b/docs/support/tutorials/index.md
@@ -47,7 +47,7 @@
 ## Chemistry
 * [Farming Gaussian jobs with HyperQueue](https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html)
 * [Using Gabedit for Gaussian jobs on Puhti](gabedit_gaussian.md)
-* [High-throughput computing with Gromacs](gromacs-throughput.md)
+* [High-throughput computing with GROMACS](gromacs-throughput.md)
 
 ## Data analysis and machine learning
 

--- a/docs/support/wn/training-new.md
+++ b/docs/support/wn/training-new.md
@@ -1,5 +1,10 @@
 # Training & tutorials
 
+## How to run GROMACS efficiently on LUMI training materials published, 6.2.2024
+
+The materials from the workshop "How to run GROMACS efficiently on LUMI" are
+now [available in the Zenodo repository](https://zenodo.org/records/10610643).
+
 ## Access CSC newsletter and mailing list archives from Docs CSC, 13.12.2023
 
 The _Contact_ page has been updated to include a selection of [CSC newsletter and mailing list archives](../contact.md#archives).


### PR DESCRIPTION
## Proposed changes

Add links to "Running GROMACS efficiently on LUMI" workshop materials from GROMACS page and Training materials index. Add "What's new" entry.

https://csc-guide-preview.rahtiapp.fi/origin/gmx-link/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes all tests.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
