### PR TITLE
Changes for Mahti web interface R4

### DIFF
--- a/docs/computing/webinterface/desktop.md
+++ b/docs/computing/webinterface/desktop.md
@@ -37,10 +37,10 @@ There are two options for connecting to the remote desktop:
 2. **With VNC client**. For better performance you can use a native VNC client, such as RealVNC or TigerVNC. Native VNC client may also be a good alternative if experiencing issues with clipboard integration between remote desktop and local host with the browser connection. Instructions for native VNC clients can be found in the Native instructions tab. This requires installing the VNC client on your local machine.
 
 ## Using the desktop
-The available applications can be found in applications menu, found in the top left corner, or by
-right-clicking the desktop. Application shortcuts directly on the desktop can also be generated or
-reset to the defaults by enabling the *Reset desktop icons* option in the Desktop app launch form on
-Mahti. To add additional desktop shortcuts, you can drag desired applications them from the
+The available applications can be found in the applications menu, found in the top-left corner, or
+by right-clicking the desktop. Application shortcuts directly on the desktop can also be generated
+or reset to the defaults by enabling the *Reset desktop icons* option in the Desktop app launch form
+on Mahti. To add additional desktop shortcuts, you can drag desired applications from the
 applications menu to the desktop.
 
 

--- a/docs/computing/webinterface/desktop.md
+++ b/docs/computing/webinterface/desktop.md
@@ -26,7 +26,7 @@ for selected applications on Puhti.
 
 ## Launching
 1. Open `Desktop` page under Apps 
-2. Specify the needed resources. Desktop is run as [batch job](../running/getting-started.md) as anything else on the supercomputers, so the required resources need to be defined before launching the desktop. The recommended partiotion is [interactive](../running/interactive-usage.md), so that the job could start as soon as possible, but if more resources are needed also other partitions are available.
+2. Specify the needed resources. Desktop is run as [batch job](../running/getting-started.md) as anything else on the supercomputers, so the required resources need to be defined before launching the desktop. The recommended partition is [interactive](../running/interactive-usage.md), so that the job could start as soon as possible, but if more resources are needed also other partitions are available.
 
 
 ## Connecting
@@ -37,12 +37,17 @@ There are two options for connecting to the remote desktop:
 2. **With VNC client**. For better performance you can use a native VNC client, such as RealVNC or TigerVNC. Native VNC client may also be a good alternative if experiencing issues with clipboard integration between remote desktop and local host with the browser connection. Instructions for native VNC clients can be found in the Native instructions tab. This requires installing the VNC client on your local machine.
 
 ## Using the desktop
-The applications mentioned above have a direct shortcut on desktop.
+The available applications can be found in applications menu, found in the top left corner, or by
+right-clicking the desktop. Application shortcuts directly on the desktop can also be generated or
+reset to the defaults by enabling the *Reset desktop icons* option in the Desktop app launch form on
+Mahti. To add additional desktop shortcuts, you can drag desired applications them from the
+applications menu to the desktop.
+
 
 For starting any other software available on the supercomputers:
 
 1. Open terminal
 2. Start the software as described in [Applications section](../../apps/index.md), usually `module load XX` and `<start_command_for_XX>`.
 
-(The applications menu in desktop does not include Puhti or Mahti scientific applications, just basic Linux tools.)
+(The applications menu in desktop does not include all Puhti or Mahti scientific applications.)
 

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,15 @@
 # Computing environment
 
+## Mahti web interface updated to release 4, 27.3.2024
+
+* GPUs (MIG) are now available in apps in the *gpusmall* partition.
+* The Desktop app has been improved
+    * Launching applications should be more reliable.
+    * The terminal window stays open if errors occur launching applications.
+    * Applications are now categorized in the menu.
+* VSCode updated to 1.86.1.
+* Open OnDemand updated to version 3.1.1.
+
 ## SSH security updates for cryptography options, 12.1.2024
 
 Recently, a new SSH vulnerability called Terrapin (CVE-2023-48795) was published describing

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,6 +1,6 @@
 # Computing environment
 
-## Mahti web interface updated to release 4, 27.3.2024
+## Mahti web interface updated to release 4, 27.2.2024
 
 * GPUs (MIG) are now available in apps in the *gpusmall* partition.
 * The Desktop app has been improved

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -8,6 +8,7 @@
     * The terminal window stays open if errors occur launching applications.
     * Applications are now categorized in the menu.
 * VSCode updated to 1.86.1.
+* TensorBoard and MLflow can now use the default module versions.
 * Open OnDemand updated to version 3.1.1.
 
 ## SSH security updates for cryptography options, 12.1.2024


### PR DESCRIPTION
Adds changes for Mahti web interface release 4. Merge after the release.

https://csc-guide-preview.rahtiapp.fi/origin/wwwmahti-r4/