### PR TITLE
Changes for Puhti web interface R18

### DIFF
--- a/docs/computing/webinterface/accelerated-visualization.md
+++ b/docs/computing/webinterface/accelerated-visualization.md
@@ -8,13 +8,16 @@ The Accelerated visualization app enables using visualization applications with 
 * [CloudCompare](../../apps/cloudcompare.md)
 * [COMSOL](../../apps/comsol.md)
 * [ParaView](../../apps/paraview.md)
+* [VisIt](../../apps/visit.md)
 * [VMD](../../apps/vmd.md)
 
 ## Launching
 1. Open the `Accelerated visualization` page under Apps.
 2. Specify the needed resources. One GPU will be reserved.
-3. Select visualization application.
-4. Launch the app.
+3. Launch the app.
+4. Connect to the desktop.
+4. Launch the visualization application from the applications menu, found either in the top-left
+   corner, or by right-clicking the desktop.
 
 !!! Note
 
@@ -37,8 +40,11 @@ Instructions for native VNC clients can be found in the Native instructions tab.
 This requires installing the VNC client on your local machine.
 
 ## Using the app
-The selected visualization application will launch automatically.
 
-A menu with settings and a shortcut to the terminal (xterm) can be found by right clicking the background in the app session.
-If the application windows do not behave as expected or menus in the application appear in the wrong place, it can usually be fixed by clicking `Restart Fluxbox` in the menu.
+The Accelerated Visualization app is used in the same way as the [Desktop app](desktop.md). However,
+shortcuts for the accelerated apps will not be generated on the desktop automatically. To create
+shortcuts for them, you can drag the desired application from the applications menu to the desktop.
 
+Note that if you are running applications that do not benefit from GPU acceleration, you should use
+the [Desktop app](desktop.md) instead. Only the applications suffixed with `(Accelerated)` benefit
+from a GPU.

--- a/docs/computing/webinterface/desktop.md
+++ b/docs/computing/webinterface/desktop.md
@@ -3,8 +3,8 @@ The desktop enables using graphical applications on a Puhti or Mahti compute nod
 
 In the Puhti web interface, the following applications are available in the desktop:
 
-* [COMSOL](../../apps/comsol.md)
 * [CloudCompare](../../apps/cloudcompare.md)
+* [COMSOL](../../apps/comsol.md)
 * [GRASS GIS](../../apps/grass.md)
 * [Grace](../../apps/grace.md)
 * [MATLAB](../../apps/matlab.md)

--- a/docs/computing/webinterface/index.md
+++ b/docs/computing/webinterface/index.md
@@ -9,7 +9,7 @@ web browser. A web interface for LUMI is also available at [www.lumi.csc.fi](htt
 
 **Features available in both the Puhti and Mahti web interfaces:**
 
-- View, download and upload files
+- View, download, upload and move files between Allas, the supercomputer and your local computer
 - Open a shell on the login node
 - Open a persistent shell on a compute node
 - View running batch jobs
@@ -19,14 +19,9 @@ web browser. A web interface for LUMI is also available at [www.lumi.csc.fi](htt
     - Julia-Jupyter
     - Jupyter
     - Jupyter for courses: An interactive Jupyter session specifically for courses
+    - MLflow
     - TensorBoard
     - Visual Studio Code
-
-
-**Features available in Mahti only:**
-
-- View, download, upload and move files between Allas, Mahti and your local computer
-
 
 **Apps available in Puhti only:**
 
@@ -94,8 +89,8 @@ The file browser comes with a basic text editor. Some important notes on that:
 
 #### Using Allas
 
-In the Mahti web interface, the [Allas object storage service](../../computing/allas) can be
-accessed using the file browser.
+In the web interface, the [Allas object storage service](../../computing/allas) can also be accessed
+using the file browser.
 
 To configure authentication for Allas it is recommended that you use the _Cloud storage configuration_ app available in the web interface.
 Once you open the app, you will be prompted to enter your CSC password.
@@ -117,14 +112,14 @@ Configured remotes that are not accessible, for example, due to expired authenti
 connection issues, are not be visible in the _Files_ dropdown menu.
 
 The file browser works the same way when accessing Allas as it does when accessing the shared
-filesystem on Mahti.
+filesystem on the supercomputer.
 Note that uploading large files from your local computer to Allas is currently not recommended due
 to technical limitations.
 
 
 #### Using IDA
 
-In the Mahti web interface, the [IDA storage service](../../data/ida/using_ida)
+The [IDA storage service](../../data/ida/using_ida)
 can also be used, although some key features, such as moving data from the
 staging area to the frozen area, are only possible though the [IDA WWW-interface](https://ida.fairdata.fi).
 To use IDA in the Mahti web interface, it must first be configured for use with Rclone on a Mahti login node as follows.
@@ -145,7 +140,7 @@ In the Rclone configuration interface, create a new remote with the following op
 7. Advanced config: No
 
 After completing the Rclone configuration, the web interface server must be restarted, which can be done by clicking
-_Restart web server_ in the _Help_ menu in top right section of the navbar in the Mahti web interface.
+_Restart web server_ in the _Help_ menu in top right section of the navbar in the web interface.
 IDA can then be accessed in the file browser, where you will be able to upload, download, transfer and edit files in the staging area
 and view and download files in the frozen area.
 

--- a/docs/computing/webinterface/matlab.md
+++ b/docs/computing/webinterface/matlab.md
@@ -1,8 +1,10 @@
 # MATLAB
 
 The app will start a MATLAB session on Puhti with the specified resources.
-Currently, only the R2023a release with Parallel Computing and Compiler SDK toolboxes is installed.
+Currently, only the R2023b release with Parallel Computing and Compiler SDK toolboxes is installed.
 
 In addition to computing resources, partition and project, there is an **optional** "License file" field.
 With it you can specify path to your own home organisation's license server to obtain MATLAB license
 from there instead. This option is useful, for example, in situations where all CSC's MATLAB licences are already reserved.
+
+For documentation on using MATLAB, see the [MATLAB documentation](../../apps/matlab.md).

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,27 @@
 # Computing environment
 
+## Puhti web interface updated to release 18, 5.3.2024
+
+* Allas and IDA can now be accessed in the file browser.
+* The Cloud storage configuration tool for generating access tokens to Allas is now available.
+* The Desktop and Accelerated Visualization apps have been improved.
+    * Accelerated Visualization now launches the same desktop as the Desktop app.
+    * Applications for the Accelerated Visualization app can now be found in the applications menu in the desktop.
+    * VisIt is now available in Accelerated Visualization.
+    * Launching applications should be more reliable.
+    * The terminal window stays open if errors occur launching applications.
+    * Applications are now categorized in the menu.
+* Handling of reservations has been improved.
+    * Future reservations are now shown.
+    * All reservations can now be used on any app regardless of partition.
+    * Reservation caching has been improved to be more up to date.
+    * Job time is now limited by reservation length automatically.
+* MATLAB updated to r2023b.
+* VSCode updated to 1.86.1.
+* TensorBoard and MLflow can now use the default module versions.
+* Open OnDemand updated to version 3.1.1.
+
+
 ## Mahti web interface updated to release 4, 27.2.2024
 
 * GPUs (MIG) are now available in apps in the *gpusmall* partition.


### PR DESCRIPTION
Adds changes for Puhti web interface release 18. Merge after the release.

https://csc-guide-preview.rahtiapp.fi/origin/wwwpuhti-r18/
