### PR TITLE
Replace Puhti maintenance announcement

### DIFF
--- a/csc-overrides/partials/announcement.html
+++ b/csc-overrides/partials/announcement.html
@@ -1,6 +1,6 @@
 {# Put the announcement, in HTML, right under this comment! #}
 <p>
-  &#128679; Please note: There will be a service break on <b>Puhti</b> on Tuesday 5 March from 08:00 to 18:00. <a href="https://research.csc.fi/-/280351-78" target="_blank">Click here for more information</a>. &#128679;
+  &#128187; Latest computing environment updates bring new small GPUs to Mahti and Allas access via Puhti web interface. <a href="https://docs.csc.fi/support/wn/comp-new/" target="_blank">See all updates here</a>! &#128187;
 </p>
 {# Remember
   - to set the announcement_visible to true in mkdocs.yml

--- a/csc-overrides/partials/announcement.html
+++ b/csc-overrides/partials/announcement.html
@@ -1,6 +1,6 @@
 {# Put the announcement, in HTML, right under this comment! #}
 <p>
-  &#128187; Latest computing environment updates bring new small GPUs to Mahti and Allas access via Puhti web interface. <a href="https://docs.csc.fi/support/wn/comp-new/">See all updates here</a>! &#128187;
+  &#128187; Latest computing environment updates bring new small GPUs to Mahti and Allas access via Puhti web interface. <a href="{{ base_url|url }}/support/wn/comp-new/">See all updates here</a>! &#128187;
 </p>
 {# Remember
   - to set the announcement_visible to true in mkdocs.yml
@@ -9,4 +9,6 @@
   - to not have loose text outside of a <p> (or an <a>)
   - that you can garnish the announcement with emojis by using their code
     points with HTML entities, for example &#x2615; for the "hot beverage" emoji.
+  - to not use the literal 'docs.csc.fi' for internal links,
+    use href="{{ base_url|url }}/path/to/page/" instead
 #}

--- a/csc-overrides/partials/announcement.html
+++ b/csc-overrides/partials/announcement.html
@@ -1,6 +1,6 @@
 {# Put the announcement, in HTML, right under this comment! #}
 <p>
-  &#128187; Latest computing environment updates bring new small GPUs to Mahti and Allas access via Puhti web interface. <a href="https://docs.csc.fi/support/wn/comp-new/" target="_blank">See all updates here</a>! &#128187;
+  &#128187; Latest computing environment updates bring new small GPUs to Mahti and Allas access via Puhti web interface. <a href="https://docs.csc.fi/support/wn/comp-new/">See all updates here</a>! &#128187;
 </p>
 {# Remember
   - to set the announcement_visible to true in mkdocs.yml


### PR DESCRIPTION
## Proposed changes

Replaced Puhti maintenance with announcement about latest computing environment updates.

https://csc-guide-preview.rahtiapp.fi/origin/remove-puhti-maintenance/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes all tests.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
