### PR TITLE
Fix a few links

### DIFF
--- a/docs/computing/installing.md
+++ b/docs/computing/installing.md
@@ -99,5 +99,5 @@ trees in R. [See here for specific details](../apps/r-env.md#r-package-installat
 
 ## More information
 
-- [Installing your own software](https://csc-training.github.io/csc-env-eff/#8-installing-your-own-software)
+- [Installing your own software](https://csc-training.github.io/csc-env-eff/part-2/installing/)
   (CSC Computing Environment slides and tutorials)

--- a/docs/support/faq/how-to-install-own-software.md
+++ b/docs/support/faq/how-to-install-own-software.md
@@ -6,6 +6,6 @@ default locations. Instead, the recommended location is your
 `/projappl/project_xxxx` folder.
 
 For details, please consult the
-[Installing own software chapter](https://a3s.fi/CSC_training/08_installing.html#/installing-own-software)
-of our Using CSC HPC Environment Efficiently course materials and follow the related 
-[hands-on tutorials](https://csc-training.github.io/csc-env-eff/#installing).
+[Installing own software chapter](https://a3s.fi/CSC_training/09_installing.html#/installing-own-software)
+of our CSC Computing Environment course materials and follow the related
+[hands-on tutorials](https://csc-training.github.io/csc-env-eff/part-2/installing/).


### PR DESCRIPTION
## Proposed changes

Fixed a few links to CSC Computing Environment course materials.

https://csc-guide-preview.rahtiapp.fi/origin/csc-env-eff-links/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes all tests.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
