### PR TITLE
Sscc2024 materials to tutorials list

### DIFF
--- a/docs/support/tutorials/index.md
+++ b/docs/support/tutorials/index.md
@@ -49,6 +49,7 @@
 * [Farming Gaussian jobs with HyperQueue](https://csc-training.github.io/csc-env-eff/hands-on/throughput/gaussian_hq.html)
 * [Using Gabedit for Gaussian jobs on Puhti](gabedit_gaussian.md)
 * [High-throughput computing with GROMACS](gromacs-throughput.md)
+* [Spring School on Computational Chemistry](https://zenodo.org/records/11172973)
 
 ## Data analysis and machine learning
 

--- a/docs/support/wn/training-new.md
+++ b/docs/support/wn/training-new.md
@@ -1,5 +1,12 @@
 # Training & tutorials
 
+## Spring School on Computational Chemistry materials available for self learning, 10.5.2024
+
+The [School materials](https://zenodo.org/records/11172973) cover intro to molecular
+dynamics and electronic structure theory lectures and hands-on exercises, and machine
+learning for molecular and material use cases. You can also access the Notebooks directly
+via the [Mahti web interface](https://www.mahti.csc.fi).
+
 ## How to run GROMACS efficiently on LUMI training materials published, 6.2.2024
 
 The materials from the workshop "How to run GROMACS efficiently on LUMI" are

--- a/docs/support/wn/training-new.md
+++ b/docs/support/wn/training-new.md
@@ -5,7 +5,8 @@
 The [School materials](https://zenodo.org/records/11172973) cover intro to molecular
 dynamics and electronic structure theory lectures and hands-on exercises, and machine
 learning for molecular and material use cases. You can also access the Notebooks directly
-via the [Mahti web interface](https://www.mahti.csc.fi).
+via the [Mahti web interface](https://www.mahti.csc.fi) (once logged in, select "Jupyter for
+courses" and the desired course module.)
 
 ## How to run GROMACS efficiently on LUMI training materials published, 6.2.2024
 


### PR DESCRIPTION
## Proposed changes

Briefly describe the changes you've made here: added a link to zenodo summary of the spring school materials in the tutorials list and a corresponding what's new entry. 

See proposed content here:

* https://csc-guide-preview.rahtiapp.fi/origin/sscc2024/support/whats-new/#training-tutorials
* https://csc-guide-preview.rahtiapp.fi/origin/sscc2024/support/tutorials/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. (If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.)
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
