### PR TITLE
Add known issue with ubuntu 20.04 and hpc.6 flavors

### DIFF
--- a/docs/cloud/pouta/known-problems.md
+++ b/docs/cloud/pouta/known-problems.md
@@ -24,6 +24,10 @@
     name after a rebuild or reboot. If you want to be sure that the
     correct device gets mounted to the same path every time it is a good
     idea to use UUIDs instead of paths.
+-   Image Ubuntu-20.04 and flavor hpc.6.* unable to boot. A bug prevents
+    instances with Ubuntu 20.04 (created or updated) and flavor hpc.6.*
+    to boot. We expect that a future update will fix it, but on the time
+    been avoid this combination.
 
 ## EC2 tools (euca2ools)
 

--- a/docs/cloud/pouta/known-problems.md
+++ b/docs/cloud/pouta/known-problems.md
@@ -24,7 +24,7 @@
     name after a rebuild or reboot. If you want to be sure that the
     correct device gets mounted to the same path every time it is a good
     idea to use UUIDs instead of paths.
--   Image Ubuntu-20.04 and flavor hpc.6.* unable to boot. A bug prevents
+-   Image Ubuntu-20.04 and flavor hpc.6 unable to boot. A bug prevents
     instances with Ubuntu 20.04 (created or updated) and flavor hpc.6.*
     to boot. We expect that a future update will fix it, but on the time
     been avoid this combination.

--- a/docs/cloud/pouta/known-problems.md
+++ b/docs/cloud/pouta/known-problems.md
@@ -24,10 +24,10 @@
     name after a rebuild or reboot. If you want to be sure that the
     correct device gets mounted to the same path every time it is a good
     idea to use UUIDs instead of paths.
--   Image Ubuntu-20.04 and flavor hpc.6 unable to boot. A bug prevents
+-   Ubuntu-20.04 images and hpc.6 flavor are unable to boot. A bug prevents
     instances with Ubuntu 20.04 (created or updated) and flavor hpc.6.*
-    to boot. We expect that a future update will fix it, but on the time
-    been avoid this combination.
+    from booting. We expect a future update to fix this, but in the meantime
+    avoid this combination.
 
 ## EC2 tools (euca2ools)
 


### PR DESCRIPTION
## Proposed changes

Add known issue with Ubuntu 20.04 images and hpc.6 flavors in Pouta.
Preview: https://csc-guide-preview.rahtiapp.fi/origin/CCCP-4546/cloud/pouta/known-problems/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. (If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.)
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
