### PR TITLE
Added note and news about new PyTorch 2.3

### DIFF
--- a/docs/apps/python-data.md
+++ b/docs/apps/python-data.md
@@ -34,9 +34,9 @@ allow.
 
 Current versions are:
 
-- `python-data/3.10-24.04`: installed in April 2024, includes for
-  example Scikit-learn 1.4.2, SciPy 1.13.0, Pandas 2.2.2 and
-  JupyterLab 4.1.6.
+- (default version) `python-data/3.10-24.04`: installed in April 2024,
+  includes for example Scikit-learn 1.4.2, SciPy 1.13.0, Pandas 2.2.2
+  and JupyterLab 4.1.6.
 
 - `python-data/3.10-23.11`: installed in November 2023, includes for
   example Scikit-learn 1.3.2, SciPy 1.11.4, Pandas 2.1.3 and
@@ -45,7 +45,7 @@ Current versions are:
 - `python-data/3.10-23.07`: installed in July 2023, includes for
   example Scikit-learn 1.2.2, SciPy 1.11.1, Pandas 2.0.3 and JupyterLab
   4.0.2.
-- (default version) `python-data/3.10-22.09` or `python-data/3.10`:
+- `python-data/3.10-22.09` or `python-data/3.10`:
   installed in September 2022, includes for example Scikit-learn
   1.1.2, SciPy 1.9.1, Pandas 1.4.4 and JupyterLab 3.4.6.
 - `python-data/3.9-22.04` or `python-data/3.9`: installed in April

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -10,6 +10,14 @@ Machine learning framework for Python.
 
 !!! info "News" 
 
+    **13.6.2024** PyTorch 2.3 added to Puhti and Mahti. The LUMI
+    installation will be delayed until early autumn due to an incompatible
+    ROCm driver version. This version has also updated how Python commands
+    are wrapped, as this solves several problems with using virtual
+    environments and Jupyter Notebooks. Due to this `apptainer` or
+    `apptainer_wrapper` commands will no longer work, but otherwise the
+    change should be invisible to users.
+
     **1.3.2024** PyTorch 2.2 added to Puhti, Mahti and LUMI. The LUMI
     module includes ROCm versions of 
     [FlashAttention-2](https://github.com/ROCm/flash-attention) 
@@ -42,22 +50,23 @@ Machine learning framework for Python.
 
 Currently supported PyTorch versions:
 
-| Version | Module         | Puhti | Mahti | LUMI | Notes                      |
-|:--------|----------------|:-----:|:-----:|------|:---------------------------|
-| 2.2.2   | `pytorch/2.2`  | -     | -     | X    | default version            |
-| 2.2.1   | `pytorch/2.2`  | X     | X     | -    | default version            |
-| 2.1.2   | `pytorch/2.1`  | -     | -     | X    |                            |
-| 2.1.0   | `pytorch/2.1`  | X     | X     | -    |                            |
-| 2.0.1   | `pytorch/2.0`  | -     | -     | X    |                            |
-| 2.0.0   | `pytorch/2.0`  | X     | X     | -    |                            |
-| 1.13.1  | `pytorch/1.13` | -     | -     | X    | limited multi-node support |
-| 1.13.0  | `pytorch/1.13` | X     | X     | -    |                            |
-| 1.12.0  | `pytorch/1.12` | X     | X     | -    |                            |
-| 1.11.0  | `pytorch/1.11` | X     | X     | -    |                            |
-| 1.10.0  | `pytorch/1.10` | (x)   | (x)   | -    |                            |
-| 1.9.0   | `pytorch/1.9`  | (x)   | (x)   | -    |                            |
-| 1.8.1   | `pytorch/1.8`  | (x)   | (x)   | -    |                            |
-| 1.7.1   | `pytorch/1.7`  | (x)   | -     | -    |                            |
+| Version | Module         | Puhti | Mahti | LUMI      | Notes                           |
+|:--------|----------------|:-----:|:-----:|-----------|:--------------------------------|
+| 2.3.1   | `pytorch/2.3`  | X     | X     | (delayed) | default version on Puhti, Mahti |
+| 2.2.2   | `pytorch/2.2`  | -     | -     | X         | default version on LUMI         |
+| 2.2.1   | `pytorch/2.2`  | X     | X     | -         |                                 |
+| 2.1.2   | `pytorch/2.1`  | -     | -     | X         |                                 |
+| 2.1.0   | `pytorch/2.1`  | X     | X     | -         |                                 |
+| 2.0.1   | `pytorch/2.0`  | -     | -     | X         |                                 |
+| 2.0.0   | `pytorch/2.0`  | X     | X     | -         |                                 |
+| 1.13.1  | `pytorch/1.13` | -     | -     | X         | limited multi-node support      |
+| 1.13.0  | `pytorch/1.13` | X     | X     | -         |                                 |
+| 1.12.0  | `pytorch/1.12` | X     | X     | -         |                                 |
+| 1.11.0  | `pytorch/1.11` | X     | X     | -         |                                 |
+| 1.10.0  | `pytorch/1.10` | (x)   | (x)   | -         |                                 |
+| 1.9.0   | `pytorch/1.9`  | (x)   | (x)   | -         |                                 |
+| 1.8.1   | `pytorch/1.8`  | (x)   | (x)   | -         |                                 |
+| 1.7.1   | `pytorch/1.7`  | (x)   | -     | -         |                                 |
 
 Includes [PyTorch](https://pytorch.org/) and related libraries with
 GPU support via CUDA/ROCm.
@@ -83,11 +92,19 @@ create a virtual environment use the command `python3 -m venv
 All modules are based on containers using Apptainer (previously known
 as Singularity). Wrapper scripts have been provided so that common
 commands such as `python`, `python3`, `pip` and `pip3` should work as
-normal. For other commands, you need to prefix them with
-`apptainer_wrapper exec`, for example `apptainer_wrapper exec
-huggingface-cli`. For more information, see [CSC's general
+normal. 
+
+For **PyTorch version 2.2 and earlier**, other commands need to be
+prefixed with `apptainer_wrapper exec`, for example `apptainer_wrapper
+exec huggingface-cli`. For more information, see [CSC's general
 instructions on how to run Apptainer
-containers](../computing/containers/run-existing.md).
+containers](../computing/containers/run-existing.md). 
+
+For **PyTorch version 2.3 and later**, we have used wrappers created
+with the tykky tool, and all commands provided by Python package
+should be wrapped and can be used directly. In case you really need to
+run something inside the container you can prefix with `_debug_exec`
+or run `_debug_shell` to open a shell session.
 
 
 !!! info "New users"
@@ -165,7 +182,7 @@ proportion of the available CPU cores in a single node:
     #SBATCH --time=1:00:00
     #SBATCH --gres=gpu:v100:1
         
-    module load pytorch/2.1
+    module load pytorch/2.3
     srun python3 myprog.py <options>
     ```
 
@@ -179,7 +196,7 @@ proportion of the available CPU cores in a single node:
     #SBATCH --time=1:00:00
     #SBATCH --gres=gpu:a100:1
     
-    module load pytorch/2.1
+    module load pytorch/2.3
     srun python3 myprog.py <options>
     ```
 
@@ -195,7 +212,7 @@ proportion of the available CPU cores in a single node:
     #SBATCH --time=1:00:00
     
     module use /appl/local/csc/modulefiles/
-    module load pytorch/2.1
+    module load pytorch/2.3
     srun python3 myprog.py <options>
     ```
 

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -14,7 +14,7 @@ Machine learning framework for Python.
     installation will be delayed until early autumn due to an incompatible
     ROCm driver version. This version has also updated how Python commands
     are wrapped, as this solves several problems with using virtual
-    environments and Jupyter Notebooks. Due to this `apptainer` or
+    environments and Jupyter Notebooks. Due to this `apptainer` and
     `apptainer_wrapper` commands will no longer work, but otherwise the
     change should be invisible to users.
 
@@ -101,10 +101,11 @@ instructions on how to run Apptainer
 containers](../computing/containers/run-existing.md). 
 
 For **PyTorch version 2.3 and later**, we have used wrappers created
-with the tykky tool, and all commands provided by Python package
-should be wrapped and can be used directly. In case you really need to
-run something inside the container you can prefix with `_debug_exec`
-or run `_debug_shell` to open a shell session.
+with [the tykky tool](../computing/containers/tykky.md), and all
+commands provided by pre-installed Python packages are wrapped and can
+be used directly. In case you really need to run something inside the
+container you can prefix with `_debug_exec` or run `_debug_shell` to
+open a shell session.
 
 
 !!! info "New users"

--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -213,7 +213,7 @@ proportion of the available CPU cores in a single node:
     #SBATCH --time=1:00:00
     
     module use /appl/local/csc/modulefiles/
-    module load pytorch/2.3
+    module load pytorch/2.2
     srun python3 myprog.py <options>
     ```
 

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -2,12 +2,12 @@
 
 ## PyTorch 2.3.1, 13.6.2024
 
-[PyTorch](../../apps/pytorch.md) PyTorch 2.3.1 added to Puhti and
-Mahti. The LUMI installation will be delayed until early autumn due to
-an incompatible ROCm driver version. This version has also updated how
+[PyTorch](../../apps/pytorch.md) 2.3.1 added to Puhti and Mahti. The
+LUMI installation will be delayed until early autumn due to an
+incompatible ROCm driver version. This version has also updated how
 Python commands are wrapped, as this solves several problems with
 using virtual environments and Jupyter Notebooks. Due to this
-`apptainer` or `apptainer_wrapper` commands will no longer work, but
+`apptainer` and `apptainer_wrapper` commands will no longer work, but
 otherwise the change should be invisible to users. See our [PyTorch
 module documentation for more
 information](../../apps/pytorch.md#available).

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,17 @@
 # Applications
 
+## PyTorch 2.3.1, 13.6.2024
+
+[PyTorch](../../apps/pytorch.md) PyTorch 2.3.1 added to Puhti and
+Mahti. The LUMI installation will be delayed until early autumn due to
+an incompatible ROCm driver version. This version has also updated how
+Python commands are wrapped, as this solves several problems with
+using virtual environments and Jupyter Notebooks. Due to this
+`apptainer` or `apptainer_wrapper` commands will no longer work, but
+otherwise the change should be invisible to users. See our [PyTorch
+module documentation for more
+information](../../apps/pytorch.md#available).
+
 ## R 4.4.0 in r-env, 7.6.2024
 	
 R version 4.4.0 is now available in `r-env` in Puhti and is set as the default version. The new version will be available in RStudio in the Puhti web interface shortly.

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -12,6 +12,11 @@ otherwise the change should be invisible to users. See our [PyTorch
 module documentation for more
 information](../../apps/pytorch.md#available).
 
+## Python Data 3.10-24.04 now the default version
+
+The recently installed `python-data/3.10-24.04` has been set as the
+default version for [Python Data](../../apps/python-data.md).
+
 ## R 4.4.0 in r-env, 7.6.2024
 	
 R version 4.4.0 is now available in `r-env` in Puhti and is set as the default version. The new version will be available in RStudio in the Puhti web interface shortly.


### PR DESCRIPTION
## Proposed changes

New PyTorch 2.3 in Puhti and Mahti. Also new tykky-wrappers which changes some behaviour.

Also added news about Python Data module default version change.

News preview: <https://csc-guide-preview.rahtiapp.fi/origin/pytorch-2.3-with-tykky-wrappers/support/wn/apps-new/#pytorch-231-1362024>
PyTorch page: <https://csc-guide-preview.rahtiapp.fi/origin/pytorch-2.3-with-tykky-wrappers/apps/pytorch/>

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. (If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.)
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
