### PR TITLE
Snakemake with Apptainers, link to Snakemake documentation

### DIFF
--- a/docs/support/tutorials/snakemake-puhti.md
+++ b/docs/support/tutorials/snakemake-puhti.md
@@ -26,13 +26,15 @@ The tools used in the workflow can be installed in following ways:
     * If different Snakemake rules use different modules, include the [module information in the Snakefile](https://snakemake.readthedocs.io/en/latest/snakefiles/deployment.html#using-environment-modules).
 2. Own custom installations as Apptainer containers:
     * Apptainer container can be downloaded from some repository or built locally. For building custom Apptainer containers, see [Creating containers page](../../computing/containers/creating.md).
-    * See Snakemake's [Running jobs in containers](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#running-jobs-in-containers) for changes required in Snakemake file and command. 
+    * See Snakemake's [Running jobs in containers](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#running-jobs-in-containers) for changes required in Snakemake file and command.
+    * For binding folders or using other Apptainer flags, use [--apptainer-args option](https://snakemake.readthedocs.io/en/stable/executing/cli.html#apptainer/singularity) of `snakemake` command.
+    * Sometimes it might be necessary to [define the shell inside the container](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#handling-shell-executable). 
 
 ```
-# If your Apptainer tutorial.sif image is stored locally in Puhti in folder "image".
-apptainer: "image/tutorial.sif"
-# If your Docker or Apptainer container image is available via URI
-apptainer: "docker://<repository>/<image_name>"
+# If your Apptainer tutorial.sif image is stored locally in Puhti in folder "image":
+container: "image/tutorial.sif"
+# If you would like to covert a Docker iamge to Apptainer container image on-the-fly:
+container: "docker://<repository>/<image_name>"
 ```
 
 ### Snakemake Tykky installation for Python

--- a/docs/support/tutorials/snakemake-puhti.md
+++ b/docs/support/tutorials/snakemake-puhti.md
@@ -25,9 +25,8 @@ The tools used in the workflow can be installed in following ways:
     * If all Snakemake rules use the same module(s), load it before running snakemake commands.
     * If different Snakemake rules use different modules, include the [module information in the Snakefile](https://snakemake.readthedocs.io/en/latest/snakefiles/deployment.html#using-environment-modules).
 2. Own custom installations as Apptainer containers:
-    * Apptainer container might be downloaded from some repository or built locally. For building custom Apptainer containers, see [Creating containers page](../../computing/containers/creating.md).
-    * Add [`--use-apptainer`](https://snakemake.readthedocs.io/en/stable/executing/cli.html#apptainer/singularity) to your `snakemake` command
-    * [Specify the container](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#running-jobs-in-containers) path at the top level of the Snakefile or for each rule separately:
+    * Apptainer container can be downloaded from some repository or built locally. For building custom Apptainer containers, see [Creating containers page](../../computing/containers/creating.md).
+    * See Snakemake's [Running jobs in containers](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#running-jobs-in-containers) for changes required in Snakemake file and command. 
 
 ```
 # If your Apptainer tutorial.sif image is stored locally in Puhti in folder "image".


### PR DESCRIPTION
Based on https://rt.csc.fi/rt/Ticket/Display.html?id=710725 we had a comment about executalble missing and depricated snakemake option in use.. Instead added now linked to Snakemake documentation, should stay better up-to-date.

https://csc-guide-preview.rahtiapp.fi/origin/ktiits-patch-1/support/tutorials/snakemake-puhti/#installation-of-tools-used-in-the-the-workflow

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. (If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.)
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
