### PR TITLE
Add info about software installation support

### DIFF
--- a/docs/apps/by_discipline.md
+++ b/docs/apps/by_discipline.md
@@ -1,6 +1,6 @@
 # Applications by discipline
 
-!!! Note
+!!! default "Note"
     In addition to technical support, CSC also provides expert consulting in questions related to sciences and methods. For more details, see our [science-specific support pages at research.csc.fi](https://research.csc.fi/sciences) or directly [contact our Service Desk](../support/contact.md).
 
 

--- a/scripts/generate_alpha.sh
+++ b/scripts/generate_alpha.sh
@@ -4,6 +4,13 @@ generated_file="$app_dir/index.md"
 
 echo -e "# Applications\n" > $generated_file
 
+echo -e '!!! default "Cannot find the application you are looking for?"' >> $generated_file
+echo -e "    * [See here for ways to install software yourself](../computing/installing.md)." >> $generated_file
+echo -e "    * You may also [contact CSC Service Desk](../support/contact.md) with" >> $generated_file
+echo -e "      your software installation request. Given enough requests, we may consider pre-installing a particular application," >> $generated_file
+echo -e "      or purchasing a license for it if the software in question is proprietary." >> $generated_file
+echo -e "    * Although we cannot promise to pre-install all requested software, CSC Service Desk is happy to support you in installing it yourself.\n" >> $generated_file
+
 echo -e "- [By discipline](by_discipline.md)" >> $generated_file
 echo -e "- [By availability](by_system.md)" >> $generated_file
 echo -e "- [By license](by_license.md)" >> $generated_file

--- a/scripts/generate_alpha.sh
+++ b/scripts/generate_alpha.sh
@@ -6,10 +6,11 @@ echo -e "# Applications\n" > $generated_file
 
 echo -e '!!! default "Cannot find the application you are looking for?"' >> $generated_file
 echo -e "    * [See here for ways to install software yourself](../computing/installing.md)." >> $generated_file
-echo -e "    * You may also [contact CSC Service Desk](../support/contact.md) with" >> $generated_file
-echo -e "      your software installation request. Given enough requests, we may consider pre-installing a particular application," >> $generated_file
-echo -e "      or purchasing a license for it if the software in question is proprietary." >> $generated_file
-echo -e "    * Although we cannot promise to pre-install all requested software, CSC Service Desk is happy to support you in installing it yourself.\n" >> $generated_file
+echo -e "    * You may also [contact CSC Service Desk](../support/contact.md) with your software" >> $generated_file
+echo -e "      installation request. Given enough requests, we may consider pre-installing a particular" >> $generated_file
+echo -e "      application, or purchasing a license for it if the software in question is proprietary." >> $generated_file
+echo -e "    * Although we cannot promise to pre-install all requested applications, CSC Service Desk" >> $generated_file
+echo -e "      is happy to support you in installing software yourself.\n" >> $generated_file
 
 echo -e "- [By discipline](by_discipline.md)" >> $generated_file
 echo -e "- [By availability](by_system.md)" >> $generated_file


### PR DESCRIPTION
## Proposed changes

Adds info about RT support on installing software by request (or help user install it themselves) to apps page.

https://csc-guide-preview.rahtiapp.fi/origin/installation-requests/apps/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. (If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.)
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
