### PR TITLE
add info about MaxSubmitJobs to Array jobs intro

### DIFF
--- a/docs/computing/running/array-jobs.md
+++ b/docs/computing/running/array-jobs.md
@@ -2,14 +2,27 @@
 
 In many cases, a computational analysis job contains a number of similar independent subtasks.
 A user may have several datasets that are analyzed in the same way, or the same simulation code
-is executed with a number of different parameters. This kind of tasks are often called as
-_embarrassingly parallel_ jobs, or _task farming_, as the tasks can in principle be distributed
-to as many processors as there are subtasks to run. If the independent jobs are "large" enough,
-so that the batch system overhead is not relevant (more than 30 minutes per job, for example),
-and the total number of independent jobs is not huge (less than 1000 per month, for example),
-array jobs in Puhti may be a good (easy) option. There are more suitable options for running
-high throughput calculations when the number of individual runs is very large or the individual
-runs are very short (see, for example, [HyperQueue](../../apps/hyperqueue.md)).
+is executed with a number of different parameters. These kinds of tasks are often called
+_embarrassingly parallel_ jobs, or collectively _task farming_, since they can, in principle,
+be distributed to as many processors as there are tasks to run.
+
+Array jobs may be a suitable approach if:
+
+1. The runtime of each independent job is long enough for the SLURM batch system
+    overhead to be irrelevant.
+    * Individual runtimes are longer than about 30 minutes.
+2. The total number of independent jobs is not excessively large.
+    * A user can only have up to 400 jobs either running or queuing on the batch
+      system.
+
+!!! note "Other options"
+    When the runtimes are very short or the number of individual jobs is very large,
+    there are more suitable options for running high-throughput calculations.
+    The recommended tool for these use cases is [HyperQueue](../../apps/hyperqueue.md).
+    Alternatives include the
+    [Linux `xargs` utility](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/xargs.html)
+    (see [this batch script](https://a3s.fi/pub/xargsjob.sh) for a usage example)
+    and the [GNU Parallel shell tool](../../support/tutorials/many.md).
 
 ## Defining an array job
 


### PR DESCRIPTION
## Proposed changes
Add info about MaxSubmitJobs to Array jobs intro. Suggest `xargs` and GNU Parallel as alternatives to HyperQueue.

Preview page:
https://csc-guide-preview.rahtiapp.fi/origin/array-job-task-limit/computing/running/array-jobs/

## Checklist before requesting a review

- [ x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x ] My pull request passes the automated tests. (If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.)
- [ x] I have included a link to the appropriate [preview page](https://csc-guide-preview.rahtiapp.fi/origin/) (select your branch from the list).
