### PR TITLE
Fix example script and highlight what needs to be changed

### DIFF
--- a/docs/data/Allas/allas_batchjobs.md
+++ b/docs/data/Allas/allas_batchjobs.md
@@ -93,7 +93,7 @@ the batch job script for Puhti could look like:
 #SBATCH --error=allas_errors_%j.txt
 
 #make sure connection to Allas is open
-source /appl/opt/allas-cli-utils/allas_conf -f -k $OS_PROJECT_NAME
+source /appl/opt/csc-cli-utils/allas-cli-utils/allas_conf -f -k $OS_PROJECT_NAME
 
 #download input data
 rclone copy allas:178-data-bucket/dataset34/data2.txt ./
@@ -102,8 +102,10 @@ rclone copy allas:178-data-bucket/dataset34/data2.txt ./
 my_analysis_command -in dataset34/data2.txt   -outdir results34
 
 #make sure connection to Allas is open
-source /appl/opt/allas-cli-utils/allas_conf -f -k $OS_PROJECT_NAME
+source /appl/opt/csc-cli-utils/allas-cli-utils/allas_conf -f -k $OS_PROJECT_NAME
 
 #upload results to allas
 rclone copyto results34 allas:178-data-bucket/
 ```
+For Mahti, remember to source `/appl/opt/csc-tools/allas-cli-utils/allas_conf` instead of `/appl/opt/csc-cli-utils/allas-cli-utils/allas_conf` in all places where you need to make sure the connection is open.
+


### PR DESCRIPTION
The example script given in the document will not work directly in Puhti, despite its description, nor will it work in Mahti. The allas_conf tool is located in a different path in both systems. The documentation does mention the correct paths, but the example script uses neither.

## Proposed changes

This commit changes the example script such that it will work in Puhti, as mentioned in the description, and instructs the user on how to make it work in Mahti.

## Checklist before requesting a review

- [X] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [X] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/allas-batch-example-script-fix/data/Allas/allas_batchjobs/)
