### PR TITLE
Added ssh host key fingerprints to docs/computing/connecting.md

### DIFF
--- a/docs/computing/connecting.md
+++ b/docs/computing/connecting.md
@@ -70,6 +70,34 @@ ssh -X yourcscusername@puhti.csc.fi
 In `PuTTY`, X11 forwarding is enabled in the connection settings (Connection -> SSH
 -> X11: Enable X11 forwarding).
 
+## First connection
+
+When connecting for the first time, the SSH client may notify you that the host is unknown
+and ask you to confirm the connection. With the OpenSSH client, e.g., this message looks like follows:
+```
+The authenticity of host 'puhti.csc.fi' can't be established.
+ECDSA key fingerprint is SHA256:kk0Tar9opQ+6Gq0GWJdWVVvFEMeI6kW1DW1VOYveT5c.
+Are you sure you want to continue connecting (yes/no/[fingerprint])?
+```
+In order to continue, you should confirm that the shown key fingerprint is one of those listed below
+and then enter `yes`. You will not be asked again unless the server key changes, in which case you
+should verify the new key.
+
+
+### Puhti key fingerprints
+| SHA256 checksum                             | Key                                |
+|---------------------------------------------|------------------------------------|
+| kk0Tar9opQ+6Gq0GWJdWVVvFEMeI6kW1DW1VOYveT5c | ssh_host_ecdsa_key.pub (ECDSA)     |
+| Q2lpykI43ffs4PrRODZ/qncjUo3eyrRHc5T9yjJEwWY | ssh_host_ed25519_key.pub (ED25519) |
+| WH1Ag2OQtMPZb+hj3YeH9uVMMetXpCvyNUbsdk0Qcpk | ssh_host_rsa_key.pub (RSA)         |
+
+### Mahti key fingerprints
+| SHA256 checksum                             | Key                                |
+|---------------------------------------------|------------------------------------|
+| WC9Lb5tmKDzUJqsQjaZLvp9T7LTs3aMUYSIy2OCdtgg | ssh_host_ecdsa_key.pub (ECDSA)     |
+| tE+1jA4Et1enbbat1V3dMRWlLtJgA8t7ZrkyIkU4ooo | ssh_host_ed25519_key.pub (ED25519) |
+| 0CxM3ECpD2LhAnMfHnm3YaXresvHrhW4cevvcPb+HNw | ssh_host_rsa_key.pub (RSA)         |
+
 ## Setting up SSH keys
 
 SSH keys provide more secure authentication and can be enabled with a two-step process:

--- a/docs/computing/connecting.md
+++ b/docs/computing/connecting.md
@@ -74,29 +74,33 @@ In `PuTTY`, X11 forwarding is enabled in the connection settings (Connection -> 
 
 When connecting for the first time, the SSH client may notify you that the host is unknown
 and ask you to confirm the connection. With the OpenSSH client, e.g., this message looks like follows:
+
 ```
 The authenticity of host 'puhti.csc.fi' can't be established.
 ECDSA key fingerprint is SHA256:kk0Tar9opQ+6Gq0GWJdWVVvFEMeI6kW1DW1VOYveT5c.
 Are you sure you want to continue connecting (yes/no/[fingerprint])?
 ```
+
 In order to continue, you should confirm that the shown key fingerprint is one of those listed below
 and then enter `yes`. You will not be asked again unless the server key changes, in which case you
-should verify the new key.
+should verify the new key against a fingerprint provided by CSC.
 
 
 ### Puhti key fingerprints
-| SHA256 checksum                             | Key                                |
-|---------------------------------------------|------------------------------------|
-| kk0Tar9opQ+6Gq0GWJdWVVvFEMeI6kW1DW1VOYveT5c | ssh_host_ecdsa_key.pub (ECDSA)     |
-| Q2lpykI43ffs4PrRODZ/qncjUo3eyrRHc5T9yjJEwWY | ssh_host_ed25519_key.pub (ED25519) |
-| WH1Ag2OQtMPZb+hj3YeH9uVMMetXpCvyNUbsdk0Qcpk | ssh_host_rsa_key.pub (RSA)         |
+
+=== | SHA256 checksum                             | Key                                |
+    |---------------------------------------------|------------------------------------|
+    | kk0Tar9opQ+6Gq0GWJdWVVvFEMeI6kW1DW1VOYveT5c | ssh_host_ecdsa_key.pub (ECDSA)     |
+    | Q2lpykI43ffs4PrRODZ/qncjUo3eyrRHc5T9yjJEwWY | ssh_host_ed25519_key.pub (ED25519) |
+    | WH1Ag2OQtMPZb+hj3YeH9uVMMetXpCvyNUbsdk0Qcpk | ssh_host_rsa_key.pub (RSA)         |
 
 ### Mahti key fingerprints
-| SHA256 checksum                             | Key                                |
-|---------------------------------------------|------------------------------------|
-| WC9Lb5tmKDzUJqsQjaZLvp9T7LTs3aMUYSIy2OCdtgg | ssh_host_ecdsa_key.pub (ECDSA)     |
-| tE+1jA4Et1enbbat1V3dMRWlLtJgA8t7ZrkyIkU4ooo | ssh_host_ed25519_key.pub (ED25519) |
-| 0CxM3ECpD2LhAnMfHnm3YaXresvHrhW4cevvcPb+HNw | ssh_host_rsa_key.pub (RSA)         |
+
+=== | SHA256 checksum                             | Key                                |
+    |---------------------------------------------|------------------------------------|
+    | WC9Lb5tmKDzUJqsQjaZLvp9T7LTs3aMUYSIy2OCdtgg | ssh_host_ecdsa_key.pub (ECDSA)     |
+    | tE+1jA4Et1enbbat1V3dMRWlLtJgA8t7ZrkyIkU4ooo | ssh_host_ed25519_key.pub (ED25519) |
+    | 0CxM3ECpD2LhAnMfHnm3YaXresvHrhW4cevvcPb+HNw | ssh_host_rsa_key.pub (RSA)         |
 
 ## Setting up SSH keys
 

--- a/docs/computing/connecting.md
+++ b/docs/computing/connecting.md
@@ -85,18 +85,17 @@ In order to continue, you should confirm that the shown key fingerprint is one o
 and then enter `yes`. You will not be asked again unless the server key changes, in which case you
 should verify the new key against a fingerprint provided by CSC.
 
+### Host key fingerprints
 
-### Puhti key fingerprints
-
-=== | SHA256 checksum                             | Key                                |
+=== "Puhti"
+    | SHA256 checksum                             | Key                                |
     |---------------------------------------------|------------------------------------|
     | kk0Tar9opQ+6Gq0GWJdWVVvFEMeI6kW1DW1VOYveT5c | ssh_host_ecdsa_key.pub (ECDSA)     |
     | Q2lpykI43ffs4PrRODZ/qncjUo3eyrRHc5T9yjJEwWY | ssh_host_ed25519_key.pub (ED25519) |
     | WH1Ag2OQtMPZb+hj3YeH9uVMMetXpCvyNUbsdk0Qcpk | ssh_host_rsa_key.pub (RSA)         |
 
-### Mahti key fingerprints
-
-=== | SHA256 checksum                             | Key                                |
+=== "Mahti"
+    | SHA256 checksum                             | Key                                |
     |---------------------------------------------|------------------------------------|
     | WC9Lb5tmKDzUJqsQjaZLvp9T7LTs3aMUYSIy2OCdtgg | ssh_host_ecdsa_key.pub (ECDSA)     |
     | tE+1jA4Et1enbbat1V3dMRWlLtJgA8t7ZrkyIkU4ooo | ssh_host_ed25519_key.pub (ED25519) |


### PR DESCRIPTION
## Proposed changes

Added ssh host key fingerprints to docs/computing/connecting.md.
These were previously buried in the What's new > Computing environment section and didn't show up in the search. Since users should verify these when prompted by SSH upon first connection (and when the key changes), it makes sense to include them on the page about Connecting.

Also added a brief note about needing to check the key and confirm the host upon first connection, which was a problem for a user in a recent RT ticket.
[preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/ssh-server-key-fingerprints/computing/connecting/) 

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
