### PR TITLE
add link from usage policy to autoremove info

### DIFF
--- a/docs/computing/usage-policy.md
+++ b/docs/computing/usage-policy.md
@@ -31,7 +31,9 @@ these rules will be terminated without warning.
 Each project has disk space in the directory `/scratch/<project>`. This fast
 parallel scratch space is intended for data that is in active use. To ensure
 that the parallel disk system does not run out of storage space and to keep
-performance acceptable CSC automatically removes files in scratch that have not
+performance acceptable,
+[CSC automatically removes files](../support/tutorials/clean-up-data.md#automatic-removal-of-files)
+in scratch that have not
 been accessed in a long time. The performance of a parallel file system starts
 to degrade when it fills up, and the more it fills up, the slower the performance
 will get.


### PR DESCRIPTION
## Proposed changes

Add link in "Disk cleaning" section of "Usage policy" which leads to "Automatic removal of files" in "Managing data on Puhti and Mahti scratch disks".

https://csc-guide-preview.2.rahtiapp.fi/origin/usage-policy-autoremove/computing/usage-policy/#disk-cleaning

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
