### PR TITLE
CentOS-7 / Centos-7-Cuda / CentOS-8-Stream images removed

### DIFF
--- a/docs/cloud/pouta/images.md
+++ b/docs/cloud/pouta/images.md
@@ -35,9 +35,6 @@ keep the additional packages at a minimum.
 
 |Image|Username|Modified <br/>|
 |--- |:---:|:---:|
-|CentOS-7        |cloud-user     |yes |
-|CentOS-7-cuda   |cloud-user     |yes |
-|CentOS-8-Stream |**centos**     |no  |
 |CentOS-9-Stream |**cloud-user** |no  |
 |AlmaLinux-8     |**almalinux**  |no  |
 |AlmaLinux-9     |**almalinux**  |no  |
@@ -46,41 +43,24 @@ keep the additional packages at a minimum.
 |Ubuntu-22.04    |**ubuntu**     |no  |
 |Ubuntu-24.04    |**ubuntu**     |no  |
 
-### CentOS-7
-CentOS is the community version of Red Hat Enterprise Linux (RHEL). CentOS-7
-is the distribution that the Pouta admins are the most accustomed to. 
-This is the second-newest major release of CentOS.
+### CentOS-9-Stream
 
-### CentOS-7-Cuda
-This is the same as CentOS-7 but comes with preinstalled NVIDIA drivers.
-These are useful in combination with the GPU flavors since you do not need
-to download the drivers yourself. We try to always have the latest NVIDIA
-drivers installed, but sometimes we are lagging a bit behind. These images
-are huge, so you should use the normal CentOS-7 image if you are not
-using a GPU-flavor VM.
-
-### CentOS-8-Stream and CentOS-9-Stream
-
-While CentOS-7 is still actively supported, [CentOS-8 has been declared end-of-life in December 2021](https://www.centos.org/centos-linux-eol/).
-The CentOS community is now actively maintaining CentOS-8-Stream and
-CentOS-9-Stream instead. The key differences lay in the relationship between
+The CentOS community is now actively maintaining CentOS-9-Stream. The key differences lay in the relationship between
 CentOS and RHEL, especially in how changes, i.e., new packages and updates,
 are deployed:
 
-* with CentOS-7 RHEL is the upstream branch for CentOS, i.e., changes are first
-deployed for RHEL and then for CentOS
-* with CentOS-8-Stream or CentOS-9-Stream, CentOS is the upstream branch for
+* with CentOS-9-Stream, CentOS is the upstream branch for
 RHEL, i.e., changes are first deployed for CentOS and then for RHEL
 
 The resulting operating system is thus possibly less stable compared to its
 previous version. The CentOS community [emphasizes](https://blog.centos.org/2020/12/future-is-centos-stream/)
 that the Stream version is nevertheless extremely close in terms of stability
 to the corresponding RHEL version and thus recommends using it as a replacement
-for CentOS-8.
+for CentOS-9.
 
 Note that this is the upstream version of the image, i.e., we do not perform
 any change to the image before making it available on our services. The default
-username is `centos` for CentOS-8-Stream and `cloud-user` for
+username is `cloud-user` for
 CentOS-9-Stream.
 
 ### AlmaLinux-8 and AlmaLinux-9

--- a/docs/cloud/pouta/images.md
+++ b/docs/cloud/pouta/images.md
@@ -46,6 +46,7 @@ keep the additional packages at a minimum.
 ### CentOS-9-Stream
 
 The CentOS community is now actively maintaining CentOS-9-Stream, which is the upstream branch for RHEL.
+Given that updates and changes are first tested in CentOS and only subsequently deployed for Red Hat Enterprise Linux (RHEL), the resulting operating system is possibly less stable compared to its previous version, i.e., when RHEL was the upstream for CentOS.
 The CentOS community [emphasizes](https://blog.centos.org/2020/12/future-is-centos-stream/)
 that the Stream version is nevertheless extremely close in terms of stability
 to the corresponding RHEL version.

--- a/docs/cloud/pouta/images.md
+++ b/docs/cloud/pouta/images.md
@@ -46,11 +46,9 @@ keep the additional packages at a minimum.
 ### CentOS-9-Stream
 
 The CentOS community is now actively maintaining CentOS-9-Stream, which is the upstream branch for RHEL.
-
 The CentOS community [emphasizes](https://blog.centos.org/2020/12/future-is-centos-stream/)
 that the Stream version is nevertheless extremely close in terms of stability
 to the corresponding RHEL version.
-
 Note that this is the upstream version of the image, i.e., we do not perform
 any change to the image before making it available on our services. The default
 username is `cloud-user`.

--- a/docs/cloud/pouta/images.md
+++ b/docs/cloud/pouta/images.md
@@ -45,23 +45,15 @@ keep the additional packages at a minimum.
 
 ### CentOS-9-Stream
 
-The CentOS community is now actively maintaining CentOS-9-Stream. The key differences lay in the relationship between
-CentOS and RHEL, especially in how changes, i.e., new packages and updates,
-are deployed:
+The CentOS community is now actively maintaining CentOS-9-Stream, which is the upstream branch for RHEL.
 
-* with CentOS-9-Stream, CentOS is the upstream branch for
-RHEL, i.e., changes are first deployed for CentOS and then for RHEL
-
-The resulting operating system is thus possibly less stable compared to its
-previous version. The CentOS community [emphasizes](https://blog.centos.org/2020/12/future-is-centos-stream/)
+The CentOS community [emphasizes](https://blog.centos.org/2020/12/future-is-centos-stream/)
 that the Stream version is nevertheless extremely close in terms of stability
-to the corresponding RHEL version and thus recommends using it as a replacement
-for CentOS-9.
+to the corresponding RHEL version.
 
 Note that this is the upstream version of the image, i.e., we do not perform
 any change to the image before making it available on our services. The default
-username is `cloud-user` for
-CentOS-9-Stream.
+username is `cloud-user`.
 
 ### AlmaLinux-8 and AlmaLinux-9
 


### PR DESCRIPTION
entOS-7 / Centos-7-Cuda / CentOS-8-Stream images are now disabled and therefore removed from the documentations

https://csc-guide-preview.2.rahtiapp.fi/origin/DeRuina-patch-1/cloud/pouta/images/

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
