### PR TITLE
renamed to Using Rahti 2 integrated registry and moved under /images

### DIFF
--- a/docs/cloud/rahti/usage/cli.md
+++ b/docs/cloud/rahti/usage/cli.md
@@ -73,7 +73,7 @@ docker login -p $(oc sa get-token pusher) -u unused docker-registry.rahti.csc.fi
 
 This service account token, the one you get with `oc sa get-token pusher` does not expire.
 
-Checkout this documentation to know how to upload images: [How to manually cache images in Rahti 1 registry](../../rahti2/images/Using_Rahti_2_integrated_registry.md)
+Checkout this documentation to know how to upload images: [Using Rahti 2 integrated registry](../../rahti2/images/Using_Rahti_2_integrated_registry.md)
 
 ## CLI cheat sheet
 

--- a/docs/cloud/rahti/usage/cli.md
+++ b/docs/cloud/rahti/usage/cli.md
@@ -73,7 +73,7 @@ docker login -p $(oc sa get-token pusher) -u unused docker-registry.rahti.csc.fi
 
 This service account token, the one you get with `oc sa get-token pusher` does not expire.
 
-Checkout this documentation to know how to upload images: [How to manually cache images in Rahti 1 registry](../../tutorials/docker_hub_manual_caching.md)
+Checkout this documentation to know how to upload images: [How to manually cache images in Rahti 1 registry](../../rahti2/images/Using_Rahti_2_integrated_registry.md)
 
 ## CLI cheat sheet
 

--- a/docs/cloud/rahti2/images/Using_Rahti_2_integrated_registry.md
+++ b/docs/cloud/rahti2/images/Using_Rahti_2_integrated_registry.md
@@ -5,7 +5,7 @@ an external dependency or improve performance.
 
 The process is simple:
 
-1. [Install](../../rahti2/usage/cli/#how-to-install-the-oc-tool) and [login with OC](../../rahti2/usage/cli/#how-to-login-with-oc).
+1. [Install](../../usage/cli/#how-to-install-the-oc-tool) and [login with OC](../../usage/cli/#how-to-login-with-oc).
 
 1. With a terminal, connect to the Rahti 2 registry:
     ```sh

--- a/docs/cloud/rahti2/images/Using_Rahti_2_integrated_registry.md
+++ b/docs/cloud/rahti2/images/Using_Rahti_2_integrated_registry.md
@@ -1,4 +1,4 @@
-# How to manually cache images in Rahti 2
+# Using Rahti 2 integrated registry
 
 It is possible to manually cache images in Rahti 2. This could be useful to remove
 an external dependency or improve performance.
@@ -27,15 +27,15 @@ The process is simple:
    ```
 
 You should be able to see your images in your project:
-![Image Streams](../img/image_streams_rahti4.png)
+![Image Streams](../../img/image_streams_rahti4.png)
 
 ## Use the image
 
 Go to your project's deployment, and edit it.
 
-![Edit deployment](../img/edit_deployment.png)
+![Edit deployment](../../img/edit_deployment.png)
 
 Go to the Images section, make sure the option "Deploy images from an image stream tag" is clicked.
 Finally select the new image.
 
-![Use cached image](../img/use_cached_image.png)
+![Use cached image](../../img/use_cached_image.png)

--- a/docs/cloud/rahti2/storage/objectstorage.md
+++ b/docs/cloud/rahti2/storage/objectstorage.md
@@ -21,7 +21,7 @@ FROM nginx:stable
 
 ENV LISTEN_PORT=8080
 
-# support running as arbitrary user which belogs to the root group
+# support running as arbitrary user which belongs to the root group
 RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
 
 # users are not allowed to listen on privileged ports
@@ -33,7 +33,7 @@ RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf
 EXPOSE 8080
 ```
 
-If you build your image locally, don't forget to [push](../../tutorials/docker_hub_manual_caching.md) it to your project.  
+If you build your image locally, don't forget to [push](../../rahti2/images/Using_Rahti_2_integrated_registry.md) it to your project.  
 You can deploy this `nginx` server with this Deployment:
 
 ```yaml
@@ -162,7 +162,7 @@ COPY rclone.sh /usr/local/bin/
 RUN chmod 755 /.rclone.conf
 RUN chmod +x /usr/local/bin/rclone.sh
 ```
-If you create your image locally, don't forget to [push](../../tutorials/docker_hub_manual_caching.md) it to your project.  
+If you create your image locally, don't forget to [push](../../rahti2/images/Using_Rahti_2_integrated_registry.md) it to your project.  
 
 Once all this done, you can deploy your `rclone` pod.
 You can use this example:

--- a/docs/cloud/tutorials/index.md
+++ b/docs/cloud/tutorials/index.md
@@ -8,7 +8,6 @@
 * [How to add docker hub credentials to a project](docker_hub_login.md)
 * [How to automatically scale up and down replicas](addHorizontalAutoscaler.md)
 * [How to backup a Postgres DB into Allas](backup-postgres-allas.md)
-* [How to manually cache images in Rahti 2's registry](docker_hub_manual_caching.md)
 * [How to package a Kubernetes application with Helm](helm.md)
 * [How to run an ad-hoc interactive container](oc-run.md)
 * [How to transfer data to Rahti 2?](transfer_data_rahti.md)

--- a/docs/support/faq/get-image-format.md
+++ b/docs/support/faq/get-image-format.md
@@ -35,7 +35,7 @@ When an old client is used to try to pull an image with the newer format, the cl
 
 ## Workarounds
 
-* A trivial fix is to pull the image using a compatible client, re-tag it, and push it to Rahti's internal registry. This newly pushed image will be using the old docker format. Follow the link for a guide on [How to manually cache images in Rahti's registry](../../../cloud/tutorials/docker_hub_manual_caching/).
+* A trivial fix is to pull the image using a compatible client, re-tag it, and push it to Rahti's internal registry. This newly pushed image will be using the old docker format. Follow the link for a guide on [How to manually cache images in Rahti's registry](../../../cloud/rahti2/images/Using_Rahti_2_integrated_registry).
 
 * If the image was built by your team, the [buildah](https://buildah.io) tool can be used. It allows to build docker images without the extra privileges the `docker build` requires, and even though by default it will build an image using the `OCI` format, it has an option to use the `docker` format instead:
 

--- a/docs/support/tutorials/index.md
+++ b/docs/support/tutorials/index.md
@@ -83,7 +83,7 @@
 * [Deploying a static web server using the command line](../../cloud/tutorials/elemental_tutorial.md)
 * [Deploying a static web server using the web interface](../../cloud/tutorials/basic-console.md)
 * [How to add docker hub credentials to a project](../../cloud/tutorials/docker_hub_login.md)
-* [How to manually cache images in Rahti's registry](../../cloud/tutorials/docker_hub_manual_caching.md)
+* [How to manually cache images in Rahti's registry](../../cloud/rahti2/images/Using_Rahti_2_integrated_registry.md)
 * [How to package a Kubernetes application with Helm?](../../cloud/tutorials/helm.md)
 * [How to transfer data to Rahti?](../../cloud/tutorials/transfer_data_rahti.md)
 * [Reverse proxy authentication using a sidecar container](../../cloud/tutorials/sidecar_proxy_authentication.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -302,6 +302,7 @@ nav:
            - cloud/rahti2/images/overview.md
            - Creating an image: cloud/rahti2/images/creating.md
            - Keeping docker images small: cloud/rahti2/images/keeping_docker_images_small.md
+           - Using Rahti 2 integrated registry: cloud/rahti2/images/Using_Rahti_2_integrated_registry.md
         - Rahti Catalog: cloud/rahti2/catalog-docs.md
         - Projects and quota: cloud/rahti2/usage/projects_and_quota.md
         - Billing: cloud/rahti2/billing.md


### PR DESCRIPTION
## Proposed changes
Renamed `How to manually cache images in Rahti 2's registry` to `Using Rahti 2 integrated registry`, Moved it under `rahti2/images/` and fixed all the links pointing to it.

## Preview

https://csc-guide-preview.2.rahtiapp.fi/origin/Using_Rahti_2_integrated_registry/cloud/rahti2/images/Using_Rahti_2_integrated_registry/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
