### PR TITLE
Added video links to sensitive data -pages

### DIFF
--- a/docs/data/sensitive-data/findata-permit.md
+++ b/docs/data/sensitive-data/findata-permit.md
@@ -1,5 +1,6 @@
 # Accessing SD Desktop with a Findata permit
 
+<iframe width="280" height="155" srcdoc="https://www.youtube.com/embed/idK2iI9rTQw" title="SD Desktop toisiokäyttötarkoitukseen — käsittelyluvan myöntäjänä Findata" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 **[Instructions in Finnish (PDF)](https://a3s.fi/docs-files/sensitive-data/PDF_instructions/SD_toisiolaki_Findata.pdf){ target="_blank" }**
 

--- a/docs/data/sensitive-data/sd-desktop-manage.md
+++ b/docs/data/sensitive-data/sd-desktop-manage.md
@@ -1,5 +1,7 @@
 # Managing volumes and virtual desktops
 
+<iframe width="280" height="155" srcdoc="https://www.youtube.com/embed/rYpuUwm8LhQ" title="Manage virtual desktops in the SD Desktop service" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 With the SD Desktop service, you can easily manage volumes and pause, reboot or delete your virtual desktops. Below we illustrate the main available options. 
 
 !!! Note

--- a/docs/data/sensitive-data/single-register-permit.md
+++ b/docs/data/sensitive-data/single-register-permit.md
@@ -1,5 +1,7 @@
 # Accessing the service with a permit from a single register
 
+<iframe width="280" height="155" srcdoc="https://www.youtube.com/embed/bMaBl0IED74" title="SD Desktop toisiokäyttötarkoitukseen — käsittelyluvan myöntäjänä yksittäinen rekisteri" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 **[Instructions in Finnish (PDF)](https://a3s.fi/docs-files/sensitive-data/PDF_instructions/SD_toisiolaki_yksittainenRekisteri.pdf){ target="_blank" }**
 
 These instructions are for researchers who have received a permit for the secondary use of social and health data **directly from a single public register**. In other words, the permit is not from Findata, and **the permit is issued for SD Desktop**.


### PR DESCRIPTION
## Proposed changes

I added links for instructional videos on the Manage virtual desktop, Access with Findata permit and Access with register permit -pages.

Preview links:
- Single register page: https://csc-guide-preview.rahtiapp.fi/origin/mk-videolinks/data/sensitive-data/single-register-permit/
- Findata page: https://csc-guide-preview.rahtiapp.fi/origin/mk-videolinks/data/sensitive-data/findata-permit/
- Manage virtual page: https://csc-guide-preview.rahtiapp.fi/origin/mk-videolinks/data/sensitive-data/sd-desktop-manage/


## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
