### PR TITLE
Update linux course links

### DIFF
--- a/docs/support/faq/how-to-get-started-at-CSC.md
+++ b/docs/support/faq/how-to-get-started-at-CSC.md
@@ -1,15 +1,16 @@
-#How to get started as a new user at CSC?
+# How to get started as a new user at CSC?
 
 You are now browsing through our service guides.
-We have collected some useful material in the following locations:
+We have collected some useful materials in the following locations:
 
-* [Registering as a CSC customer](https://research.csc.fi/accounts-and-projects)
-* [Get started at CSC -collection page](https://research.csc.fi/get-started)
-* [Services for research](https://research.csc.fi/home)
+* [CSC accounts and projects](../../accounts/index.md)
+* [CSC customer portal My CSC](https://my.csc.fi)
+* [Free-of-charge use cases](https://research.csc.fi/free-of-charge-use-cases)
+* [Services for research](https://research.csc.fi)
 * [Services by discipline](https://research.csc.fi/sciences)
 * [Tutorials](../../support/tutorials/index.md)
 * [Frequently Asked Questions](index.md)
-* [Contact us](../../support/contact.md)
-* [Collection of training materials](https://research.csc.fi/en/web/training/materials)
+* [Collection of training materials](../training-material.md)
+* [CSC training calendar](https://csc.fi/en/trainings/training-calendar/)
 
-Direct support from CSC Servicedesk: send email to servicedesk (at) csc.fi
+Need direct support? [Contact CSC Service Desk](../contact.md)!

--- a/docs/support/training-material.md
+++ b/docs/support/training-material.md
@@ -8,10 +8,9 @@ and platforms by CSC and partners!
 
 ## Linux & HPC basics
 
-* [Linux 101 tutorial](tutorials/env-guide/index.md)
-* [Linux 1: Introduction to Linux course material](https://research.csc.fi/en/web/training/-/linux1_autumn2018)
-* [Linux 2: Intermediate Linux course materials](https://research.csc.fi/en/web/training/-/linux-2-november-2018)
-* [Linux 3: Scripting course material](https://research.csc.fi/en/web/training/-/linux3_spring_2019)
+* [Linux 101 guide](tutorials/env-guide/index.md)
+* [Linux 1: Introduction to Linux course material](https://e-learn.csc.fi/course/view.php?id=35)
+* [Linux 2: Intermediate Linux course materials](https://e-learn.csc.fi/course/view.php?id=45)
 * [MPI: A Short Introduction to One-sided Communication](https://www.futurelearn.com/courses/mpi-one-sided) PRACE MOOC
 * [Using CSC HPC Environment Efficiently](https://a3s.fi/CSC_training/csc-env.html) Slides, tutorials and exercises about the CSC environment
 * [HPC Glossary](glossary.md) All of the tooltipped acronyms (such as "HPC") as a single page.

--- a/docs/support/training-material.md
+++ b/docs/support/training-material.md
@@ -9,8 +9,8 @@ and platforms by CSC and partners!
 ## Linux & HPC basics
 
 * [Linux 101 guide](tutorials/env-guide/index.md)
-* [Linux 1: Introduction to Linux course material](https://e-learn.csc.fi/course/view.php?id=35)
-* [Linux 2: Intermediate Linux course materials](https://e-learn.csc.fi/course/view.php?id=45)
+* [Linux 1: Introduction to Linux course material (GitHub source)](https://github.com/csc-training/linux-1) and [related lecture videos](https://video.csc.fi/channel/Introduction+to+Linux+-course/514985)
+* [Linux 2: Intermediate Linux course materials (GitHub source)](https://github.com/csc-training/linux-2)
 * [MPI: A Short Introduction to One-sided Communication](https://www.futurelearn.com/courses/mpi-one-sided) PRACE MOOC
 * [Using CSC HPC Environment Efficiently](https://a3s.fi/CSC_training/csc-env.html) Slides, tutorials and exercises about the CSC environment
 * [HPC Glossary](glossary.md) All of the tooltipped acronyms (such as "HPC") as a single page.

--- a/docs/support/training-material.md
+++ b/docs/support/training-material.md
@@ -62,7 +62,6 @@ and platforms by CSC and partners!
 
 * [Fairdata service training material](https://www.fairdata.fi/en/training/materials/)
 * [Data management checklist](https://www.fairdata.fi/en/why-fairdata/data-management-checklist/) find tips on how to take care of your research data.
-* [Remote training day for the Universities of the Applied Sciences](https://research.csc.fi/en/web/training/-/csc-tki-toiminnan-tukena) 18th May (in Finnish)
 
 ## Training materials and sources from CSC and partners
 


### PR DESCRIPTION
Link to updated page preview: https://csc-guide-preview.rahtiapp.fi/origin/fix-old-coursematerial-links/support/training-material/

Linux 1 and 2 linked to research.csc.fi pages, which didn't link anywhere. Replaced these with elena links. These can be a bit confusing. An alternative would be to link to github source directly. Deleted linux-3 as I didn't find a replacement.

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
