### PR TITLE
Change shebang to eliminate error. 

### DIFF
--- a/scripts/generate_glossary.sh
+++ b/scripts/generate_glossary.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 source_dir="csc-overrides/assets/snippets/glossaries"
 glossary_dir="docs/support"
 generated_file="$glossary_dir/glossary.md"


### PR DESCRIPTION
sh does not support the regexp, bash does.

## Proposed changes

```
scripts/generate_glossary.sh: 16: Bad substitution
```

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/bad-sustitution/support/glossary/) of your branch.

## Checklist before requesting a review

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/bad-sustitution/support/glossary/) (select your branch from the list).
