### PR TITLE
Use Travis CI's Python environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,12 @@ addons:
     packages:
       - aspell
       - aspell-en
-      - python3
-      - python3-pip
-      - python3-setuptools
+language: python
+python:
+  - "3.11"
 before_install:
-  - pip3 install --user wheel
-  - pip3 install --user --requirement requirements.txt
   - curl -L https://git.io/misspell | BINDIR=~/.local/bin sh
-install:
-#  - pip install --upgrade pip
+  - python -m pip install --upgrade pip
 script:
 
   # Checks all files for commonly misspelled English words with client9's misspell

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
   - "3.11"
 before_install:
   - curl -L https://git.io/misspell | BINDIR=~/.local/bin sh
-  - python -m pip install --upgrade pip
 script:
 
   # Checks all files for commonly misspelled English words with client9's misspell


### PR DESCRIPTION
## Proposed changes

There was a problem with pip on Travis CI (perhaps due to Travis updating their Jammy image?).
  - [example of errored build on Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/builds/273221722)
  - [travisci/ci-ubuntu-2204 - Docker Image | Docker Hub](https://hub.docker.com/r/travisci/ci-ubuntu-2204)

Build of 7a79562&mdash;fix seems to have worked: https://app.travis-ci.com/github/CSCfi/csc-user-guide/builds/273225575
Nothing should have changed with Docs itself: https://csc-guide-preview.2.rahtiapp.fi/origin/travis-config/
