### PR TITLE
Added new versions to GDAL and PDAL pages

### DIFF
--- a/docs/apps/gdal.md
+++ b/docs/apps/gdal.md
@@ -11,7 +11,7 @@ tags:
 
 GDAL is available with following versions:
 
-* 3.9.2 - in the 3.38 [QGIS](qgis.md) in Puhti
+* 3.9.2 - in the 3.38 [QGIS](qgis.md) and 3.11.10 [geoconda](geoconda.md) in Puhti
 * 3.9.1 - in the 3.11.9 [geoconda](geoconda.md) in Puhti and Mahti
 * 3.8.5 stand-alone: `gdal` in Puhti
 * 3.8.3 - in the 3.31 [QGIS](qgis.md) in Puhti and LUMI

--- a/docs/apps/pdal.md
+++ b/docs/apps/pdal.md
@@ -11,6 +11,7 @@ tags:
 
 PDAL is available in the following versions:
 
+* 2.8.0 - [geoconda-3.11.10 module](geoconda.md) with pdal Python library, in Puhti
 * 2.7.2 - [QGIS-3.38 module](qgis.md) without pdal Python library, but with [pdal_wrench](https://github.com/PDAL/wrench), in Puhti
 * 2.7.2 - [geoconda-3.11.9 module](geoconda.md) with pdal Python library, in Puhti and Mahti
 * 2.6.2 - [QGIS-3.34 module](qgis.md) without pdal Python library, but with [pdal_wrench](https://github.com/PDAL/wrench), in Puhti


### PR DESCRIPTION
## Proposed changes

Forgot to add the new versions of GDAL and PDAL that came with the new geoconda package. Added now.
https://csc-guide-preview.2.rahtiapp.fi/origin/ehuusko-geoconda/apps/gdal/
https://csc-guide-preview.2.rahtiapp.fi/origin/ehuusko-geoconda/apps/pdal/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
