### PR TITLE
Maestro old license manager deprecation note

### DIFF
--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -33,6 +33,19 @@ Specifically, this means that module versions older than two years will be remov
 This policy is enforced to free up disk space and encourage use of the latest versions
 which tend to be more performant and have less bugs.
 
+!!! info "Maestro versions older than 2023.1 will not work after 13.3.2025!"
+    Schrödinger has taken into use a
+    [new license manager](https://www.schrodinger.com/life-science/learn/white-paper/new-schrodinger-license-manager/),
+    which does not support Maestro versions older than 2023.1. Consequently,
+    **CSC's will no longer be able to provide a license for Maestro versions
+    2022.4 and older after 13th of March 2025**. If not done already, please
+    migrate to using versions 2023.1 or later as soon as possible!
+
+    Please note that CSC's Schrödinger Maestro
+    [license configuration instructions](https://wiki.eduuni.fi/pages/viewpage.action?pageId=130528861)
+    have also been updated accordingly.
+    [See more details below](#local-installation).
+
 !!! info "Some notes about warnings"
     Maestro gives a warning for using a `schrodinger.hosts` file from your home
     directory. This is **not an issue**: that file cannot be made available in
@@ -57,12 +70,6 @@ us via [ServiceDesk](/support/contact/).
 It is recommended to download and install Maestro on your own computer, see below.
 
 ### Local installation
-
-!!! info "Maestro versions 2024.3 onward use a new license manager"
-    Please note that the
-    [license configuration instructions](https://wiki.eduuni.fi/pages/viewpage.action?pageId=130528861)
-    have been updated for Maestro versions 2024.3 and later, which use the new
-    Schrödinger License Manager (SLM).
 
 Maestro can be installed on a Linux, Mac or Windows computer. Download the
 appropriate files from [the Schrödinger website](https://www.schrodinger.com/).

--- a/docs/support/tutorials/power-maestro.md
+++ b/docs/support/tutorials/power-maestro.md
@@ -354,21 +354,6 @@ You can check the currently available licenses (tokens) with:
 $SCHRODINGER/run lictool status
 ```
 
-!!! info "Note for older Maestro versions"
-    If you are using Maestro version 2024.2 or older, the above command will
-    not work. In this case, you can check the currently available licenses
-    (tokens) with:
-
-    ```bash
-    $SCHRODINGER/utilities/licutil -avail
-    ```
-
-    and currently used licenses (tokens) with:
-
-    ```bash
-    $SCHRODINGER/utilities/licutil -used
-    ```
-
 Note that some Maestro tools or workflows use multiple modules and hence licenses
 or tokens from multiple modules. Typically, one running instance of a module (a job or
 a subjob) requires several tokens. For example, Desmond and Glide jobs take 8 tokens each.

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,15 @@
 # Applications
 
+## Maestro versions older than 2023.1 will not work after 13.3.2025
+
+Schrödinger has taken into use a
+[new license manager](https://www.schrodinger.com/life-science/learn/white-paper/new-schrodinger-license-manager/),
+which does not support Maestro versions older than 2023.1. Consequently, **CSC
+will no longer be able to provide a license for Maestro versions 2022.4 and
+older after 13th of March 2025**. If not done already, please migrate to using
+versions 2023.1 or later as soon as possible! See our Maestro page for details on
+[how to configure licensing for your local Maestro installation](../../apps/maestro.md#local-installation).
+
 ## GROMACS 2024.4, 7.11.2024
 
 [GROMACS](../../apps/gromacs.md) 2024.4 is now available on Puhti, Mahti and LUMI.


### PR DESCRIPTION
## Proposed changes

https://csc-guide-preview.2.rahtiapp.fi/origin/deprecate-maestro-flexlm/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
