### PR TITLE
Add PyTorch 2.5.1 for Puhti and Mahti

### DIFF
--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -9,6 +9,8 @@ tags:
 Machine learning framework for Python.
 
 !!! info "News" 
+    **17.12.2024** PyTorch 2.5.1 added to Puhti and Mahti. Includes vLLM
+    and FAISS among many other updates.
 
     **19.9.2024** PyTorch 2.4.1 with ROCm 6.1 added to LUMI. The LUMI
     PyTorch module now includes [vLLM version
@@ -65,6 +67,7 @@ Currently supported PyTorch versions:
 
 | Version | Module         | Puhti | Mahti | LUMI | Notes                      |
 |:--------|----------------|:-----:|:-----:|------|:---------------------------|
+| 2.5.1   | `pytorch/2.5`  | X     | X     | -    | New tykky-based wrappers   |
 | 2.4.1   | `pytorch/2.4`  | -     | -     | X    | default version            |
 | 2.4.0   | `pytorch/2.4`  | X     | X     | -    | New tykky-based wrappers   |
 | 2.3.1   | `pytorch/2.3`  | X     | X     | -    | New tykky-based wrappers   |


### PR DESCRIPTION
## Proposed changes

Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/pytorch-2.5/apps/pytorch/

No news yet, I will make news when LUMI version is also available.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
