### PR TITLE
Show commit SHA in preview

### DIFF
--- a/csc-overrides/partials/footer.html
+++ b/csc-overrides/partials/footer.html
@@ -51,6 +51,11 @@
   <div class="md-footer-meta md-typeset">
     <div class="md-footer-meta__inner md-grid">
       {% include "partials/copyright.html" %}
+      {% if page and page.meta and page.meta["head_sha"] %}
+          <pre style="color: pink;
+                      font-size: small;"
+          >commit {{ page.meta["head_sha"] | string }}</pre>
+      {% endif %}
       {% if config.extra.social %}
         {% include "partials/social.html" %}
       {% endif %}

--- a/hooks/preview.py
+++ b/hooks/preview.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from git import Repo
+from mkdocs.plugins import get_plugin_logger
+
+
+class PreviewHook:
+    MKDOCS_HOOK_NAME = "preview-hook"
+    ENVIRONMENT_KEY = "environment"
+    PREVIEW_ENVIRONMENT = "preview"
+
+    def __init__(self):
+      self.environment = None
+      self.startup_command = None
+      self.logger = get_plugin_logger(self.MKDOCS_HOOK_NAME)
+      self.head_sha = Repo(Path.cwd()).head.commit.hexsha
+
+    @property
+    def is_preview_build(self):
+        return self.environment == self.PREVIEW_ENVIRONMENT and \
+               self.startup_command == "build"
+
+    def on_startup(self, command, dirty):
+      self.startup_command = command
+      return None
+
+    def on_config(self, config):
+        self.environment = config.extra[self.ENVIRONMENT_KEY]
+        if self.is_preview_build:
+            self.logger.info(f"preview build, commit {self.head_sha}")
+        return None
+
+    def on_page_markdown(self, markdown, page, config, files):
+      if self.is_preview_build:
+          page.meta["head_sha"] = self.head_sha
+      return None
+
+
+hook = PreviewHook()
+on_startup = hook.on_startup
+on_config = hook.on_config
+on_page_markdown = hook.on_page_markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ extra:
 
 hooks:
   - hooks/archives.py
+  - hooks/preview.py
 
 plugins:
   - tags:


### PR DESCRIPTION
## Proposed changes

Show the Git HEAD commit SHA at the bottom of the footer when building in Preview. No more guessing whether your changes are not showing up in preview because a build has stalled/failed.

![image](https://github.com/user-attachments/assets/2a0d9c13-1ea2-4450-8207-f42e62102bab)

https://csc-guide-preview.2.rahtiapp.fi/origin/show-commit-in-preview/


## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
