### PR TITLE
Remove unused apt packages from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 ---
 os: linux
 dist: jammy
-addons:
-  apt:
-    packages:
-      - aspell
-      - aspell-en
 language: python
 python:
   - "3.11"


### PR DESCRIPTION
## Proposed changes

Remove 'aspell' from Travis build as it's not used.