### PR TITLE
Changes for Puhti web interface R24 and Mahti web interface R10

### DIFF
--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,6 +1,6 @@
 # Computing environment
 
-## Puhti and Mahti web interfaces updated to release 24 and 10, 29.1.2025
+## Puhti and Mahti web interfaces updated to release 24 and 10, 30.1.2025
 
 * VSCode has been updated to 1.96.4.
 * The accessibility statement contact info has been updated.

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,12 @@
 # Computing environment
 
+## Puhti and Mahti web interfaces updated to release 24 and 10, 29.1.2025
+
+* VSCode has been updated to 1.96.4.
+* The accessibility statement contact info has been updated.
+* MLflow now works with when using NVME again.
+* Open OnDemand updated to version 3.1.10.
+
 ## Puhti and Mahti web interfaces updated to release 23 and 9, 23.10.2024
 
 * MLflow, Tensorboard, and the Desktop app now work with newer Apptainer.


### PR DESCRIPTION
Adds the change log for Puhti web interface R24 and Mahti web interface R10.

https://csc-guide-preview.rahtiapp.fi/origin/wwwpuhti-r24-wwwmahti-r10/
