### PR TITLE
Maestro 2025.1

### DIFF
--- a/csc-overrides/partials/announcement.html
+++ b/csc-overrides/partials/announcement.html
@@ -1,6 +1,6 @@
 {# Put the announcement, in HTML, right under this comment! #}
 <p>
-&#128295; No, it's not just you! The navigation sidebars <em>do</em> have a new look. <a href="/support/wn/training-new/#visual-changes-for-docs-csc">Click here for details.</a> &#128295;
+&#128295; Due to licensing changes, Schrödinger Maestro versions older than 2023.1 will no longer work at CSC after 13.3.2025! <a href="/support/wn/training-new/#visual-changes-for-docs-csc">Click here for details.</a> &#128295;
 </p>
 {# Remember
   - to set the announcement_visible to true in mkdocs.yml

--- a/csc-overrides/partials/announcement.html
+++ b/csc-overrides/partials/announcement.html
@@ -1,6 +1,6 @@
 {# Put the announcement, in HTML, right under this comment! #}
 <p>
-&#128295; Due to licensing changes, Schrödinger Maestro versions older than 2023.1 will no longer work at CSC after 13.3.2025! <a href="/support/wn/training-new/#visual-changes-for-docs-csc">Click here for details.</a> &#128295;
+&#128227; Due to licensing changes, <a href="/apps/maestro/">Schrödinger Maestro</a> versions older than 2023.1 will no longer work at CSC after 13.3.2025! <a href="/support/wn/apps-new/#maestro-versions-older-than-20231-will-not-work-after-1332025">Click here for details.</a> &#128227;
 </p>
 {# Remember
   - to set the announcement_visible to true in mkdocs.yml

--- a/docs/apps/maestro.md
+++ b/docs/apps/maestro.md
@@ -25,8 +25,8 @@ self-learning materials.
 
 ## Available
 
-* Puhti: 2023.1, 2023.2, 2023.3, 2023.4, 2024.1, 2024.2, 2024.3, 2024.4
-* Mahti: 2023.1, 2023.2, 2023.3, 2023.4, 2024.1, 2024.2, 2024.3, 2024.4
+* Puhti: 2023.2, 2023.3, 2023.4, 2024.1, 2024.2, 2024.3, 2024.4, 2025.1
+* Mahti: 2023.2, 2023.3, 2023.4, 2024.1, 2024.2, 2024.3, 2024.4, 2025.1
 
 A two-year cleaning cycle is applied on the Maestro modules on CSC supercomputers.
 Specifically, this means that module versions older than two years will be removed.

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,12 @@
 # Applications
 
+## Schrödinger Maestro 2025.1, 6.2.2025
+
+[Schrödinger Maestro](../../apps/maestro.md) version 2025.1 has been installed
+and set as the default module on Puhti and Mahti. See
+[release notes](https://www.schrodinger.com/life-science/download/release-notes/)
+for a list of new features and improvements.
+
 ## Molpro 2024.3 is available on Puhti and Mahti, 3.2.2025
 
 Molpro has been updated to version [2024.3](../../apps/molpro.md). Previously available only on Puhti, this latest version is now also on Mahti. See the [Recent changes](https://www.molpro.net/manual/doku.php?id=recent_changes) for details on new features, bug fixes, and improvements.
@@ -15,7 +22,7 @@ information](../../apps/pytorch.md#available).
 
 Schrödinger has taken into use a
 [new license manager](https://www.schrodinger.com/life-science/learn/white-paper/new-schrodinger-license-manager/),
-which does not support Maestro versions older than 2023.1. Consequently, **CSC
+which does not support [Maestro](../../apps/maestro.md) versions older than 2023.1. Consequently, **CSC
 will no longer be able to provide a license for Maestro versions 2022.4 and
 older after 13th of March 2025**. If not done already, please migrate to using
 versions 2023.1 or later as soon as possible! See our Maestro page for details on


### PR DESCRIPTION
## Proposed changes

https://csc-guide-preview.2.rahtiapp.fi/origin/maestro-2025.1/

Note that the announcement links do not work in the preview. This is an issue related to using absolute paths, which are required by the announcement feature. They links will, however, work in production.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
