### PR TITLE
remove custom envs section

### DIFF
--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -91,30 +91,6 @@ Once you have finished:
 * Close (`exit`) also the interactive session. 
 * Close SSH tunnel with `Ctrl + C`.
 
-## Custom Python environment with Jupyter Notebook
-
-If you want to use a custom Conda environment with Jupyter Notebook, the
-following workflow could be used (adapted to your situation):
-
-```bash
-# Set up PROJAPPL environment variable, where to install your Conda environment. 
-# Add your project here
-export PROJAPPL=/projappl/project_xxx
-# Activate Conda commands
-module load bioconda
-# Create Conda environment with your packages
-# It is important to include the notebook package
-conda create --name gromacs-tutorials -c conda-forge -c bioconda gromacs=2020.4 matplotlib nglview notebook numpy requests pandas seaborn  
-# Activate the new Conda environment
-source activate gromacs-tutorials
-# Start Jupyter kernel, you will see a separate kernel with name "gromacs"
-python -m ipykernel install --user --name gromacs-tutorials --display-name "gromacs" 
-# load one of those packages that have Jupyter
-module load python-data
-# Launch Jupyter
-start-jupyter-server 
-```
-
 ## SSH tunnelling with PuTTy
 Both RStudio and Jupyter Notebook also print out PuTTy instructions that have to be copied to PuTTy settings. The port numbers and compute node name may change from session to session.
 

--- a/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
+++ b/docs/support/tutorials/rstudio-or-jupyter-notebooks.md
@@ -63,7 +63,7 @@ module load python-data
 start-jupyterlab-server
 ```
 
-It is also possible to use some other pre-installed [Python module](../../apps/python.md) than `python-data`, if it includes Jupyter. You can also use your [own custom Python environment with Jupyter Notebook.](#custom-python-environment-with-jupyter-notebook)
+It is also possible to use some other pre-installed [Python module](../../apps/python.md) than `python-data`, if it includes Jupyter.
 
 ***
 


### PR DESCRIPTION
https://csc-guide-preview.rahtiapp.fi/origin/jupyter-custom-env-removal/support/tutorials/rstudio-or-jupyter-notebooks/

had old stuff about conda etc. 
Web interface now recommended way, so not writing anything new.

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
