### PR TITLE
Fix GB -> GiB in Mahti NVMe example

### DIFF
--- a/docs/computing/running/example-job-scripts-mahti.md
+++ b/docs/computing/running/example-job-scripts-mahti.md
@@ -147,8 +147,8 @@ srun myprog <options>
 # - Each job gets 1.875 GB memory per reserved core automatically.
 #   If a task needs more memory, use `--cpus-per-task` option.
 # - Memory reservation slurm options are ignored
-# - Local NVMe disk up to 3500 GB is available, reserve with
-#   `--gres=nvme:<size in GB>` option and use through
+# - Local NVMe disk up to 3500 GiB is available, reserve with
+#   `--gres=nvme:<size in GiB>` option and use through
 #   $LOCAL_SCRATCH environment variable
 
 export MY_JOB_TMPDIR=$LOCAL_SCRATCH


### PR DESCRIPTION
## Proposed changes

- Fix `GB` -> `GiB` unit being wrong. In this case, the error is over 7%.
- [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-nvme-gb-gib-fix/computing/running/example-job-scripts-mahti/) 

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-nvme-gb-gib-fix/computing/running/example-job-scripts-mahti/).
