### PR TITLE
JAX release notes for feburary 2025.

### DIFF
--- a/docs/apps/jax.md
+++ b/docs/apps/jax.md
@@ -15,8 +15,12 @@ Currently supported JAX versions:
 
 | Version | Module             | Puhti   | Mahti   | LUMI       | Notes          |
 |:-------:|--------------------|:-------:|:-------:|:----------:|----------------|
-| 0.4.30  | `jax/0.4.30`       | default | default | default    | all packages   |
-| 0.4.30  | `jax/0.4.30-small` | X       | X       | X*         | framework only |
+| 0.5.0   | `jax/0.5.0`        | default | default | -          | all packages   |
+|         | `jax/0.5.0-small`  | X       | X       | -          | framework only |
+| 0.4.38  | `jax/0.4.38`       | X       | X       | default*   | all packages   |
+|         | `jax/0.4.38-small` | X       | X       | X*         | framework only |
+| 0.4.30  | `jax/0.4.30`       | X       | X       | X*         | all packages   |
+|         | `jax/0.4.30-small` | X       | X       | X*         | framework only |
 | 0.4.23  | `jax/0.4.23-py3.9` | X       | X       | X*         |                |
 | 0.4.20  | `jax/0.4.20`       | X       | X       | X*         |                |
 | 0.4.18  | `jax/0.4.18`       | -       | -       | X*         |                |
@@ -25,8 +29,8 @@ Currently supported JAX versions:
 | 0.4.1   | `jax/0.4.1`        | X       | X       | -          |                |
 | 0.3.13  | `jax/0.3.13`       | X       | X       | -          |                |
 
-The modules contain [JAX](https://github.com/google/jax/) for Python 3.9
-with GPU support via CUDA/ROCm as well as a large list of additional python packages commonly used together with JAX.
+The modules contain [JAX](https://github.com/google/jax/) for Python with GPU support via CUDA/ROCm as well as a large list of additional python packages commonly used together with JAX.
+The Python version differs between modules releases. Modules with JAX version up to 0.4.23 use Python 3.9, later modules use Python 3.12.
 
 **Versions in LUMI, marked as "*" are still experimental with limited
 support.** Some of the features described below might not work for them.
@@ -82,18 +86,23 @@ To use the default version (most-recent) on Puhti or Mahti, initialize it with:
 module load jax
 ```
 
+or
+```bash
+module load jax/small
+```
+
 To access CSC-installed JAX on LUMI:
 
 ```bash
 module use /appl/local/csc/modulefiles/
-module load jax
+module load jax  # jax/small
 ```
 
 !!! note
 
     In your scripts we recommend to fix the version so that
     changes in future upgrades do not break scripts, e.g.,:
-    `module load jax/0.4.23-py3.9`
+    `module load jax/0.5.0` or `module load jax/0.5.0-small`
 
 Please note that the JAX modules already include the corresponding
 CUDA and cuDNN or ROCm libraries, so **there is no need to load any

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,19 @@
 # Applications
 
+## JAX 0.4.38 available on Puhti, Mahti and LUMI, 0.5.0 available on Puhti and Mahti, 19.02.2025
+
+
+[JAX](../../apps/jax.md) 0.4.38 has now been installed on Puhti,
+Mahti and LUMI. This has been made the default version on LUMI.
+
+Additionally, JAX 0.5.0 has been installed on Puhti and Mahti
+and made the default version there. There is currently no support
+for ROCm for this JAX version and it has not been installed to LUMI.
+JAX 0.5.0 comes with [breaking changes](https://github.com/jax-ml/jax/releases/tag/jax-v0.5.0).
+If your code is incompatible, you can consider upgrading it or falling back to 0.4.38.
+
+On LUMI, the 0.4.38 module fixes memory allocation instabilities that were present in 0.4.30.
+
 ## Snakemake and Nextflow tutorials significantly improved
 
 Tutorials with major updates available for workflow tools: [Snakemake](../tutorials/snakemake-puhti.md) and [Nextflow](../tutorials/nextflow-tutorial.md). The tutorial describe different options for the installing and running the tools. Note also the new [master thesis by Antoni Gołoś comparing automated workflow approaches on supercomputers](https://urn.fi/URN:NBN:fi:aalto-202406164397).


### PR DESCRIPTION
## Proposed changes

Added releases notes for JAX 0.4.38 and 0.5.0.
Changes are made to
- JAX software page:  https://csc-guide-preview.2.rahtiapp.fi/origin/jax-feb25/apps/jax/
- Application news: https://csc-guide-preview.2.rahtiapp.fi/origin/jax-feb25/support/wn/apps-new/#jax-0438-available-on-puhti-mahti-and-lumi-050-available-on-puhti-and-mahti-19022025

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/jax-feb25/apps/jax/) (select your branch from the list).
