### PR TITLE
Update tykky.md

### DIFF
--- a/docs/computing/containers/tykky.md
+++ b/docs/computing/containers/tykky.md
@@ -10,8 +10,8 @@ Tykky use cases:
 - Conda installations, based on Conda `environment.yml`.
 - Pip installations, based on pip `requirements.txt`.
 - Container installations, based on existing Docker or Apptainer/Singularity images.
-    - This includes installations from the Bioconda channel, see [this tutorial for
-      an example](../../support/tutorials/bioconda-tutorial.md).
+    - This includes installations from the Bioconda channel, see
+      [this tutorial for an example](../../support/tutorials/bioconda-tutorial.md).
 
 Tykky wraps installations inside an Apptainer/Singularity container to improve startup
 times, reduce I/O load, and lessen the number of files on large parallel file systems.
@@ -46,12 +46,17 @@ module load tykky
 
 ## Conda-based installation
 
-First, make sure that you have read and understood the license terms for Miniconda
-and any used channels before using the command.
+!!! note "About licensing"
+    If you use environments installed with Tykky versions older than 0.4.0,
+    please ensure that you have read and understood the license terms for
+    Miniconda and any used channels before using the command.
+    
+    - [Anaconda terms of service](https://legal.anaconda.com/policies/en?name=terms-of-service#anaconda-terms-of-service).
+    - [Miniconda end-user license agreement](https://legal.anaconda.com/policies/en?name=terms-of-service#offering-description-miniconda).
+    - [Anaconda terms of service FAQs](https://www.anaconda.com/pricing/terms-of-service-faqs).
 
-- [Miniconda end-user license agreement](https://legal.anaconda.com/policies/en?name=offering-specific-terms#miniconda).
-- [Anaconda terms of service](https://legal.anaconda.com/policies/en/?name=terms-of-service#terms-of-service).
-- [A blog entry on Anaconda commercial edition](https://www.anaconda.com/blog/anaconda-commercial-edition-faq).
+    Tykky versions 0.4.0 and later use Miniforge, for which the above license restrictions do not apply.
+    [See Tykky release history](https://github.com/CSCfi/hpc-container-wrapper/releases).
 
 1) Create a **Conda environment file** `env.yml`:
 


### PR DESCRIPTION
Tykky uses Miniforge since v0.4.0. Update text.

https://csc-guide-preview.2.rahtiapp.fi/origin/tykky-license/computing/containers/tykky/