### PR TITLE
clarifications to ssh instructions

### DIFF
--- a/docs/accounts/how-to-create-new-project.md
+++ b/docs/accounts/how-to-create-new-project.md
@@ -16,8 +16,10 @@ A [CSC user account](how-to-create-new-user-account.md#getting-an-account-with-h
 	* [Commercial](how-to-create-new-project.md#commercial)
 	* [Course](how-to-create-new-project.md#course)
 	* [LUMI](how-to-create-new-project.md#how-to-create-finnish-lumi-projects)
+6. After you have created the project, remember to add [Service](how-to-add-service-access-for-project.md) to the project.
 
 ![New Project creation view.](../img/mycsc-create-new-project.png){width=400}
+
 ## Academic
 
 Academic project category is reserved for [free-of-charge use cases](https://research.csc.fi/free-of-charge-use-cases){:target="_blank"} and they can be created only by members of Finnish higher education institutions, state research institutes and CSC.

--- a/docs/computing/connecting/index.md
+++ b/docs/computing/connecting/index.md
@@ -38,6 +38,12 @@ typically come with a pre-installed SSH client. See the instructions for
 
 ## Using an SSH client
 
+Starting 14 April 2025, logging in to Puhti and Mahti using an SSH client
+requires that you have [set up SSH keys](ssh-keys.md) and
+[added your public key to MyCSC](ssh-keys.md#adding-public-key-in-mycsc).
+Traditional password-based authentication and public keys stored in your
+personal `~/.ssh/authorized_keys` file will **not** work.
+
 Unix-based systems like macOS and Linux typically come with a pre-installed
 terminal program called simply *Terminal*. The instructions for using an
 [SSH client on macOS and Linux](ssh-unix.md) show how to connect to a CSC
@@ -47,12 +53,6 @@ While Windows systems do not have a similar pre-existing solution for connecting
 over SSH, there are multiple programs that can be used for this. The
 instructions for using an [SSH client on Windows](ssh-windows.md) lists a few
 popular options.
-
-Starting April 14 2025, logging in to Puhti and Mahti using an SSH client
-requires that you have [set up SSH keys](ssh-keys.md) and
-[added your public key to MyCSC](ssh-keys.md#adding-public-key-in-mycsc).
-Traditional password-based authentication and public keys stored in your
-personal `~/.ssh/authorized_keys` file will **not** work.
 
 Once you have set up SSH keys and added your public key to MyCSC, use a
 command like below to connect over SSH:

--- a/docs/computing/connecting/index.md
+++ b/docs/computing/connecting/index.md
@@ -48,19 +48,31 @@ over SSH, there are multiple programs that can be used for this. The
 instructions for using an [SSH client on Windows](ssh-windows.md) lists a few
 popular options.
 
+Starting April 14 2025, logging in to Puhti and Mahti using an SSH client
+requires that you have [set up SSH keys](ssh-keys.md) and
+[added your public key to MyCSC](ssh-keys.md#adding-public-key-in-mycsc).
+Traditional password-based authentication and public keys stored in your
+personal `~/.ssh/authorized_keys` file will **not** work.
+
+Once you have set up SSH keys and added your public key to MyCSC, use a
+command like below to connect over SSH:
+
+```bash
+# Replace <username> with the name of your CSC user account and
+# <host> with "puhti" or "mahti"
+
+ssh <username>@<host>.csc.fi
+```
+
+!!! note
+    It might take up to one hour for your new key to become active after adding
+    it to MyCSC.
+
 Once the SSH connection to the supercomputer is open, you can interact with it
 by issuing Linux commands using the Bash shell program. An introduction to
 working on the Linux command-line can be found in our
 [Linux basics tutorial for CSC](../../support/tutorials/env-guide/index.md).
 You can have several connections to CSC supercomputers open at the same time.
-
-!!! note "SSH keys"
-    Starting April 14 2025, logging in to Puhti and Mahti using an SSH client
-    requires that you have set up SSH keys and added your public key to MyCSC.
-    Traditional password-based authentication and public keys stored in your
-    personal `~/.ssh/authorized_keys` file will not work.
-
-    [Read the detailed instructions on setting up and using SSH keys](ssh-keys.md).
 
 ### First connection
 

--- a/docs/computing/connecting/ssh-keys.md
+++ b/docs/computing/connecting/ssh-keys.md
@@ -2,8 +2,9 @@
 
 --8<-- "auth-update-ssh.md"
 
-SSH keys provide more convenient and secure authentication. Setting them up is
-a simple two-step process.
+[SSH keys](https://www.ssh.com/academy/ssh-keys) provide more convenient and
+secure authentication. Setting them up is a two-step process, and is required
+to be able to connect to CSC supercomputers using an SSH client.
 
 1. [Generate SSH keys on your local workstation](#generating-ssh-keys).
     - SSH keys are always generated in pairs consisting of one _public key_ and

--- a/docs/computing/connecting/ssh-keys.md
+++ b/docs/computing/connecting/ssh-keys.md
@@ -99,6 +99,12 @@ You can add your public key through the
    longer than that, please
    [contact the CSC Service Desk](../../support/contact.md).
 
+Users can check their public keys on Puhti or Mahti using the command:
+
+```bash
+ls -l /var/lib/acco/sshkeys/${USER}/${USER}.pub
+```
+
 !!! info "Required key format"
       Your public key should consist of the SSH key type and the key sequence,
       separated by a single space. If your key is improperly formatted, an

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -20,15 +20,15 @@ You will be asked to type a passphrase. Please choose a secure passphrase. It
 should be at least 8 characters long and contain numbers, letters and special
 characters. Never leave the passphrase empty!
 
+After you have generated an SSH key pair, you need to add the **public key** to
+the MyCSC portal.
+[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
 !!! note "Using SSH keys"
     See the page on [setting up SSH keys](ssh-keys.md) for general
-    information about using SSH keys for authentication.
-
-## Copying public key to supercomputer
-
-Starting April 14 2025, the only way to copy a public key to a supercomputer is
-through the MyCSC customer portal.
-[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+    information about using SSH keys for authentication. Note that copying the
+    public key directly to CSC supercomputers instead of adding it to MyCSC
+    will no longer work after April 14, 2025.
 
 ## Basic usage
 

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -3,35 +3,8 @@
 --8<-- "auth-update-ssh.md"
 
 On Unix-based systems like macOS and Linux, it is recommended to connect to CSC
-supercomputers using the pre-installed terminal program.
-
-## Basic usage
-
-The OpenSSH client typically comes pre-installed on macOS and Linux systems.
-You can create a remote SSH connection by opening the terminal and running:
-
-```bash
-# Replace <username> with the name of your CSC user account and
-# <host> with "puhti" or "mahti"
-
-ssh <username>@<host>.csc.fi
-```
-
-## Graphical connection
-
-Displaying graphics, such as GUIs and plots, over an SSH connection requires
-a window system. Most macOS and Linux systems have a server program for the X
-window system (X11) installed by default.
-
-To enable displaying graphics over SSH, use the `-X` (X11 forwarding) or `-Y`
-(trusted X11 forwarding) option when launching the SSH client:
-
-```bash
-ssh -X <username>@<host>.csc.fi
-```
-
-For more information about the X11 forwarding options, run `man ssh` in the
-terminal.
+supercomputers using the pre-installed terminal program. The OpenSSH client
+typically comes pre-installed on macOS and Linux systems.
 
 ## Generating SSH keys
 
@@ -55,6 +28,34 @@ characters. Never leave the passphrase empty!
 Starting April 14 2025, the only way to copy a public key to a supercomputer is
 through the MyCSC customer portal.
 [Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
+## Basic usage
+
+After setting up SSH keys and adding your public key to MyCSC, you can create a
+remote SSH connection by opening the terminal and running:
+
+```bash
+# Replace <username> with the name of your CSC user account and
+# <host> with "puhti" or "mahti"
+
+ssh <username>@<host>.csc.fi
+```
+
+## Graphical connection
+
+Displaying graphics, such as GUIs and plots, over an SSH connection requires
+a window system. Most macOS and Linux systems have a server program for the X
+window system (X11) installed by default.
+
+To enable displaying graphics over SSH, use the `-X` (X11 forwarding) or `-Y`
+(trusted X11 forwarding) option when launching the SSH client:
+
+```bash
+ssh -X <username>@<host>.csc.fi
+```
+
+For more information about the X11 forwarding options, run `man ssh` in the
+terminal.
 
 ## Authentication agent
 

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -8,7 +8,8 @@ typically comes pre-installed on macOS and Linux systems.
 
 ## Generating SSH keys
 
-On macOS and Linux, you can use the `ssh-keygen` command-line utility for
+Connecting to CSC supercomputers using an SSH client requires setting up SSH
+keys. On macOS and Linux, you can use the `ssh-keygen` command-line utility for
 generating SSH keys:
 
 ```bash

--- a/docs/computing/connecting/ssh-windows.md
+++ b/docs/computing/connecting/ssh-windows.md
@@ -9,16 +9,36 @@ popular alternatives: [PowerShell](#powershell), [PuTTY](#putty) and
 
 ## PowerShell
 
-### Basic usage (PowerShell)
-
 You can use the
 [Windows PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/security/remoting/ssh-remoting-in-powershell)
 command-line shell to connect to a CSC supercomputer using the
 [Win32 OpenSSH client](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse).
 To install OpenSSH on a Windows device, follow
 [these installation instructions](https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui#install-openssh-for-windows).
-After installing OpenSSH, you can connect to a CSC supercomputer by opening
-PowerShell and running:
+
+### Generating SSH keys (PowerShell)
+
+After installing OpenSSH, you can generate SSH keys using PowerShell by
+running:
+
+```bash
+ssh-keygen -o -a 100 -t ed25519
+```
+
+!!! note "Using SSH keys"
+    See the page on [setting up SSH keys](ssh-keys.md) for general
+    information about using SSH keys for authentication.
+
+### Copying public key to supercomputer (PowerShell)
+
+Starting April 14 2025, the only way to copy a public key to a supercomputer is
+through the MyCSC customer portal.
+[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
+### Basic usage (PowerShell)
+
+After setting up SSH keys and adding your public key to MyCSC, you can connect
+to a CSC supercomputer by opening PowerShell and running:
 
 ```bash
 # Replace <username> with the name of your CSC user account and
@@ -45,24 +65,6 @@ creating the connection:
 ssh -X <username>@<host>.csc.fi
 ```
 
-### Generating SSH keys (PowerShell)
-
-You can generate SSH keys using PowerShell by running:
-
-```bash
-ssh-keygen -o -a 100 -t ed25519
-```
-
-!!! note "Using SSH keys"
-    See the page on [setting up SSH keys](ssh-keys.md) for general
-    information about using SSH keys for authentication.
-
-### Copying public key to supercomputer (PowerShell)
-
-Starting April 14 2025, the only way to copy a public key to a supercomputer is
-through the MyCSC customer portal.
-[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
-
 ### Authentication agent (PowerShell)
 
 To avoid having to type your passphrase every time you connect,
@@ -79,25 +81,7 @@ to store your keys in memory for the duration of your local login session.
 
 ## PuTTY
 
-### Basic usage (PuTTY)
-
 The [PuTTY SSH client](https://putty.org/) is an alternative to using OpenSSH.
-When you launch PuTTY, you are asked to configure your SSH session. Do so
-according to the table below and click `Open`.
-
-| Option | Value |
-|-|-|
-| **Host Name** | `puhti.csc.fi` or `mahti.csc.fi` |
-| **Port** | `22` |
-| **Connection type** | `SSH` |
-
-### Graphical connection (PuTTY)
-
-If you want to create a connection with graphical support,
-you can use, for example, the
-[Xming X server](http://www.straightrunning.com/XmingNotes/). To enable displaying
-graphics remotely, select `Enable X11 forwarding` in the PuTTY program settings
-(`Connection --> SSH --> X11`).
 
 ### Generating SSH keys (PuTTY)
 
@@ -115,11 +99,30 @@ Starting April 14 2025, the only way to copy a public key to a supercomputer is
 through the MyCSC customer portal.
 [Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
 
-### Connecting with SSH keys (PuTTY)
+### Basic usage (PuTTY)
+
+After setting up SSH keys and adding your public key to MyCSC, you can connect
+to a CSC supercomputer using PuTTY. When you launch PuTTY, you are asked to
+configure your SSH session. Do so according to the table below:
+
+| Option | Value |
+|-|-|
+| **Host Name** | `puhti.csc.fi` or `mahti.csc.fi` |
+| **Port** | `22` |
+| **Connection type** | `SSH` |
 
 When creating a remote connection using PuTTY, select the private key file
 under `Connection --> SSH --> Auth`. If you want the private key to be
-used each time you connect, save your session to store your choice.
+used each time you connect, save your session to store your choice. Finally,
+click `Open`.
+
+### Graphical connection (PuTTY)
+
+If you want to create a connection with graphical support,
+you can use, for example, the
+[Xming X server](http://www.straightrunning.com/XmingNotes/). To enable displaying
+graphics remotely, select `Enable X11 forwarding` in the PuTTY program settings
+(`Connection --> SSH --> X11`).
 
 ### Authentication agent (PuTTY)
 
@@ -129,27 +132,8 @@ to store your private keys in memory.
 
 ## MobaXterm
 
-### Basic usage (MobaXterm)
-
 [MobaXterm](https://mobaxterm.mobatek.net/) is an SSH client with an embedded X
-server, which means that it can be used to display graphics. To connect using
-MobaXterm, open the terminal and run:
-
-```bash
-# Replace <username> with the name of your CSC user account and
-# <host> with "puhti" or "mahti"
-
-ssh <username>@<host>.csc.fi
-```
-
-### Graphical connection (MobaXterm)
-
-To enable displaying graphics over SSH, use the `-X` (X11 forwarding) or `-Y`
-(trusted X11 forwarding) option when creating the connection:
-
-```bash
-ssh -X <username>@<host>.csc.fi
-```
+server, which means that it can be used to display graphics.
 
 ### Generating SSH keys (MobaXterm)
 
@@ -172,6 +156,28 @@ set a persistent home directory for MobaXterm in the program settings
 Starting April 14 2025, the only way to copy a public key to a supercomputer is
 through the MyCSC customer portal.
 [Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
+### Basic usage (MobaXterm)
+
+After setting up SSH keys and adding your public key to MyCSC, you can connect
+to a CSC supercomputer using MobaXterm. To connect using MobaXterm, open the
+terminal and run:
+
+```bash
+# Replace <username> with the name of your CSC user account and
+# <host> with "puhti" or "mahti"
+
+ssh <username>@<host>.csc.fi
+```
+
+### Graphical connection (MobaXterm)
+
+To enable displaying graphics over SSH, use the `-X` (X11 forwarding) or `-Y`
+(trusted X11 forwarding) option when creating the connection:
+
+```bash
+ssh -X <username>@<host>.csc.fi
+```
 
 ### Authentication agent (MobaXterm)
 

--- a/docs/computing/connecting/ssh-windows.md
+++ b/docs/computing/connecting/ssh-windows.md
@@ -18,7 +18,8 @@ To install OpenSSH on a Windows device, follow
 
 ### Generating SSH keys (PowerShell)
 
-After installing OpenSSH, you can generate SSH keys using PowerShell by
+Connecting to CSC supercomputers using an SSH client requires setting up SSH
+keys. After installing OpenSSH, you can generate SSH keys using PowerShell by
 running:
 
 ```bash
@@ -85,8 +86,10 @@ The [PuTTY SSH client](https://putty.org/) is an alternative to using OpenSSH.
 
 ### Generating SSH keys (PuTTY)
 
-To generate SSH keys for connecting with PuTTY, use the [PuTTYgen key
-generator](https://www.puttygen.com/). The PuTTY documentation provides
+Connecting to CSC supercomputers using an SSH client requires setting up SSH
+keys. To generate SSH keys for connecting with PuTTY, use the
+[PuTTYgen key generator](https://www.puttygen.com/). The PuTTY documentation
+provides
 [instructions for using PuTTYgen](https://www.putty.be/0.76/htmldoc/Chapter8.html).
 
 !!! note "Using SSH keys"
@@ -137,7 +140,8 @@ server, which means that it can be used to display graphics.
 
 ### Generating SSH keys (MobaXterm)
 
-You can generate SSH keys using MobaXterm by running:
+Connecting to CSC supercomputers using an SSH client requires setting up SSH
+keys. You can generate SSH keys using MobaXterm by running:
 
 ```bash
 ssh-keygen -o -a 100 -t ed25519

--- a/docs/computing/connecting/ssh-windows.md
+++ b/docs/computing/connecting/ssh-windows.md
@@ -26,15 +26,15 @@ running:
 ssh-keygen -o -a 100 -t ed25519
 ```
 
+After you have generated an SSH key pair, you need to add the **public key** to
+the MyCSC portal.
+[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
 !!! note "Using SSH keys"
     See the page on [setting up SSH keys](ssh-keys.md) for general
-    information about using SSH keys for authentication.
-
-### Copying public key to supercomputer (PowerShell)
-
-Starting April 14 2025, the only way to copy a public key to a supercomputer is
-through the MyCSC customer portal.
-[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+    information about using SSH keys for authentication. Note that copying the
+    public key directly to CSC supercomputers instead of adding it to MyCSC
+    will no longer work after April 14, 2025.
 
 ### Basic usage (PowerShell)
 
@@ -92,15 +92,15 @@ keys. To generate SSH keys for connecting with PuTTY, use the
 provides
 [instructions for using PuTTYgen](https://www.putty.be/0.76/htmldoc/Chapter8.html).
 
+After you have generated an SSH key pair, you need to add the **public key** to
+the MyCSC portal.
+[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
 !!! note "Using SSH keys"
     See the page on [setting up SSH keys](ssh-keys.md) for general
-    information about using SSH keys for authentication.
-
-### Copying public key to supercomputer (PuTTY)
-
-Starting April 14 2025, the only way to copy a public key to a supercomputer is
-through the MyCSC customer portal.
-[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+    information about using SSH keys for authentication. Note that copying the
+    public key directly to CSC supercomputers instead of adding it to MyCSC
+    will no longer work after April 14, 2025.
 
 ### Basic usage (PuTTY)
 
@@ -151,15 +151,15 @@ If you want your generated keys to persist through MobaXterm restarts,
 set a persistent home directory for MobaXterm in the program settings
 (`Settings --> Configuration --> General`).
 
+After you have generated an SSH key pair, you need to add the **public key** to
+the MyCSC portal.
+[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+
 !!! note "Using SSH keys"
     See the page on [setting up SSH keys](ssh-keys.md) for general
-    information about using SSH keys for authentication.
-
-### Copying public key to supercomputer (MobaXterm)
-
-Starting April 14 2025, the only way to copy a public key to a supercomputer is
-through the MyCSC customer portal.
-[Read the instructions here](ssh-keys.md#adding-public-key-in-mycsc).
+    information about using SSH keys for authentication. Note that copying the
+    public key directly to CSC supercomputers instead of adding it to MyCSC
+    will no longer work after April 14, 2025.
 
 ### Basic usage (MobaXterm)
 


### PR DESCRIPTION
https://csc-guide-preview.2.rahtiapp.fi/origin/improve-ssh-keys/computing/connecting/#using-an-ssh-client

Looks like a lot of changes, but basically I just reordered the sections so that it is clearer that the user really needs to first set up the SSH keys before they can try to connect over SSH.