### PR TITLE
Decrease expiration time in filesender CLI example

### DIFF
--- a/docs/data/moving/funet.md
+++ b/docs/data/moving/funet.md
@@ -91,7 +91,7 @@ Assuming you are on a Linux server (e.g. Puhti or Mahti):
     ```ini
     [system]
     base_url = https://filesender.funet.fi/rest.php
-    default_transfer_days_valid = 21
+    default_transfer_days_valid = 7
 
     [user]
     username = <your username>


### PR DESCRIPTION
There were some tickets about too long expiration times causing errors. Decreasing to 7 days should fix these.