### PR TITLE
Python FAQ update + add Python usage guide to Docs front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,8 @@ template: home.html
     [LUMI User Guide :material-open-in-new:](https://docs.lumi-supercomputer.eu/){ target=_blank }
 
     [Allas User Guide :material-arrow-right:](data/Allas/index.md)
+    
+    [Python Usage Guide :material-arrow-right:](support/tutorials/python-usage-guide.md)
 
     [Machine Learning Guide :material-arrow-right:](support/tutorials/ml-guide.md)
 

--- a/docs/support/faq/python-package-trouble.md
+++ b/docs/support/faq/python-package-trouble.md
@@ -4,7 +4,7 @@
 
 Some examples:
 
-```bash
+```console
 $ module purge
 $ which python3
 /usr/bin/python3   # ← system Python
@@ -63,7 +63,7 @@ Below is an example (with many lines removed) using the python-data
 module combined with a venv and some packages installed into the
 user's home directory.
 
-```sh
+```console
 Package    Version  Location                                                                Installer
 ---------- -------- ----------------------------------------------------------------------- ---------
 aiohttp    3.9.3    /PUHTI_TYKKY_FRQGCcR/miniconda/envs/env1/lib/python3.10/site-packages   conda    # ← tykky
@@ -93,7 +93,7 @@ example pytorch has packages installed into `/usr/local/lib` or
 `/usr/local/lib64`. Note that these are paths inside the pytorch
 container.
 
-```bash
+```console
 Package    Version  Location                                  Installer
 ---------- -------- ----------------------------------------- ---------
 absl-py    1.4.0    /usr/local/lib/python3.11/site-packages   pip      # ← pytorch container

--- a/docs/support/faq/python-package-trouble.md
+++ b/docs/support/faq/python-package-trouble.md
@@ -29,7 +29,7 @@ $ which python3
 
 You can also check the Python version:
 
-```
+```bash
 python3 --version
 ```
 

--- a/docs/support/faq/python-package-trouble.md
+++ b/docs/support/faq/python-package-trouble.md
@@ -1,6 +1,40 @@
 # How to troubleshoot Python installation problems
 
-## Use `pip list -v` to find out where your packages are coming from
+## Run `which python3` to see if you are really in the environment you expect to be
+
+Some examples:
+
+```bash
+$ module purge
+$ which python3
+/usr/bin/python3   # ← system Python
+
+$ module load python-data
+$ which python3
+/appl/soft/ai/tykky/python-data-2024-04-update2/bin/python3
+
+$ module load geoconda
+$ which python3
+/appl/soft/geo/geoconda/3.11.10/bin/python3
+
+$ module load pytorch
+$ which python3
+/appl/soft/ai/wrap/pytorch-2.6/bin/python3
+
+$ module load pytorch
+$ source venv-pytorch2.6/bin/activate  # ← activating virtual environment
+$ which python3
+/scratch/project_2001659/mvsjober/venv-pytorch2.6/bin/python3
+```
+
+You can also check the Python version:
+
+```
+python3 --version
+```
+
+
+## Use `pip3 list -v` to find out where your packages are coming from
 
 When troubleshooting Python installation problems, we often see
 that users have installed their own versions of packages
@@ -9,13 +43,17 @@ modules. It can be very easy to forget something you installed a long
 time ago, and it is also easy to miss that pip is installing some
 additional packages that you are not aware of.
 
-The command `pip list -v` is an easy way to find out where your
+As a reminder see our [Python usage
+guide](../tutorials/python-usage-guide.md) on how to install your own
+packages on top of CSC's Python installations.
+
+The command `pip3 list -v` is an easy way to find out where your
 packages are coming from. The list might be very long, so you might
 want to use `less` to get a view where you can scroll up and down, or
 `grep` to extract the lines you are interested in.
 
 ```bash
-pip list -v | less
+pip3 list -v | less
 ```
 
 In `less` you can use the arrow keys or Page Up and Page Down keys to
@@ -36,7 +74,7 @@ biopython  1.85     /users/mvsjober/.local/lib/python3.10/site-packages         
 cowsay     6.1      /projappl/project_2001659/mvsjober/my-venv/lib/python3.10/site-packages pip      # ← project venv
 ```
 
-In the `pip list -v` output, check the Location column. In the example
+In the `pip3 list -v` output, check the Location column. In the example
 above the packages with locations starting with `/PUHTI_TYKKY_` are
 those coming from the python-data module, which has been installed
 with [Tykky][tykky]. Note that these are paths inside the container
@@ -47,7 +85,7 @@ virtual environment found in a project folder.
 To see only packages not coming from the CSC-installed python-data module:
 
 ```bash
-pip list -v | grep -v /PUHTI_TYKKY
+pip3 list -v | grep -v /PUHTI_TYKKY
 ```
 
 Note that some modules are not using [Tykky][tykky] and Conda, for


### PR DESCRIPTION
## Proposed changes

- Add new `which python` check to the Python troubleshooting FAQ
- Add Python usage guide to Docs front page links

Previews:
- https://csc-guide-preview.2.rahtiapp.fi/origin/python-faq-updates/
- https://csc-guide-preview.2.rahtiapp.fi/origin/python-faq-updates/support/faq/python-package-trouble/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
