### PR TITLE
RSA 2048 unsupported

### DIFF
--- a/docs/computing/connecting/ssh-keys.md
+++ b/docs/computing/connecting/ssh-keys.md
@@ -107,8 +107,7 @@ You can add your public key through the
    you last logged into the portal.
 4. Enter a _Title_ for your key pair, e.g. "my-ssh-key".
 5. Paste your **public** SSH key into the _Key_ field. Supported key types are
-   Ed25519 and RSA 2048 through 16384. **We strongly recommend Ed25519**. If
-   opting for RSA, please use at least 4096 bits.
+   Ed25519 and RSA 4096 through 16384. **We strongly recommend Ed25519**.
 6. Select _Add_.
 7. You should now see your new key listed under _SSH PUBLIC KEYS_. Note that
    it might take up to one hour for your new key to become active. If it takes

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -20,8 +20,8 @@ You will be asked to type a passphrase. Please choose a secure passphrase. It
 should be at least 8 characters long and contain numbers, letters and special
 characters. Never leave the passphrase empty!
 
-Supported key types are Ed25519 and RSA 2048 through 16384. **We strongly
-recommend Ed25519**. If opting for RSA, please use at least 4096 bits.
+Supported key types are Ed25519 and RSA 4096 through 16384. **We strongly
+recommend Ed25519**.
 
 After you have generated an SSH key pair, you need to add the **public key** to
 the MyCSC portal.

--- a/docs/computing/connecting/ssh-windows.md
+++ b/docs/computing/connecting/ssh-windows.md
@@ -23,8 +23,8 @@ or in a local terminal by running:
 ssh-keygen -a 100 -t ed25519
 ```
 
-Supported key types are Ed25519 and RSA 2048 through 16384. **We strongly
-recommend Ed25519**. If opting for RSA, please use at least 4096 bits.
+Supported key types are Ed25519 and RSA 4096 through 16384. **We strongly
+recommend Ed25519**.
 
 If you want your generated keys to persist through MobaXterm restarts,
 set a persistent home directory for MobaXterm in the program settings
@@ -100,8 +100,8 @@ keys. To generate SSH keys for connecting with PuTTY, use the
 provides
 [instructions for using PuTTYgen](https://www.putty.be/0.76/htmldoc/Chapter8.html).
 
-Supported key types are Ed25519 and RSA 2048 through 16384. **We strongly
-recommend Ed25519**. If opting for RSA, please use at least 4096 bits.
+Supported key types are Ed25519 and RSA 4096 through 16384. **We strongly
+recommend Ed25519**.
 
 After you have generated an SSH key pair, you need to add the **public key** to
 the MyCSC portal.
@@ -170,8 +170,8 @@ running:
 ssh-keygen -a 100 -t ed25519
 ```
 
-Supported key types are Ed25519 and RSA 2048 through 16384. **We strongly
-recommend Ed25519**. If opting for RSA, please use at least 4096 bits.
+Supported key types are Ed25519 and RSA 4096 through 16384. **We strongly
+recommend Ed25519**.
 
 After you have generated an SSH key pair, you need to add the **public key** to
 the MyCSC portal.


### PR DESCRIPTION
## Proposed changes

MyCSC no longer accepts RSA 2048 keys.

https://csc-guide-preview.2.rahtiapp.fi/origin/increase-min-bits/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
