### PR TITLE
Changes for www-Puhti R26 and www-Mahti R12

### DIFF
--- a/docs/computing/webinterface/index.md
+++ b/docs/computing/webinterface/index.md
@@ -19,7 +19,8 @@ Please note that logging in to Puhti and Mahti web interfaces requires
     consume a **modest amount of computational resources**. Some examples are
     **pre- and post-processing of data** in Jupyter Notebooks using
     **at most a few tens of CPU cores**, **small-scale AI/ML experiments**
-    using a **single GPU**, and **data visualization** tasks.
+    using a **single GPU**, and **data visualization** tasks. As such, the
+    maximum length of interactive jobs is limited to 16 hours.
 
     Please note that the interactive applications in the web interfaces are
     **not** suitable for **multi-node** and **multi-GPU jobs**. Such workloads
@@ -104,7 +105,11 @@ specific instructions, see the [Interactive apps](apps.md) page.
 !!! warning-label
     Only a few partitions of Puhti and Mahti are available for use in the web
     interfaces. Some apps also have a more limited set of partitions available
-    than others.
+    than others.  
+    The maximum length of jobs in the web interfaces is 16 hours to keep the
+    queueing times for interactive resources short. If you have work that
+    requires longer jobs than that, we recommend that you run your software as
+    [batch jobs](../running/getting-started.md).
 
 In the **Puhti web interface**, the `interactive`, `small`, `test`, `gpu` and
 `gputest` partitions are available. Selecting the `gpu` or `gputest` partition

--- a/docs/computing/webinterface/jupyter.md
+++ b/docs/computing/webinterface/jupyter.md
@@ -76,6 +76,14 @@ installation. So, if you created an installation with the command `conda-contain
 
 ### Virtual environment
 
+!!! Note
+
+    Ensure that you are using the correct Python kernel when using a virtual
+    environment. Otherwise, Python packages installed in the virtual
+    environment may not be possible to import in the notebook. When launching
+    Jupyter with a virtual environment, the kernel installed by the
+    web interface will be named `Python 3 (venv)`.
+
 You can create a virtual environment by enabling the *Virtual environment* option in the app form,
 as seen in the [Installing packages section](#installing-packages), and providing desired path of
 your virtual environment in the *Virtual environment path* field. The path should be under either

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,13 @@
 # Computing environment
 
+## Puhti and Mahti web interfaces updated to release 26 and 12, 6.5.2025
+
+* Jobs in the web interfaces have been limited to a maximum of 16 hours to improve queueing times.
+* VSCode now sets python.defaultInterpreterPath to help identifying the correct Python interpreter.
+* Virtual environments in the Jupyter app now work better with some modules, e.g. geoconda.
+* The email on session start option has been added to all interactive apps.
+* Open OnDemand updated to version 4.0.3.
+
 ## New data cleaning policy on Puhti, 17.4.2025
 
 On Puhti there is a process to clean (delete) old files in scratch that are not


### PR DESCRIPTION
Adds changes for Puhti web interface release 26 and Mahti web interface release 12:

- Changelog
- Jupyter kernel venv note
- Max job length

https://csc-guide-preview.2.rahtiapp.fi/origin/wwwpuhti-r26-wwwmahti-r12/