### PR TITLE
allas S3 endpoint 

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -779,18 +779,19 @@ When prompted about an existing LaTeX distribution, answer `yes` to continue the
 
 The `r-env` module comes with the [`aws.s3`](https://cran.r-project.org/web/packages/aws.s3/) package for working with S3 storage, which makes it possible to use the Allas storage system directly from an R script. See [here](https://github.com/csc-training/geocomputing/blob/master/R/allas/working_with_allas_from_R_S3.R) for a practical example involving raster data. 
 
-Accessing Allas via the `r-env` module can be done as follows. First configure Allas by running these commands before launching an interactive shell session:
+Accessing Allas via the `r-env` module can be done as follows. First configure [Allas connection for S3](../data/Allas/using_allas/python_boto3.md#configuring-s3):
 
 ```bash
 module load allas
-allas-conf --mode s3cmd
+allas-conf --mode S3
 ```
 
-After [starting an interactive session and launching R / RStudio Server](#interactive-use-on-a-compute-node), you can now access your bucket list as follows. Note that, for this to work, you will need to have the `allas` module loaded and the argument `region=''` added to the `bucketlist()` function:
+To get the list of your buckets:
 
 ```r
 library(aws.s3)
-bucketlist(region='')
+options("cloudyr.aws.default_region" = "")
+bucketlist()
 ```
 
 ## Citation

--- a/docs/data/Allas/using_allas/python_boto3.md
+++ b/docs/data/Allas/using_allas/python_boto3.md
@@ -66,18 +66,15 @@ After running `allas-conf --mode s3cmd`, the credentials and S3 region are store
 them. You can also define another location for the credentials file by
 modifying the `AWS_SHARED_CREDENTIALS_FILE` environment variable.
 
-If you wish to access Allas from a personal workstation or some other server,
-you can copy the configuration files
-[using a file transfer tool](../../moving/index.md) like `scp`.
-If you want `boto3` to find the credentials automatically
-without having to modify `AWS_SHARED_CREDENTIALS_FILE`,
-make sure that you also copy the parent directory as in the example
-below.
+If you wish to access Allas from a personal laptop or some other server,
+copy the `~/.aws`-folder to your home directory on that computer: `C:\Users\username\.aws` on Windows or `~/.aws/` on Mac and Linux.
+[Use any file transfer tool](../../moving/index.md), for example `scp`.
 
 ```bash
-# Copy the credentials file and its parent directory to your home directory
+# Copy the aws configuration files to your home directory
 scp -r <username>@<hostname>.csc.fi:~/.aws $HOME
 ```
+
 
 ### Credentials for accessing multiple CSC projects
 

--- a/docs/data/Allas/using_allas/python_boto3.md
+++ b/docs/data/Allas/using_allas/python_boto3.md
@@ -61,10 +61,13 @@ To use Allas with S3 and boto3, some configurations need to be set up:
 
 The easiest way to set up S3 configuration for `boto3` is by
 [configuring an S3 connection on a CSC supercomputer](s3_client.md#configuring-s3-connection-in-supercomputers).
-After running `allas-conf --mode s3cmd`, the credentials and S3 region are stored in
-`credentials` and S3 endpoint in `config` file in `~/.aws/` folder. That is the default location where `boto3` looks for
-them. You can also define another location for the credentials file by
-modifying the `AWS_SHARED_CREDENTIALS_FILE` environment variable.
+
+```bash
+module load allas
+allas-conf --mode S3
+```
+
+This saves the credentials and S3 region in `credentials` and S3 endpoint in `config` file in the default `~/.aws/` folder. 
 
 If you wish to access Allas from a personal laptop or some other server,
 copy the `~/.aws`-folder to your home directory on that computer: `C:\Users\username\.aws` on Windows or `~/.aws/` on Mac and Linux.

--- a/docs/data/Allas/using_allas/python_boto3.md
+++ b/docs/data/Allas/using_allas/python_boto3.md
@@ -51,19 +51,23 @@ installed. If you wish to use the library in another Python environment, you can
 use `pip` to
 [add it on top of an existing module](../../../support/tutorials/python-usage-guide.md#installing-python-packages-to-existing-modules).
 
-## Configuring S3 credentials
+## Configuring S3
+To use Allas with S3 and boto3, some configurations need to be set up:
+* Credentials: access key and secret key
+* S3 endpoint
+* S3 region
 
-### Credentials for accessing a single project
+### Configurations for accessing a single CSC project
 
-The easiest way to set up S3 credentials for using `boto3` is by
+The easiest way to set up S3 configuration for `boto3` is by
 [configuring an S3 connection on a CSC supercomputer](s3_client.md#configuring-s3-connection-in-supercomputers).
-After running `allas-conf --mode s3cmd`, the credentials are stored in
-`~/.aws/credentials`, which is the default location where `boto3` looks for
+After running `allas-conf --mode s3cmd`, the credentials and S3 region are stored in
+`credentials` and S3 endpoint in `config` file in `~/.aws/` folder. That is the default location where `boto3` looks for
 them. You can also define another location for the credentials file by
 modifying the `AWS_SHARED_CREDENTIALS_FILE` environment variable.
 
-If you wish to access Allas from a personal workstation,
-you can simply copy the credentials file to your device
+If you wish to access Allas from a personal workstation or some other server,
+you can copy the configuration files
 [using a file transfer tool](../../moving/index.md) like `scp`.
 If you want `boto3` to find the credentials automatically
 without having to modify `AWS_SHARED_CREDENTIALS_FILE`,
@@ -75,7 +79,7 @@ below.
 scp -r <username>@<hostname>.csc.fi:~/.aws $HOME
 ```
 
-### Credentials for accessing multiple projects
+### Credentials for accessing multiple CSC projects
 
 Using `allas-conf --mode s3cmd` is straightforward,
 but it overwrites the existing credentials file when run,
@@ -117,6 +121,8 @@ You can now use these credentials to
 S3 credentials configured only for one project:
 ```python
 # Create resource using credentials from the default location
+# With newer versions of aws-library defining endpoint here is not any more mandatory, if it is given in the config file.
+
 import boto3
 
 s3_resource = boto3.resource('s3', endpoint_url='https://a3s.fi')

--- a/docs/support/tutorials/gis/gdal_cloud.md
+++ b/docs/support/tutorials/gis/gdal_cloud.md
@@ -60,25 +60,18 @@ AWS_SECRET_ACCESS_KEY=yyy
 AWS_DEFAULT_REGION=regionOne
 ```
 
-The end-point URL is not needed for Amazon S3, but is needed for other services. Unfortunately it can not be given via `credentials` file, but needs to be given to GDAL as environment variable. For example to set Allas end-point: Windows command shell: `set AWS_S3_ENDPOINT=a3s.fi` or Linux/Max: `export AWS_S3_ENDPOINT=a3s.fi`
+The end-point URL is not needed for Amazon S3, but is needed for other services. Unfortunately it can not be given via configuration files, but needs to be set as environment variable for GDAK for each session when S3 is used. 
+For example to set Allas end-point: 
+
+* Windows command shell: `set AWS_S3_ENDPOINT=a3s.fi`
+* Linux/Mac: `export AWS_S3_ENDPOINT=a3s.fi`
 
 #### S3 connection set up for Allas 
 
-On CSC supercomputers the easiest option to set up Allas connection details is to use [allas-conf command](../../../data/Allas/using_allas/s3_client.md#configuring-s3-connection-in-supercomputers):
+The easiest way to set up S3 configuration for `GDAL` is by
+[configuring an S3 connection on a CSC supercomputer](../../../data/Allas/using_allas/python_boto3.md#configuring-s3). 
 
-```
-module load allas
-allas-conf --mode s3cmd
-```
-
-* `module load allas` sets AWS_S3_ENDPOINT environment variable, which needs to be run each time S3 is used.
-* `allas-conf --mode s3cmd` writes the keys and region name to `credentials` file (also prints them to Terminal) and must be run only when using first time or when changing the CSC project.
-
-After this, you are ready to use GDAL or GDAL-based tools on supercomputers.
-
-If you want to use Allas on some other machine, then copy `~/.aws/credentials` file from supercomputer to the other machine and set `AWS_S3_ENDPOINT` as described above.
-
-If you are not using CSC supercomputers, you can install `allas-conf` to your Linux/Mac machine, follow the instructions in [CSC's Allas command line interface utilities repository](https://github.com/CSCfi/allas-cli-utils). 
+GDAL requires additionally that Allas endpoint is given as AWS_S3_ENDPOINT environment variable, see the commands above.
 
 #### S3 connection set up for Copernicus Data Space Ecosystem (CDSE)
 


### PR DESCRIPTION
## Proposed changes

https://csc-guide-preview.rahtiapp.fi/origin/allas-s3-endpoint/data/Allas/using_allas/python_boto3/
https://csc-guide-preview.rahtiapp.fi/origin/allas-s3-endpoint/support/tutorials/gis/gdal_cloud/

Clarified the S3 set up documentation and moved some general stuff from GDAL page to boto3 page.
allas-conf --mode s3cmd still used in some other places, like R and nextflow pages, do we want to fix to allas-conf --mode S3?

## Checklist before requesting a review

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
