### PR TITLE
update projects section

### DIFF
--- a/docs/computing/quantum-computing/projects.md
+++ b/docs/computing/quantum-computing/projects.md
@@ -1,16 +1,19 @@
 # Quantum Projects on LUMI 
 
-Access to **Helmi** and **Q50** requires a LUMI project with allocated quantum computing resources. 
-To get started, create a LUMI project via MyCSC. Note that Q50 projects follow a separate application procedure, refer to the [Open Call](https://fiqci.fi/publications/2025-03-04-Q50-Call-1_2025) for details. Each project must have a **Principal Investigator** as the Project Manager, typically a senior researcher.
-
-
-Detailed instructions on the process of creating a general LUMI project via MyCSC are here:
-
-* [How to create a LUMI project and apply for resources](../../accounts/how-to-create-new-project.md#how-to-create-finnish-lumi-projects)
-
 !!! info "Getting Started"
-	To get started with Helmi/VTT Q50 see
-	[Access Helmi/Q50 through LUMI](access.md). 
+	To get started with using Helmi/VTT Q50 see
+	[Access Helmi/Q50 through LUMI](access.md).
+
+Access to **Helmi** and **Q50** requires a LUMI project with allocated quantum computing resources. 
+To apply for an academic project with quantum computing time See the resources below.
+
+## VTT Q5 Helmi
+
+[Open call for Helmi academic projects](https://fiqci.fi/publications/2022-11-01-Helmi_pilot)
+
+## VTT Q50
+
+[Open call for Q50 academic projects](https://fiqci.fi/publications/2025-07-03-Q50-Call-2_2025)
 
 ## Further reading:
 


### PR DESCRIPTION
## Update the Projects section of the Quantum Computing docs

Removed links to Lumi project docs not directly related to applying for quantum computing time. Added links to open calls for academic quantum computing projects with instructions on how to apply for a project.

Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/qc-projects-update/

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
