### PR TITLE
Fix typo in the Running Quantum Jobs section

### DIFF
--- a/docs/computing/quantum-computing/running-quantum-jobs.md
+++ b/docs/computing/quantum-computing/running-quantum-jobs.md
@@ -496,7 +496,7 @@ It is recommended to use the `Advanced settings`. Under the `Custom init` option
     ```bash
     module use /appl/local/quantum/modulefiles
     module load fiqci-vtt-qiskit
-    export DEVICES=("Q5", "Q50")
+    export DEVICES=("Q5" "Q50")
     source $RUN_SETUP
     ```
 
@@ -521,7 +521,7 @@ It is recommended to use the `Advanced settings`. Under the `Custom init` option
     ```bash
     module use /appl/local/quantum/modulefiles
     module load fiqci-vtt-cirq
-    export DEVICES=("Q5", "Q50")
+    export DEVICES=("Q5" "Q50")
     source $RUN_SETUP
     ```
 


### PR DESCRIPTION
Fix typo

Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/qc-running-on-typo/

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
