### PR TITLE
Move vscode dev tunnels note from ood page to remote-dev

### DIFF
--- a/docs/computing/webinterface/vscode.md
+++ b/docs/computing/webinterface/vscode.md
@@ -61,4 +61,3 @@ To install the extension:
 ## Troubleshooting
 
 - If VSCode does not work properly you can clear the settings and launch the application again. This can be done done by deleting the folder `~/.local/share/csc-vscode`.
-- Dev tunnels are not supported and their usage has been blocked. We recommend accessing VScode server instances via the supercomputer web interface, or experimenting with the [Remote SSH plugin](../../support/tutorials/remote-dev.md).

--- a/docs/support/tutorials/remote-dev.md
+++ b/docs/support/tutorials/remote-dev.md
@@ -230,3 +230,13 @@ Please do not run any computations on HPC via the VS Code Terminal tab or using
 VS Code's debuggers. This would run the code on a login node by default, which
 is **not meant for demanding computations**. The setup is also fragile in
 general.
+
+## VSCode Remote Tunnels
+
+VSCode also offers a [Remote
+Tunnel](https://code.visualstudio.com/docs/remote/tunnels) feature as
+an alternative to SSH. The **VSCode dev tunnels feature has been
+intentionally disabled on Puhti and Mahti** due to security concerns,
+as it would give a third party the ability to control access into
+CSC's supercomputers. We recommend using the Remote SSH feature
+instead (documented above).


### PR DESCRIPTION
## Proposed changes

Moved the text about VSCode dev tunnels being blocked from the OOD page to the remote-dev page which covers the remote VSCode usage.

Previews:
- moved from this page: https://csc-guide-preview.2.rahtiapp.fi/origin/move-vscode-tunnels-note/computing/webinterface/vscode/#troubleshooting (it used to be in the Troubleshooting section for OOD VSCode)
- to this: https://csc-guide-preview.2.rahtiapp.fi/origin/move-vscode-tunnels-note/support/tutorials/remote-dev/#vscode-remote-tunnels (last thing on the page)

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
