### PR TITLE
Update docs for www-puhti R28 and www-mahti R13

### DIFF
--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,13 @@
 # Computing environment
 
+## Puhti and Mahti web interfaces updated to release 28 and 13, 19.8.2025
+
+* Rclone updated to 1.70.3
+* TensorBoard now waits until it has fully launched before allowing the user to connect.
+* Desktop app now uses module reset instead of module restore.
+* Some security and performance improvements have been made.
+* Open OnDemand updated to 4.0.6.
+
 ## Puhti and Mahti web interfaces updated to release 26 and 12, 6.5.2025
 
 * Jobs in the web interfaces have been limited to a maximum of 16 hours to improve queueing times.


### PR DESCRIPTION
Updates the what's new page for Puhti web interface release 28 and Mahti web interface release 13.
https://csc-guide-preview.2.rahtiapp.fi/origin/wwwpuhti-r28-wwwmahti-r13/