### PR TITLE
Add pip cache FAQ entry plus links to it from various locations

### DIFF
--- a/docs/support/faq/disk-quota-exceeded.md
+++ b/docs/support/faq/disk-quota-exceeded.md
@@ -75,3 +75,6 @@ lue $HOME
 ```
 
 [See also this LUE tutorial](https://csc-training.github.io/csc-env-eff/hands-on/disk-areas/disk-areas-tutorial-lue.html).
+
+If you are a Python user and you notice that `.cache/pip` seems to be the culprit, 
+see our FAQ entry on [how to configure the pip cache](../faq/python-pip-cache.md).

--- a/docs/support/faq/index.md
+++ b/docs/support/faq/index.md
@@ -47,6 +47,7 @@
 * [How do I install missing Python packages to CSC-provided modules?](../tutorials/python-usage-guide.md#installing-python-packages-to-existing-modules)
 * [How do I create my own Python environment?](../tutorials/python-usage-guide.md#creating-your-own-python-environments)
 * [How to troubleshoot Python installation problems?](python-package-trouble.md)
+* [How to avoid Python pip cache filling up my home directory](python-pip-cache.md)
 
 ## Allas
 

--- a/docs/support/faq/python-pip-cache.md
+++ b/docs/support/faq/python-pip-cache.md
@@ -1,0 +1,52 @@
+# How to avoid Python pip cache filling up my home directory
+
+## The default pip cache directory
+
+The [Python package manager pip uses a cache][pip-caching] to reduce
+network access and to avoid having to rebuild packages that have
+already been built. By default this cache resides in the user's home
+directory in `~/.cache/pip`. You can check what is your current pip
+cache directory with the command `pip cache dir`. For example:
+
+```console
+$ pip cache dir
+/users/mvsjober/.cache/pip
+```
+
+For example installing PyTorch will put around 3.7 GB of files into
+the cache, this can easily fill up your [home directory
+quota][home-dir]. You can clean up your cache either by simply
+deleting it with `rm -rf ~/.cache/pip` or (more gently) by using the
+command `pip cache purge`:
+
+```console
+$ pip cache purge
+Files removed: 52
+```
+
+## Changing the pip cache directory
+
+To avoid problems in the future it might be a good idea to store your
+pip cache on the scratch file system instead. The pip cache can be set
+with the `--cache-dir` flag or, globally by setting the
+`PIP_CACHE_DIR` environment variable. For example (change the path to
+something appropriate for your project and user):
+
+```console
+$ export PIP_CACHE_DIR=/scratch/project_2001659/mvsjober/pip-cache/
+$ mkdir -p $PIP_CACHE_DIR
+```
+
+You can now test that pip has picked up this change:
+
+```console
+$ pip cache dir
+/scratch/project_2001659/mvsjober/pip-cache/
+```
+
+If you want to make this setting permanent for your user, you can add
+the export-line to the `.bashrc` file in your home directory.
+
+
+[pip-caching]: https://pip.pypa.io/en/stable/topics/caching/
+[home-dir]: https://docs.csc.fi/computing/disk/#home-directory

--- a/docs/support/faq/python-pip-cache.md
+++ b/docs/support/faq/python-pip-cache.md
@@ -33,7 +33,7 @@ with the `--cache-dir` flag or, globally by setting the
 something appropriate for your project and user):
 
 ```console
-$ export PIP_CACHE_DIR=/scratch/project_2001659/mvsjober/pip-cache/
+$ export PIP_CACHE_DIR=/scratch/<project>/<username>/pip-cache/
 $ mkdir -p $PIP_CACHE_DIR
 ```
 

--- a/docs/support/tutorials/python-usage-guide.md
+++ b/docs/support/tutorials/python-usage-guide.md
@@ -131,6 +131,15 @@ in a module provided by CSC, do not hesitate to contact our
 
     ---
 
+
+!!! warning 
+
+    Even if you are installing Python packages to projappl or scratch, the
+    pip command may still fill up your home directory as it stores its
+    cache there by default. See our FAQ entry on [how to configure the pip
+    cache](../faq/python-pip-cache.md).
+
+
 ### Creating your own Python environments
 
 It is also possible to create your own Python environments.


### PR DESCRIPTION
## Proposed changes

Added FAQ entry on pip cache filling up your home, and how to change pip cache scratch instead. Also added links to this page from various logical places.

Preview of FAQ page:
- https://csc-guide-preview.2.rahtiapp.fi/origin/python-faq-pip-cache/support/faq/python-pip-cache/

Links to FAQ from these locations:
- https://csc-guide-preview.2.rahtiapp.fi/origin/python-faq-pip-cache/support/faq/#python-on-supercomputers
- https://csc-guide-preview.2.rahtiapp.fi/origin/python-faq-pip-cache/support/faq/disk-quota-exceeded/#i-have-deleted-many-files-but-still-get-disk-quota-exceeded-warning
- https://csc-guide-preview.2.rahtiapp.fi/origin/python-faq-pip-cache/support/tutorials/python-usage-guide/#installing-python-packages-to-existing-modules


## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
