### PR TITLE
Fix ntasks in doMPI example

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -298,7 +298,7 @@ arrays <- commandArgs(trailingOnly = TRUE)
 
 *Jobs using `doMPI` (with `foreach`)*
 
-The `foreach` package implements a for-loop that uses iterators and allows for parallel execution using the `%dopar%` operator. It is possible to execute parallel `foreach` loops on Puhti using the `doMPI` package. While otherwise the batch job file looks similar to that used for a multi-processor job, we could modify the `srun` command at the end of the batch job file:
+The `foreach` package implements a for-loop that uses iterators and allows for parallel execution using the `%dopar%` operator. It is possible to execute parallel `foreach` loops on Puhti using the `doMPI` package. While otherwise the batch job file looks similar to that used for a multi-processor job, we replace `--cpus-per-task=8` with `--ntasks=8`. In addition, we could modify the `srun` command at the end of the batch job file:
 
 ```bash
 srun apptainer_wrapper exec Rscript --no-save --slave myscript.R


### PR DESCRIPTION
doMPI example says to use similar batch job script as for a multicore job, but in practice --cpus-per-task has to be replaced by --ntasks=8.

## Proposed changes

Instead of '_While otherwise the batch job file looks similar to that used for a multi-processor job, we could modify_' -> 
While otherwise the batch job file looks similar to that used for a multi-processor job, we **replace `--cpus-per-task=8`with `--ntasks=8`**. In addition, we could modify...**
 [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/helijuottonen-dompifix/apps/r-env/#parallel-batch-jobs)  -> Jobs using doMPI (with foreach)

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
