### PR TITLE
Replace Python package lists with command

### DIFF
--- a/docs/apps/python.md
+++ b/docs/apps/python.md
@@ -68,26 +68,30 @@ python3.9
 Puhti and Mahti have several pre-installed
 [environment modules](../computing/modules.md) containing
 Python environments made for different science areas.
-For more details about the Python versions and libraries that are available
-for a module, please see the corresponding application page by opening
-one of the links in the table below.
 
-| Module name | Purpose | Package list |
-|-|-|-|
-| [biopythontools](biopython.md) | bioinformatics | [open](https://a3s.fi/python-pkg-lists/biopythontools.txt) |
-| [geoconda](geoconda.md) | geoinformatics | [open](https://a3s.fi/python-pkg-lists/geoconda.txt) |
-| [jax](jax.md) | JAX ML framework | [open](https://a3s.fi/python-pkg-lists/jax.txt) |
-| [python-data](python-data.md) | data analysis and ML utilities | [open](https://a3s.fi/python-pkg-lists/python-data.txt) |
-| [pytorch](pytorch.md) | PyTorch ML framework | [open](https://a3s.fi/python-pkg-lists/pytorch.txt) |
-| [qiskit](qiskit.md) | quantum computing | [open](https://a3s.fi/python-pkg-lists/qiskit.txt) |
-| [tensorflow](tensorflow.md) | TensorFlow ML framework | [open](https://a3s.fi/python-pkg-lists/tensorflow.txt) |
+| Module name | Purpose |
+|-|-|
+| [biopythontools](biopython.md) | bioinformatics |
+| [geoconda](geoconda.md) | geoinformatics |
+| [jax](jax.md) | JAX ML framework |
+| [python-data](python-data.md) | data analysis and ML utilities |
+| [pytorch](pytorch.md) | PyTorch ML framework |
+| [qiskit](qiskit.md) | quantum computing |
+| [tensorflow](tensorflow.md) | TensorFlow ML framework |
 
 To use any of the above environments, simply load the corresponding module
 using the `module load` command.
-For example:
 
 ```bash
-module load python-data
+module load <MODULE_NAME>  # e.g. module load python-data
+```
+
+To see the Python libraries included in a module, you can run the following
+line. The `-s` option
+[excludes packages installed by the user](https://docs.python.org/3/using/cmdline.html#cmdoption-s).
+
+```bash
+python3 -sm pip list
 ```
 
 Typically, after activating a Python-based module, the `python3` command points


### PR DESCRIPTION
## Proposed changes

While maintaining up-to-date lists of libraries included in CSC Python modules was a nice idea, it relies on manually running a pair of scripts, which is perhaps not a sustainable solution. This branch removes the links to the package lists and documents a command that the user can use to check module contents on their own, the main point being the use of the [`-s` flag](https://docs.python.org/3/using/cmdline.html#cmdoption-s), that excludes user-installed packages from the resulting list. The changes [can be previewed here](https://csc-guide-preview.2.rahtiapp.fi/origin/python-package-lists/apps/python/#pre-installed-python-environments).

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
