### PR TITLE
Add LLM guide to Tutorials index

### DIFF
--- a/docs/support/tutorials/index.md
+++ b/docs/support/tutorials/index.md
@@ -63,6 +63,7 @@
 * [Machine learning guide](ml-guide.md)
 * [Using RStudio or Jupyter notebooks in Puhti](rstudio-or-jupyter-notebooks.md)
 * [Starting with parallel R](parallel-r.md)
+* [Working with large language models on supercomputers](ml-llm.md)
 
 ## Geoinformatics
 


### PR DESCRIPTION
## Proposed changes

Added [LLM guide](https://docs.csc.fi/support/tutorials/ml-llm/) to Tutorials index under Data analysis and machine learning.

[Preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/llm-tutorial-visibility/support/tutorials/#data-analysis-and-machine-learning)

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
