### PR TITLE
added OMP_NUM_THREADS

### DIFF
--- a/docs/apps/turbomole.md
+++ b/docs/apps/turbomole.md
@@ -77,6 +77,7 @@ module load turbomole/7.8
 export TURBOTMPDIR=`echo $PWD |cut -d'/' -f1-3`"/TM_TMPDIR/"$SLURM_JOB_ID
 mkdir -p $TURBOTMPDIR
 export PARNODES=$SLURM_CPUS_PER_TASK  # for SMP
+export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK
 export PATH=$TURBODIR/bin/`$TURBODIR/scripts/sysname`:$PATH
 jobex -ri -c 300 > jobex.out
 ```


### PR DESCRIPTION
Added export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK to the SMP example
https://csc-guide-preview.2.rahtiapp.fi/origin/turbomole_update/

## Checklist before requesting a review

- [ X] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [X] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [X] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
