### PR TITLE
WIP: Shut off and suspended VMs can be powered off

### DIFF
--- a/docs/cloud/pouta/known-problems.md
+++ b/docs/cloud/pouta/known-problems.md
@@ -24,10 +24,6 @@
     name after a rebuild or reboot. If you want to be sure that the
     correct device gets mounted to the same path every time it is a good
     idea to use UUIDs instead of paths.
--   Ubuntu-20.04 images and hpc.6 flavor are unable to boot. A bug prevents
-    instances with Ubuntu 20.04 (created or updated) and flavor hpc.6.*
-    from booting. We expect a future update to fix this, but in the meantime
-    avoid this combination.
 
 ## EC2 tools (euca2ools)
 

--- a/docs/cloud/pouta/vm-lifecycle.md
+++ b/docs/cloud/pouta/vm-lifecycle.md
@@ -45,6 +45,10 @@ may benefit from the paused state but modern workflows generally do
 not use this state. Pausing a virtual machine is billed in the same
 way as an **active** state virtual machine.
 
+!!! warning
+
+    A *paused* virtual machine will be powered off during maintenance.
+
 ### Suspend
 Suspending a virtual machine saves its current state on
 the virtual machine's host compute node. The virtual machine can be
@@ -55,6 +59,10 @@ are not able to access your machine when it is in the *suspended* state.
 Virtual machines in the suspended state are billed in the same way
 as **active** state virtual machines. Suspending is not generally used
 in modern workflows.
+
+!!! warning
+
+    A *suspended* virtual machine will be powered off during maintenance.
 
 ### Shelved
 Shelving means shutting down a virtual machine and removing it from the host compute node. 


### PR DESCRIPTION
* Shut off and suspended VMs can be powered off during maintenance.
* ubuntu 20 bug on hpc6 does not seem to exist anymore.

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
