### PR TITLE
Add missing `module` command to pytorch docs

### DIFF
--- a/docs/apps/pytorch.md
+++ b/docs/apps/pytorch.md
@@ -203,7 +203,7 @@ To check the exact packages and versions included in the loaded module you can
 run:
 
 ```text
-list-packages
+module list-packages
 ```
 
 


### PR DESCRIPTION
## Proposed changes

`list-packages` alone is not an available command after doing the steps above, but `module list-packages` is and it does provide verification that pytorch has been loaded, so I suppose this is what we want. The relevant change can be viewed in https://csc-guide-preview.2.rahtiapp.fi/origin/pytorch-typofix/apps/pytorch/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
