### PR TITLE
Add warning about reindexing on certain pgsql upgrades

### DIFF
--- a/docs/cloud/dbaas/operations.md
+++ b/docs/cloud/dbaas/operations.md
@@ -34,7 +34,7 @@ The commands to use:
 5. Verify with your preferred tool that your database is working as expected.
 
 !!! warning "Certain PostgreSQL upgrades will cause databases to be reindexed"
-    The libraries used by PostgreSQL internally for collation might change between datastore versions.
+    The libraries used by PostgreSQL internally for collation (sorting, comparing, and ordering data) might change between datastore versions.
     When this happens, a full reindex of all databases is required to prevent issues with data consistency.
     This reindexing can take a considerable amount of time, especially with large databases containing complex indexes.
     Currently upgrading from 17.5 or earlier to 17.6 or newer triggers the reindexing. Upgrading between


### PR DESCRIPTION
## Proposed changes

Added a warning about automatic reindexing that might happen on PostgreSQL version upgrades:
https://csc-guide-preview.2.rahtiapp.fi/origin/DBAAS-484/cloud/dbaas/operations/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
