### PR TITLE
Remove warning about old vmXXXX DNS records

### DIFF
--- a/docs/cloud/pouta/additional-services.md
+++ b/docs/cloud/pouta/additional-services.md
@@ -105,9 +105,6 @@ All our floating IPs are by default mapped to a hostname, for example:
 fip-86-50-168-120.kaj.poutavm.fi has address 86.50.168.120
 ```
 
-!!! info "Retired `vmXXX` entries (27th October 2025)"
-    After the 27th October 2025 the old `vmXXX` DNS records will no be available. Contact us (<servicedesk@csc.fi>) if you have any question or issue.
-
 These default DNS records do also have the reverse DNS entry. To find the hostname of a floating IP, you can use `host` command:
 
 ```sh


### PR DESCRIPTION
## Proposed changes

The removal of A-PTR records in the old vmXXXX format was completed on October 27th, 2025. Having passed already three weeks, the warning can be now removed.

https://csc-guide-preview.2.rahtiapp.fi/origin/CCCP-4834/cloud/pouta/additional-services/#predefined-dns-names

## Checklist before requesting a review

- [X] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [X] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [X] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
