### PR TITLE
Add colors for card grids

### DIFF
--- a/csc-overrides/assets/stylesheets/cards.css
+++ b/csc-overrides/assets/stylesheets/cards.css
@@ -1,0 +1,78 @@
+/* Accent card */
+
+.grid.cards li:has(p.csc-grid-card-accent) {
+  background-color: var(--csc-grid-card-accent-background-color);
+  border-color: var(--csc-grid-card-accent-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-accent) hr {
+  border-color: var(--csc-grid-card-accent-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-accent) .twemoji {
+  color: var(--csc-grid-card-accent-foreground-color);
+}
+
+
+/* Info card */
+
+.grid.cards li:has(p.csc-grid-card-info) {
+  background-color: var(--csc-grid-card-info-background-color);
+  border-color: var(--csc-grid-card-info-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-info) hr {
+  border-color: var(--csc-grid-card-info-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-info) .twemoji {
+  color: var(--csc-grid-card-info-foreground-color);
+}
+
+
+/* Success card */
+
+.grid.cards li:has(p.csc-grid-card-success) {
+  background-color: var(--csc-grid-card-success-background-color);
+  border-color: var(--csc-grid-card-success-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-success) hr {
+  border-color: var(--csc-grid-card-success-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-success) .twemoji {
+  color: var(--csc-grid-card-success-foreground-color);
+}
+
+
+/* Warning card */
+
+.grid.cards li:has(p.csc-grid-card-warning) {
+  background-color: var(--csc-grid-card-warning-background-color);
+  border-color: var(--csc-grid-card-warning-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-warning) hr {
+  border-color: var(--csc-grid-card-warning-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-warning) .twemoji {
+  color: var(--csc-grid-card-warning-foreground-color);
+}
+
+
+/* Error card */
+
+.grid.cards li:has(p.csc-grid-card-error) {
+  background-color: var(--csc-grid-card-error-background-color);
+  border-color: var(--csc-grid-card-error-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-error) hr {
+  border-color: var(--csc-grid-card-error-foreground-color);
+}
+
+.grid.cards li:has(p.csc-grid-card-error) .twemoji {
+  color: var(--csc-grid-card-error-foreground-color);
+}

--- a/csc-overrides/assets/stylesheets/extra.css
+++ b/csc-overrides/assets/stylesheets/extra.css
@@ -5,6 +5,7 @@
 @import url(./announcement.css);
 @import url(./banner.css);
 @import url(./breadcrumbs.css);
+@import url(./cards.css);
 @import url(./content.css);
 @import url(./feedback.css);
 @import url(./footer.css);

--- a/csc-overrides/assets/stylesheets/variables.css
+++ b/csc-overrides/assets/stylesheets/variables.css
@@ -50,5 +50,16 @@
   --csc-admonition--bg: #FDF3D1;
 
   --md-admonition-icon--error: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2c5.53 0 10 4.47 10 10s-4.47 10-10 10S2 17.53 2 12 6.47 2 12 2m3.59 5L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41z"></path></svg>');
-  --md-admonition-icon--training: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M128 96c0-35.3 28.7-64 64-64h352c35.3 0 64 28.7 64 64v240h-96v-16c0-17.7-14.3-32-32-32h-64c-17.7 0-32 14.3-32 32v16H254.9c10.9-18.8 17.1-40.7 17.1-64 0-70.7-57.3-128-128-128-5.4 0-10.8.3-16 1zm205 352c-5.1-24.2-16.3-46.1-32.1-64H608c0 35.3-28.7 64-64 64zM64 272a80 80 0 1 1 160 0 80 80 0 1 1-160 0M0 480c0-53 43-96 96-96h96c53 0 96 43 96 96 0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32"/></svg>')
+  --md-admonition-icon--training: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--! Font Awesome Free 7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2025 Fonticons, Inc.--><path d="M128 96c0-35.3 28.7-64 64-64h352c35.3 0 64 28.7 64 64v240h-96v-16c0-17.7-14.3-32-32-32h-64c-17.7 0-32 14.3-32 32v16H254.9c10.9-18.8 17.1-40.7 17.1-64 0-70.7-57.3-128-128-128-5.4 0-10.8.3-16 1zm205 352c-5.1-24.2-16.3-46.1-32.1-64H608c0 35.3-28.7 64-64 64zM64 272a80 80 0 1 1 160 0 80 80 0 1 1-160 0M0 480c0-53 43-96 96-96h96c53 0 96 43 96 96 0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32"/></svg>');
+
+  --csc-grid-card-accent-background-color: var(--c-accent-100);
+  --csc-grid-card-accent-foreground-color: var(--c-accent-600);
+  --csc-grid-card-info-background-color: var(--c-info-100);
+  --csc-grid-card-info-foreground-color: var(--c-info-600);
+  --csc-grid-card-success-background-color: var(--c-success-100);
+  --csc-grid-card-success-foreground-color: var(--c-success-600);
+  --csc-grid-card-warning-background-color: var(--c-warning-100);
+  --csc-grid-card-warning-foreground-color: var(--c-warning-600);
+  --csc-grid-card-error-background-color: var(--c-error-100);
+  --csc-grid-card-error-foreground-color: var(--c-error-600);
 }

--- a/docs/ref.md
+++ b/docs/ref.md
@@ -1168,6 +1168,91 @@ The [Grids feature from _Material for MkDocs_](https://squidfunk.github.io/mkdoc
   </div>
 </div>
 
+
+### With colors
+
+```html title="Grid with colors"
+<div class="grid cards" markdown>
+
+- :material-dna:{ .lg .middle } **Accent**
+  { .csc-grid-card-accent }
+
+    ---
+
+    Science!
+
+- :material-information:{ .lg .middle } **Info**
+  { .csc-grid-card-info }
+
+    ---
+
+    This.
+
+- :material-check-circle:{ .lg .middle } **Success**
+  { .csc-grid-card-success }
+
+    ---
+
+    Do!
+
+- :material-alert:{ .lg .middle } **Warning**
+  { .csc-grid-card-warning }
+
+    ---
+
+    Don't!
+
+- :material-close-circle:{ .lg .middle } **Error**
+  { .csc-grid-card-error }
+
+    ---
+
+    Why?!
+
+</div>
+```
+
+<div class="result" markdown>
+  <div class="grid cards" markdown>
+
+  - :material-dna:{ .lg .middle } **Accent**
+    { .csc-grid-card-accent }
+
+      ---
+
+      Science!
+
+  - :material-information:{ .lg .middle } **Info**
+    { .csc-grid-card-info }
+
+      ---
+
+      This.
+
+  - :material-check-circle:{ .lg .middle } **Success**
+    { .csc-grid-card-success }
+
+      ---
+
+      Do!
+
+  - :material-alert:{ .lg .middle } **Warning**
+    { .csc-grid-card-warning }
+
+      ---
+
+      Don't!
+
+  - :material-close-circle:{ .lg .middle } **Error**
+    { .csc-grid-card-error }
+
+      ---
+
+      Why?!
+
+  </div>
+</div>
+
 [^1]: This is the footnote ...and here's a shoenote for the footnote: 👞🎵
 [^2]:
     Here's another footnote. Though, this one's a _barefootnote_!  


### PR DESCRIPTION
## Proposed changes

Add predefined styles for coloring the cards like so:

<img width="387" height="656" alt="image" src="https://github.com/user-attachments/assets/23f8cf4a-fd4a-46ab-8eee-7f314ad8d05d" />


Preview here: https://csc-guide-preview.2.rahtiapp.fi/origin/color-cards/ref/#with-colors

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
