### PR TITLE
pouta networking: fix a command fetching network id for subnet create…

### DIFF
--- a/docs/cloud/pouta/networking.md
+++ b/docs/cloud/pouta/networking.md
@@ -76,7 +76,7 @@ Click on **Add Interface**
 ```sh
 $ openstack network create test-network
 $ openstack subnet create --dns-nameserver 193.166.4.24 --dns-nameserver 193.166.4.25 \
-    --network $(openstack network list -f value -c ID -c Name|grep -v public|cut -d " " -f1) \
+    --network $(openstack network list -f value -c ID -c Name|grep test-network|cut -d " " -f1) \
     --subnet-range 192.168.0.1/24 --allocation-pool start=192.168.0.10,end=192.168.0.30 test-network
 $ openstack router create test-router
 $ openstack router set --external-gateway public test-router


### PR DESCRIPTION
## Proposed changes



Fixes a minor logic issue in CLI instructions for creating a subnet: "openstack network list -f value -c ID -c Name|grep -v public|cut -d " " -f1" lists all network IDs expect the "public" network, and if there is more than one network in a project, the logic fails.

Working logic could be, for example to grep with the name of recently created network.

Link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/pouta-networking-subnet-logic/)

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
