### PR TITLE
Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials

### DIFF
--- a/docs/cloud/rahti/tutorials/index.md
+++ b/docs/cloud/rahti/tutorials/index.md
@@ -29,6 +29,7 @@
 * 🔴 [CI/CD on Rahti](ci_cd_introduction.md)
 * 🔴 [Kustomize](kustomize.md)
 * 🔴 [Learn cloud computing by developing and deploying a web application](web-app-dev-cloud.md)
+* 🔴 [Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials](/docs/support/tutorials/pukki_db_monitor.md)
 * 🔴 [Reverse proxy authentication using a sidecar container](sidecar_proxy_authentication.md)
 
 We also have an [FAQ](../../../support/faq/index.md#rahti) for Rahti. Take a look at it.

--- a/docs/cloud/rahti/tutorials/index.md
+++ b/docs/cloud/rahti/tutorials/index.md
@@ -29,7 +29,7 @@
 * 🔴 [CI/CD on Rahti](ci_cd_introduction.md)
 * 🔴 [Kustomize](kustomize.md)
 * 🔴 [Learn cloud computing by developing and deploying a web application](web-app-dev-cloud.md)
-* 🔴 [Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials](/docs/support/tutorials/pukki_db_monitor.md)
+* 🔴 [Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials](../../../support/tutorials/pukki_db_monitor.md)
 * 🔴 [Reverse proxy authentication using a sidecar container](sidecar_proxy_authentication.md)
 
 We also have an [FAQ](../../../support/faq/index.md#rahti) for Rahti. Take a look at it.

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -39,8 +39,7 @@ The example files can be found in [CSC github](https://github.com/CSCfi/pukki-db
 
 4. Click **Create Application Credential**
 
-5. Use:
-   - Role: `reader`
+5. Use Role: `reader`
 
 6. Create the credential and download the file
 
@@ -97,7 +96,7 @@ For more info about Rahti registry [read here](../../cloud/rahti/images/Using_Ra
 
 Open and update:
 
-``
+```
 [db-monitor-cronjob.yaml](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-cronjob.yaml)
 ```
 

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -46,15 +46,20 @@ The example files can be found in [CSC github](https://github.com/CSCfi/pukki-db
 !!! note
     Application credentials are linked to the user account that created them. If the user leaves the project or their access is revoked, the credentials will become invalid
 
-Read more about [Application credentials here](../../cloud/dbaas/application-credentials.md) 
+Read more about [Application credentials here](../../cloud/dbaas/application-credentials.md)
 
-# 2. Configure Credentials in Rahti
+# 2. Clone the example repository
 
-Edit the file:
+Clone the example repository:
 
+```sh
+git clone https://github.com/CSCfi/rahti-openstack-dbaas-monitor.git
 ```
-[db-monitor-openstack-secret.yaml](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-openstack-secret.yaml)
-```
+
+# 3. Configure Credentials in Rahti
+
+Edit the file `db-monitor-openstack-secret.yaml`
+
 Replace all placeholder values:
 
 ```
@@ -70,7 +75,7 @@ Then apply the Secret:
 oc apply -f db-monitor-openstack-secret.yaml
 ```
 
-# 3. Build and push the container image
+# 4. Build and push the container image
 
 Login to the Rahti registry:
 
@@ -92,13 +97,9 @@ sudo docker push image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:late
 
 For more info about Rahti registry [read here](../../cloud/rahti/images/Using_Rahti_integrated_registry.md)
 
-# 4. Configure the CronJob
+# 5. Configure the CronJob
 
-Open and update:
-
-```
-[db-monitor-cronjob.yaml](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-cronjob.yaml)
-```
+Open `db-monitor-cronjob.yaml` and update
 
 image path:
 ```
@@ -119,7 +120,7 @@ Apply the configuration:
 oc apply -f db-monitor-cronjob.yaml
 ```
 
-# 5. Run a manual test
+# 6. Run a manual test
 
 Before waiting for the scheduled run, test manually:
 

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -53,7 +53,7 @@ Read more about [Application credentials here](../../cloud/dbaas/application-cre
 Clone the example repository:
 
 ```sh
-git clone https://github.com/CSCfi/rahti-openstack-dbaas-monitor.git
+git clone https://github.com/CSCfi/pukki-dbaas-monitor.git
 ```
 
 # 3. Configure Credentials in Rahti

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -53,8 +53,9 @@ Read more about [Application credentials here](../../cloud/dbaas/application-cre
 
 Edit the file:
 
-[`db-monitor-openstack-secret.yaml`](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-openstack-secret.yaml)
-
+```
+[db-monitor-openstack-secret.yaml](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-openstack-secret.yaml)
+```
 Replace all placeholder values:
 
 ```
@@ -94,20 +95,25 @@ For more info about Rahti registry [read here](../../cloud/rahti/images/Using_Ra
 
 # 4. Configure the CronJob
 
-Open:
+Open and update:
 
-[`db-monitor-cronjob.yaml`](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-cronjob.yaml)
-
-Update:
+``
+[db-monitor-cronjob.yaml](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-cronjob.yaml)
+```
 
 image path:
-   - image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
+```
+image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
+```
 email settings:
-   - MAIL_FROM: "<replace me>"
-   - MAIL_TO: "<replace me>"
+```
+MAIL_FROM: "<replace me>"
+MAIL_TO: "<replace me>"
+```
 optional threshold:
-   - THRESHOLD_PERCENT: "90"
-
+```
+THRESHOLD_PERCENT: "90"
+```
 Apply the configuration:
 
 ```sh

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -1,10 +1,13 @@
+!!! error "Advanced level"
+    You need to have Docker and Python knowledge.  
+    Regarding Rahti, we will privilege the use of OpenShift CLI tool [oc](../usage/cli.md)
+
 # Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials
 
 This tutorial shows how to run a **Rahti CronJob** that uses **Pukki application credentials** to query OpenStack DBaaS instances and send an email alert if any database instance volume exceeds a configured threshold (default: **90%**).
 
 Application credentials are the recommended way to authenticate automated tools and scripts without exposing your personal username and password.
 
----
 
 # Overview
 
@@ -26,33 +29,25 @@ openstack database instance show <instance_name> -f json
 
 The example files can be found in [CSC github](https://github.com/CSCfi/pukki-dbaas-monitor)
 
----
-
 # 1. Create application credentials in Pukki
 
 1. Log in to Pukki
 
 2. Select your project
 
-3. Navigate to:
-
-   ```
-   Identity → Application Credentials
-   ```
+3. Navigate to `Identity → Application Credentials`
 
 4. Click **Create Application Credential**
 
 5. Use:
-   * Role: `reader`
+   - Role: `reader`
 
 6. Create the credential and download the file
 
 !!! note
     Application credentials are linked to the user account that created them. If the user leaves the project or their access is revoked, the credentials will become invalid
 
-Read more about [Application credentials](../../cloud/dbaas/application-credentials.md) 
-
----
+Read more about [Application credentials here](../../cloud/dbaas/application-credentials.md) 
 
 # 2. Configure Credentials in Rahti
 
@@ -75,8 +70,6 @@ Then apply the Secret:
 oc apply -f db-monitor-openstack-secret.yaml
 ```
 
----
-
 # 3. Build and push the container image
 
 Login to the Rahti registry:
@@ -97,7 +90,7 @@ Push the image:
 sudo docker push image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
 ```
 
----
+For more info about Rahti registry [read here](../../cloud/rahti/images/Using_Rahti_integrated_registry.md)
 
 # 4. Configure the CronJob
 
@@ -108,20 +101,18 @@ Open:
 Update:
 
 image path:
-- image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
+   - image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
 email settings:
-- MAIL_FROM: "<replace me>"
-- MAIL_TO: "<replace me>"
+   - MAIL_FROM: "<replace me>"
+   - MAIL_TO: "<replace me>"
 optional threshold:
-- THRESHOLD_PERCENT: "90"
+   - THRESHOLD_PERCENT: "90"
 
 Apply the configuration:
 
 ```sh
 oc apply -f db-monitor-cronjob.yaml
 ```
-
----
 
 # 5. Run a manual test
 
@@ -131,7 +122,6 @@ Before waiting for the scheduled run, test manually:
 oc create job --from=cronjob/openstack-db-monitor db-monitor-test
 oc logs -f job/db-monitor-test
 ```
-Expected output
 
 You should see something like:
 
@@ -142,8 +132,6 @@ db-a: 12.50%
 db-b: 93.00%
 Alert email sent for 1 instance(s)
 ```
-
----
 
 # Conclusion
 

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -1,6 +1,6 @@
 !!! error "Advanced level"
     You need to have Docker and Python knowledge.  
-    Regarding Rahti, we will privilege the use of OpenShift CLI tool [oc](../usage/cli.md)
+    Regarding Rahti, we will privilege the use of OpenShift CLI tool [oc](../../cloud/rahti/usage/cli.md)
 
 # Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials
 

--- a/docs/support/tutorials/pukki_db_monitor.md
+++ b/docs/support/tutorials/pukki_db_monitor.md
@@ -1,0 +1,154 @@
+# Monitor Pukki DBaaS instance sizes from a Rahti CronJob using application credentials
+
+This tutorial shows how to run a **Rahti CronJob** that uses **Pukki application credentials** to query OpenStack DBaaS instances and send an email alert if any database instance volume exceeds a configured threshold (default: **90%**).
+
+Application credentials are the recommended way to authenticate automated tools and scripts without exposing your personal username and password.
+
+---
+
+# Overview
+
+The example workflow:
+
+1. Create an application credential in Pukki
+2. Store credentials as a Secret in Rahti
+3. Build a container image with a monitoring script
+4. Push the image to the Rahti internal registry
+5. Deploy a CronJob
+6. Run periodic checks and send email alerts
+
+The script uses:
+
+```bash
+openstack database instance list -f json
+openstack database instance show <instance_name> -f json
+```
+
+The example files can be found in [CSC github](https://github.com/CSCfi/pukki-dbaas-monitor)
+
+---
+
+# 1. Create application credentials in Pukki
+
+1. Log in to Pukki
+
+2. Select your project
+
+3. Navigate to:
+
+   ```
+   Identity → Application Credentials
+   ```
+
+4. Click **Create Application Credential**
+
+5. Use:
+   * Role: `reader`
+
+6. Create the credential and download the file
+
+!!! note
+    Application credentials are linked to the user account that created them. If the user leaves the project or their access is revoked, the credentials will become invalid
+
+Read more about [Application credentials](../../cloud/dbaas/application-credentials.md) 
+
+---
+
+# 2. Configure Credentials in Rahti
+
+Edit the file:
+
+[`db-monitor-openstack-secret.yaml`](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-openstack-secret.yaml)
+
+Replace all placeholder values:
+
+```
+OS_AUTH_URL: "<replace me>"
+OS_REGION_NAME: "<replace me>"
+OS_APPLICATION_CREDENTIAL_ID: "<replace me>"
+OS_APPLICATION_CREDENTIAL_SECRET: "<replace me>"
+```
+
+Then apply the Secret:
+
+```sh
+oc apply -f db-monitor-openstack-secret.yaml
+```
+
+---
+
+# 3. Build and push the container image
+
+Login to the Rahti registry:
+
+```sh
+sudo docker login -u unused -p $(oc whoami -t) image-registry.apps.2.rahti.csc.fi
+```
+
+Build the [image](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/Dockerfile) (uses [`requirements.txt`](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/requirements.txt), [`monitor_dbaas.py`](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/monitor_dbaas.py) ):
+
+```sh
+sudo docker build -t image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest .
+```
+
+Push the image:
+
+```sh
+sudo docker push image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
+```
+
+---
+
+# 4. Configure the CronJob
+
+Open:
+
+[`db-monitor-cronjob.yaml`](https://github.com/CSCfi/pukki-dbaas-monitor/blob/main/db-monitor-cronjob.yaml)
+
+Update:
+
+image path:
+- image-registry.apps.2.rahti.csc.fi/<replace me>/db-monitor:latest
+email settings:
+- MAIL_FROM: "<replace me>"
+- MAIL_TO: "<replace me>"
+optional threshold:
+- THRESHOLD_PERCENT: "90"
+
+Apply the configuration:
+
+```sh
+oc apply -f db-monitor-cronjob.yaml
+```
+
+---
+
+# 5. Run a manual test
+
+Before waiting for the scheduled run, test manually:
+
+```sh
+oc create job --from=cronjob/openstack-db-monitor db-monitor-test
+oc logs -f job/db-monitor-test
+```
+Expected output
+
+You should see something like:
+
+```
+Starting OpenStack DBaaS volume usage check
+Found 3 instance(s): db-a, db-b, db-c
+db-a: 12.50%
+db-b: 93.00%
+Alert email sent for 1 instance(s)
+```
+
+---
+
+# Conclusion
+
+In this tutorial, you used Pukki application credentials to securely authenticate a Rahti-based automation workflow that monitors DBaaS instance storage.
+
+Application credentials provide a safe and practical way to grant scripts and services access to OpenStack APIs without exposing personal user credentials. By storing them in Rahti Secrets and using them in a CronJob, you can build automated workflows that are both secure and maintainable.
+
+When using application credentials, it is important to remember that they are tied to the user who created them. For long-running or shared services, you should plan how credentials are managed, rotated, and owned within the project to avoid unexpected disruptions.


### PR DESCRIPTION
## Proposed changes

- https://csc-guide-preview.2.rahtiapp.fi/origin/db-monitor/cloud/rahti/tutorials/
- https://csc-guide-preview.2.rahtiapp.fi/origin/db-monitor/support/tutorials/pukki_db_monitor
## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
