### PR TITLE
WIP Roihu quickstart guide link fixes

### DIFF
--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -147,7 +147,7 @@ Basic workflow:
 See the relevant documentation below for detailed information:
 
 1. [Available batch job partitions](../../computing/running/batch-job-partitions.md)
-2. [Creating a batch job script](../../../computing/running/batch-job-partitions.md)
+2. [Creating a batch job script](../../computing/running/batch-job-partitions.md)
 3. [Submit a batch job](../../computing/running/submitting-jobs.md)
 4. [Performance checklist](../../computing/running/performance-checklist.md)
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -33,7 +33,7 @@ To connect via SSH:
 1. Set up SSH keys (same as Puhti/Mahti)
 2. **New:** _Sign_ your public key and download a _certificate_
     * Certificates are valid for **24 hours**
-    * See our instructions for managing certificates: [Signing public SSH keys](../../../computing/connecting/ssh-keys/#signing-public-key)
+    * See our instructions for managing certificates: [Signing public SSH keys](../../computing/connecting/ssh-keys.md#signing-public-key)
 
 For platform-specific instructions, see:
 
@@ -107,8 +107,8 @@ If not available, choose one of the following approaches depending on your needs
 HPC software written using programming languages such as C, C++ or Fortran need to be compiled before installing.  
 For instructions on the available compilers and preferred options, see the instructions for compiling software on:
 
-- [Compiling on Roihu-CPU](../../../computing/compiling-roihu/#compiling-on-roihu-cpu)
-- [Compiling on Roihu-GPU](../../../computing/compiling-roihu/#compiling-on-roihu-gpu)
+- [Compiling on Roihu-CPU](../../computing/compiling-roihu.md#compiling-on-roihu-gpu)
+- [Compiling on Roihu-GPU](../../computing/compiling-roihu.md#compiling-on-roihu-gpu)
 
 ### Containers
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -143,7 +143,7 @@ Basic workflow:
 See the relevant documentation below for detailed information:
 
 1. [Available batch job partitions](../../computing/running/batch-job-partitions.md)
-2. [Creating a batch job script](../../../computing/running/creating-job-scripts-roihu.md)
+2. [Creating a batch job script](../../../computing/running/batch-job-partitions.md)
 3. [Submit a batch job](../../computing/running/submitting-jobs.md)
 4. [Performance checklist](../../computing/running/performance-checklist.md)
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -66,7 +66,11 @@ For platform-specific instructions, see:
 
     **All login nodes still share the same file system, so your files are accessible from all of them.**
 
-### Roihu web interface (available after general availability)
+### Roihu web interface
+
+!!! warning "Roihu web interface availability during the pilot period"
+     Roihu web interface will only be vailable after General Availability. Please connect via SSH during the pilot phase.
+     
 
 The simplest way to connect to Roihu is to use the web interface.
 
@@ -103,8 +107,8 @@ If not available, choose one of the following approaches depending on your needs
 HPC software written using programming languages such as C, C++ or Fortran need to be compiled before installing.  
 For instructions on the available compilers and preferred options, see the instructions for compiling software on:
 
-- [Compiling on Roihu-CPU](../../computing/compiling-roihu.md#building-mpi-applications)
-- [Compiling on Roihu-GPU](../../computing/compiling-roihu.md#building-gpu-applications)
+- [Compiling on Roihu-CPU](../../computing/compiling-roihu.md#compiling-on-roihu-cpu)
+- [Compiling on Roihu-GPU](../../computing/compiling-roihu.md#compiling-on-roihu-gpu)
 
 ### Containers
 
@@ -179,4 +183,4 @@ srun --argos=no <your-executable>
 
 * [Roihu system overview](../../computing/systems-roihu.md)
 * [CSC Computing Environment self-learning materials](https://csc-training.github.io/csc-env-eff/)
-* [Contact our service desk](https://docs.csc.fi/support/contact/)
+* [Contact our service desk](../contact.md)

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -93,7 +93,7 @@ Note that previous extended disk quotas on Puhti or Mahti will not be automatica
 Before installing anything:
 
 1. Check if the software is already available:
-   - [List of pre-installed applications](../apps/index.md)
+   - [List of pre-installed applications](../../apps/index.md)
    - `module spider <module name>`
 
 If not available, choose one of the following approaches depending on your needs:
@@ -123,7 +123,7 @@ More details on working with containers in CSC's computing environment can be fo
 
 Best practice guidelines on installing your own Python and R packages can be found in the Python, R and Tykky container wrapper pages below.
 
-- [Installing Python packages and environments](../support/tutorials/python-usage-guide.md)
+- [Installing Python packages and environments](../tutorials/python-usage-guide.md)
 - [Containerizing Conda and pip environments with Tykky](../../computing/containers/tykky.md)
 - [R package installations](../../apps/r-env.md#r-package-installations)
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -143,7 +143,7 @@ Basic workflow:
 See the relevant documentation below for detailed information:
 
 1. [Available batch job partitions](../../computing/running/batch-job-partitions.md)
-2. [Creating a batch job script](../../computing/running/creating-job-scripts-roihu.md)
+2. [Creating a batch job script](../../../computing/running/creating-job-scripts-roihu.md)
 3. [Submit a batch job](../../computing/running/submitting-jobs.md)
 4. [Performance checklist](../../computing/running/performance-checklist.md)
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -33,7 +33,7 @@ To connect via SSH:
 1. Set up SSH keys (same as Puhti/Mahti)
 2. **New:** _Sign_ your public key and download a _certificate_
     * Certificates are valid for **24 hours**
-    * See our instructions for managing certificates: [Signing public SSH keys](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-quickstart/computing/connecting/ssh-keys/#signing-public-key)
+    * See our instructions for managing certificates: [Signing public SSH keys](../../computing/connecting/ssh-keys/#signing-public-key)
 
 For platform-specific instructions, see:
 
@@ -107,8 +107,8 @@ If not available, choose one of the following approaches depending on your needs
 HPC software written using programming languages such as C, C++ or Fortran need to be compiled before installing.  
 For instructions on the available compilers and preferred options, see the instructions for compiling software on:
 
-- [Compiling on Roihu-CPU](../../computing/compiling-roihu.md#compiling-on-roihu-cpu)
-- [Compiling on Roihu-GPU](../../computing/compiling-roihu.md#compiling-on-roihu-gpu)
+- [Compiling on Roihu-CPU](../../../computing/compiling-roihu.md#compiling-on-roihu-cpu)
+- [Compiling on Roihu-GPU](../../../computing/compiling-roihu.md#compiling-on-roihu-gpu)
 
 ### Containers
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -107,8 +107,8 @@ If not available, choose one of the following approaches depending on your needs
 HPC software written using programming languages such as C, C++ or Fortran need to be compiled before installing.  
 For instructions on the available compilers and preferred options, see the instructions for compiling software on:
 
-- [Compiling on Roihu-CPU](../../../computing/compiling-roihu.md/#compiling-on-roihu-cpu)
-- [Compiling on Roihu-GPU](../../../computing/compiling-roihu.md/#compiling-on-roihu-gpu)
+- [Compiling on Roihu-CPU](../../../computing/compiling-roihu/#compiling-on-roihu-cpu)
+- [Compiling on Roihu-GPU](../../../computing/compiling-roihu/#compiling-on-roihu-gpu)
 
 ### Containers
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -40,7 +40,7 @@ For platform-specific instructions, see:
 * [Instructions for Linux/macOS](../../computing/connecting/ssh-unix.md).
 * [Instructions for Windows](../../computing/connecting/ssh-windows.md).
 
-**[Read detailed instructions for creating and managing SSH keys and certificates](../../computing/connecting/ssh-keys.md).**
+**[Read detailed instructions for managing SSH keys and certificates](../../computing/connecting/ssh-keys.md).**
 
 !!! warning "Separate CPU and GPU environments"
     Roihu has
@@ -114,18 +114,18 @@ Another option is to build your own container from scratch.
 
 More details on working with containers in CSC's computing environment can be found from the links below:
 
-- [Overview of containers](containers/overview.md)
-- [Running containers](containers/overview.md#running-containers)
-- [Creating containers](containers/overview.md#building-container-images)
-- [Tykky container wrapper](containers/tykky.md)
+- [Overview of containers](../../computing/containers/overview.md)
+- [Running containers](../../computing/containers/overview.md#running-containers)
+- [Creating containers](../../computing/containers/overview.md#building-container-images)
+- [Tykky container wrapper](../../computing/containers/tykky.md)
 
 ### Python/R environments
 
 Best practice guidelines on installing your own Python and R packages can be found in the Python, R and Tykky container wrapper pages below.
 
 - [Installing Python packages and environments](../support/tutorials/python-usage-guide.md)
-- [Containerizing Conda and pip environments with Tykky](containers/tykky.md)
-- [R package installations](../apps/r-env.md#r-package-installations)
+- [Containerizing Conda and pip environments with Tykky](../../computing/containers/tykky.md)
+- [R package installations](../../apps/r-env.md#r-package-installations)
 
 ## Running your first job
 
@@ -142,10 +142,10 @@ Basic workflow:
 
 See the relevant documentation below for detailed information:
 
-1. [Available batch job partitions](batch-job-partitions.md)
-2. [Creating a batch job script](creating-job-scripts-roihu.md)
-3. [Submit a batch job](submitting-jobs.md)
-4. [Performance checklist](performance-checklist.md)
+1. [Available batch job partitions](../../computing/running/batch-job-partitions.md)
+2. [Creating a batch job script](../../computing/running/creating-job-scripts-roihu.md)
+3. [Submit a batch job](../../computing/running/submitting-jobs.md)
+4. [Performance checklist](../../computing/running/performance-checklist.md)
 
 For common Slurm error messages, see our FAQ on [Why does my batch job fail?](../faq/why-does-my-batch-job-fail.md).
 

--- a/docs/support/tutorials/roihu.md
+++ b/docs/support/tutorials/roihu.md
@@ -33,7 +33,7 @@ To connect via SSH:
 1. Set up SSH keys (same as Puhti/Mahti)
 2. **New:** _Sign_ your public key and download a _certificate_
     * Certificates are valid for **24 hours**
-    * See our instructions for managing certificates: [Signing public SSH keys](../../computing/connecting/ssh-keys/#signing-public-key)
+    * See our instructions for managing certificates: [Signing public SSH keys](../../../computing/connecting/ssh-keys/#signing-public-key)
 
 For platform-specific instructions, see:
 
@@ -107,8 +107,8 @@ If not available, choose one of the following approaches depending on your needs
 HPC software written using programming languages such as C, C++ or Fortran need to be compiled before installing.  
 For instructions on the available compilers and preferred options, see the instructions for compiling software on:
 
-- [Compiling on Roihu-CPU](../../../computing/compiling-roihu.md#compiling-on-roihu-cpu)
-- [Compiling on Roihu-GPU](../../../computing/compiling-roihu.md#compiling-on-roihu-gpu)
+- [Compiling on Roihu-CPU](../../../computing/compiling-roihu.md/#compiling-on-roihu-cpu)
+- [Compiling on Roihu-GPU](../../../computing/compiling-roihu.md/#compiling-on-roihu-gpu)
 
 ### Containers
 


### PR DESCRIPTION
## Proposed changes

Fix a broken link that fails automated tests, into a placeholder.
https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-quickstart/support/tutorials/roihu/


## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
