### PR TITLE
sbf exclusive warning added to script page

### DIFF
--- a/docs/computing/running/creating-job-scripts-roihu.md
+++ b/docs/computing/running/creating-job-scripts-roihu.md
@@ -396,18 +396,24 @@ As a new feature on Roihu, it is possible to request local disk mounts from a ce
 This fast storage capacity is provided over the network and
 appears as local scratch from within a Slurm job.
 
-!!! info "About fast local scratch storage"
-    These settings are likely to change.
+!!! warning "You must request these resources in conjunction with `--exclusive`"
+    At the present you can only request this storage for jobs that are making use of full nodes,
+    i.e. that are submitted with the `--exclusive` flag. Presently if you do not specify this flag
+    your job will fail, but will be marked "CANCELLED by 350" and you will lack any stdout or stderr
+    logs. This should be resolved once support for shared node jobs arrives in Q3 2026.
 
 Request this local storage using the following flag in the batch script:
 
 ```bash
+#SBATCH --exclusive
 #SBATCH --bb="#BB_LUA SBF storagesize=<local_storage_space> path=/run/sbb/<username>"
 ```
 
-For example, requesting 100 GiB storage:
+For example, requesting 100 GiB storage
+(remember to update `<username>` to your username in the sbatch header):
 
 ```bash
+#SBATCH --exclusive
 #SBATCH --bb="#BB_LUA SBF storagesize=100G path=/run/sbb/<username>"
 ```
 


### PR DESCRIPTION
## Proposed changes

Added the warning that you need --exclusive for sbf to batch script page.

- https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-sbf-exclusive-updates/computing/running/creating-job-scripts-roihu/


## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
