### PR TITLE
Add changelog for www-Puhti R33 and www-Mahti R17

### DIFF
--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,7 +1,8 @@
 # Computing environment
 
-## Puhti and Mahti web interface updated to release 33 and 17, 12.5.2026
+## Puhti and Mahti web interface updated to release 33 and 17, 11.6.2026
 
+* The MATLAB version can now be selected.
 * Jupyter for Courses now has an option to reset the course material.
 * VSCode now has an option to re-open the last opened workspace.
 * Open OnDemand updated to 4.1.5.

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,11 @@
 # Computing environment
 
+## Puhti and Mahti web interface updated to release 33 and 17, 12.5.2026
+
+* Jupyter for Courses now has an option to reset the course material.
+* VSCode now has an option to re-open the last opened workspace.
+* Open OnDemand updated to 4.1.5.
+
 ## Puhti and Mahti web interface updated to release 32 and 16, 25.2.2026
 
 * [Jupyter with an R kernel](../../computing/webinterface/r-jupyter.md) is now available on Mahti.


### PR DESCRIPTION
This adds the changelog for Puhti web interface release 33 and Mahti web interface release 17.

https://csc-guide-preview.2.rahtiapp.fi/origin/wwwpuhti-r33-wwwmahti-r17
