### PR TITLE
Bump urllib3 from 2.6.3 to 2.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ requests==2.33.0
 sgmllib3k==1.0.0
 six==1.17.0
 smmap==5.0.2
-urllib3==2.6.3
+urllib3==2.7.0
 watchdog==6.0.0

--- a/translation/requirements.txt
+++ b/translation/requirements.txt
@@ -41,5 +41,5 @@ tqdm==4.67.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
-urllib3==2.6.3
+urllib3==2.7.0
 wrapt==2.0.1


### PR DESCRIPTION
## Proposed changes

Dependabot only opened a PR for requirements.txt under translation/, even though warning about both cases.

[Preview(-devel)](https://csc-guide-preview-devel.2.rahtiapp.fi/origin/urllib3-vuln/)

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
