### PR TITLE
Add Roihu to r-env documentation

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -22,7 +22,7 @@ catalog:
 -   RStudio Server is an integrated development environment (IDE) for R. More information on RStudio can be found on the [RStudio website](https://posit.co/products/open-source/rstudio).
 
 !!! info "News"
-    **25.5.2026** `r-env` documentation has been updated with instructions in R use on the upcoming Roihu supercomputer.  
+    **25.5.2026** `r-env` documentation has been updated with instructions in R use on the Roihu supercomputer.  
     **29.4.2026** `r-env` documentation has been updated and re-organised. Template scripts for parallel R batch jobs can now be found 
     on a separate tutorial page [Parallel R batch job examples](../support/tutorials/parallel-r-examples.md).  
     **17.2.2026** R version 4.5.2 is now available in `r-env` in Puhti and Mahti and is set as the default version.  
@@ -34,7 +34,7 @@ catalog:
 
 ## Available
 
-`r-env` includes 1500+ pre-installed R packages, including support for [geospatial analyses](r-env-for-gis.md) and parallel computing. For improved performance, `r-env` has been compiled using the [Intel® oneAPI Math Kernel Library (oneMKL)](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html) (formerly Intel® MKL).
+`r-env` includes 1700+ pre-installed R packages, including support for [geospatial analyses](r-env-for-gis.md) and parallel computing. For improved performance, `r-env` has been compiled using the [Intel® oneAPI Math Kernel Library (oneMKL)](https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl.html) (formerly Intel® MKL).
 
 With a small number of exceptions, R package versions on `r-env` are date-locked ([CRAN packages](https://cran.r-project.org/web/packages/index.html)) or fixed to a specific [Bioconductor](https://www.bioconductor.org/) version.
 
@@ -43,7 +43,7 @@ Current modules and versions supported on CSC's supercomputers:
 === "Roihu-CPU"
     | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version | Cmdstan version |
     |:-----------------------:|:--------------------|:--------------------:|:----------------------:|:--------------:|:---------------:|
-    | r-env/452 (default)     | Apr 4 2026          | 3.22                 | 2026.01.0-392          | 2025.3.0       | 2.38.0          |
+    | r-env/452 (default)     | Apr 4 2026          | 3.22                 | 2026.01.0-392          | 2025.3.0       | 2.39.0          |
 
 === "Puhti"
     | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version | Cmdstan version |
@@ -512,7 +512,7 @@ To use it, one must set the correct path to CmdStan using `cmdstanr`. For exampl
 
 === "Roihu-CPU"
     ```r
-    cmdstanr::set_cmdstan_path("/appl/soft/manual/aida/x86_64/r-env/452-stan/cmdstan-2.38.0")
+    cmdstanr::set_cmdstan_path("/appl/soft/manual/aida/x86_64/r-env/452-stan/cmdstan-2.39.0")
     ```
     If a model fails to compile, try running `module purge` before starting R.
     
@@ -528,14 +528,7 @@ To use it, one must set the correct path to CmdStan using `cmdstanr`. For exampl
 If you are using CmdStan in an interactive session, the above command will work directly. For non-interactive batch jobs, the path to CmdStan needs to be separately set in the batch job file. This is done by including the following commands further to your other batch job file contents: 
 
 === "Roihu-CPU"
-    ```r
-    # Set R version
-    export RVER=452
-    
-    # Launch R after binding CmdStan
-    SING_FLAGS="$SING_FLAGS -B /appl/soft/manual/aida/x86_64/r-env/${RVER}-stan:/appl/soft/manual/aida/x86_64/r-env/${RVER}-stan"
-    srun Rscript --no-save script.R
-    ```
+    Under construction. Sorry for any inconvenience and please check back later!
 
 === "Puhti"
     ```r
@@ -560,6 +553,8 @@ If you are using CmdStan in an interactive session, the above command will work 
 Other details on using the CmdStan backend are package-specific. As one example, one could use it with the [`brms`](https://paul-buerkner.github.io/brms/) package:
 
 ```r
+# Note: this doesn't currently work in Roihu, but we are trying to find a solution. 
+
 library(brms)
 
 fit_serial <- brm(

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -22,7 +22,7 @@ catalog:
 -   RStudio Server is an integrated development environment (IDE) for R. More information on RStudio can be found on the [RStudio website](https://posit.co/products/open-source/rstudio).
 
 !!! info "News"
-    **25.5.2026** `r-env` documentation has been updated with instructions in R use on the Roihu supercomputer.  
+    **25.5.2026** `r-env` documentation has been updated with instructions for R use on the Roihu supercomputer.  
     **29.4.2026** `r-env` documentation has been updated and re-organised. Template scripts for parallel R batch jobs can now be found 
     on a separate tutorial page [Parallel R batch job examples](../support/tutorials/parallel-r-examples.md).  
     **17.2.2026** R version 4.5.2 is now available in `r-env` in Puhti and Mahti and is set as the default version.  

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -10,6 +10,7 @@ catalog:
   available_on:
     - Puhti
     - Mahti
+    - Roihu
 ---
 
 # r-env
@@ -21,6 +22,7 @@ catalog:
 -   RStudio Server is an integrated development environment (IDE) for R. More information on RStudio can be found on the [RStudio website](https://posit.co/products/open-source/rstudio).
 
 !!! info "News"
+    **25.5.2026** `r-env` documentation has been updated with instructions in R use on the upcoming Roihu supercomputer.  
     **29.4.2026** `r-env` documentation has been updated and re-organised. Template scripts for parallel R batch jobs can now be found 
     on a separate tutorial page [Parallel R batch job examples](../support/tutorials/parallel-r-examples.md).  
     **17.2.2026** R version 4.5.2 is now available in `r-env` in Puhti and Mahti and is set as the default version.  
@@ -37,6 +39,11 @@ catalog:
 With a small number of exceptions, R package versions on `r-env` are date-locked ([CRAN packages](https://cran.r-project.org/web/packages/index.html)) or fixed to a specific [Bioconductor](https://www.bioconductor.org/) version.
 
 Current modules and versions supported on CSC's supercomputers:
+
+=== "Roihu-CPU"
+    | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version | Cmdstan version |
+    |:-----------------------:|:--------------------|:--------------------:|:----------------------:|:--------------:|:---------------:|
+    | r-env/452 (default)     | Apr 4 2026          | 3.22                 | 2026.01.0-392          | 2025.3.0       | 2.38.0          |
 
 === "Puhti"
     | Module name (R version) | CRAN package dating | Bioconductor version | RStudio Server version | oneMKL version | Cmdstan version |
@@ -57,9 +64,10 @@ Current modules and versions supported on CSC's supercomputers:
     | r-env/451               | July 7 2025         | 3.21                 | 2025.05.1-513          | 2025.2.0       | 2.36.0          |
     | r-env/442               | Feb 12 2025         | 3.20                 | 2024.12.0-467          | 2025.0.1       | 2.36.0          |
 
+
 Other software and libraries:
 
-- Open MPI (with Mellanox OFED™ software) 4.1.7 (r-env/451, r-env/452) , 4.1.2 (from r-env/421 to r-env 442)
+- Open MPI (with Mellanox OFED™ software) 4.1.9 (r-env/452 on Roihu-CPU), 4.1.7 (r-env/452 on Puhti and Mahti, r-env/451), 4.1.2 (from r-env/421 to r-env 442)
 - TensorFlow 2.20.0 (r-env/452), 2.19.0 (r-env/451), 2.18.0 (r-env/442), 2.9.1 (from r-env/421 to r-env/440)
 - cget 0.2.0
 
@@ -97,10 +105,10 @@ There are several ways to use R with the `r-env` module:
 
   -   R console in the command line in an [interactive shell session on a compute node](../computing/running/interactive-usage.md) 
 
-  -   On the login node, using the R console. Use this option only for moving data, checking package availability and installing packages. Puhti login nodes are [not intended for heavy computing](../computing/usage-policy.md#login-nodes). 
+  -   On the login node, using the R console. Use this option only for moving data, checking package availability and installing packages. Login nodes are [not intended for heavy computing](../computing/usage-policy.md#login-nodes). 
 
 !!! note ""
-    Interactive jobs running in the `interactive` partition have specific limits on resources (time, memory, CPU cores). See [available resources on Puhti](../computing/running/batch-job-partitions.md#puhti-interactive-partition) and [available resources on Mahti](../computing/running/batch-job-partitions.md#mahti-cpu-partitions-with-core-based-allocation).
+    Interactive jobs running in the `interactive` partition have specific limits on resources (time, memory, CPU cores). See [available resources on Roihu](../computing/running/batch-job-partitions.md#roihu-cpu-partitions), on [Puhti](../computing/running/batch-job-partitions.md#puhti-interactive-partition) and on [Mahti](../computing/running/batch-job-partitions.md#mahti-cpu-partitions-with-core-based-allocation).
 
 **Non-interactive use**
 
@@ -131,38 +139,75 @@ To use R interactively from the command line on a compute node, first start an [
     **Option 1.** In the [supercomputer web interfaces](../computing/webinterface/index.md), open a shell session with the *Compute node shell* tool. When selecting the resources, make sure to reserve local disk space for temporary files. 
     
     **Option 2.** When [connecting to the supercomputer with an SSH client on your own workstation](../computing/connecting/index.md#using-an-ssh-client), open a shell session using the [`sinteractive` command](../computing/running/interactive-usage.md). 
-    As an example, the command below would launch a session with 4 GB of memory and 8 GB of local disk. Local disk space should always be reserved for temporary files with the option `--tmp` when using R interactively.
+    As an example, the command below would launch a session with 4 GB of memory and 8 GB of local disk (on Puhti and Mahti).
 
+    === "Roihu-CPU"
+          Each core gives 1.875 GB of memory. To get more memory, reserve more cores (maximum 32 cores for 60 GB of memory).
+          Each user has 20 GB of temporary disk space by default in the `interactive` partition.
+          
+          ``` bash
+          sinteractive --account <project> --cores 2
+          ```
+    
     === "Puhti"
+        Local disk space should always be reserved for temporary files with the option `--tmp` when using R interactively.
+        
         ``` bash
         sinteractive --account <project> --mem 4000 --tmp 8
         ```
               
     === "Mahti"
+          On Mahti, each core gives 1.875 GB of memory.
+          Local disk space should always be reserved for temporary files with the option `--tmp` when using R interactively.
+          
           ``` bash
-          # On Mahti, each core gives 1.875 GB of memory
           sinteractive --account <project> --cores 2 --tmp 8
           ```
+    
           
     It is possible to specify other options including the running time ([see the `sinteractive` documentation](../computing/running/interactive-usage.md)).
 
 Once you have opened an interactive shell session, you can **launch a command line version of R** as follows (note that the command needs to be run on a compute node):
 
-``` bash
-module load r-env
-start-r
-```
+=== "Roihu-CPU"
+    ``` bash
+    module load r-env
+    start-r
+    ```
+=== "Puhti"
+    ``` bash
+    module load r-env
+    start-r
+    ```
+=== "Mahti"
+    ``` bash
+    module load r-env
+    start-r
+    ```
+
 
 ### Interactive use on a login node
 
-It is also possible to use the R console on the login node for **light tasks**. Use this option only for moving data, checking package availability and installing packages. Puhti login nodes are [not intended for heavy computing](../computing/usage-policy.md#login-nodes).
+It is also possible to use the R console on the login node for **light tasks**. Use this option only for moving data, checking package availability and installing packages. Login nodes are [not intended for heavy computing](../computing/usage-policy.md#login-nodes).
 
 To launch the R console on a login node, run the following commands:
 
-``` bash
-module load r-env
-apptainer_wrapper exec R --no-save
-```
+=== "Roihu-CPU"
+    ``` bash
+    module load r-env
+    apptainer exec --bind=$(csc-common-bind) R --no-save
+    ```
+=== "Puhti"
+    ``` bash
+    module load r-env
+    apptainer_wrapper exec R --no-save
+    ```
+=== "Mahti"
+    ``` bash
+    module load r-env
+    apptainer_wrapper exec R --no-save
+    ```
+
 
 ### Non-interactive batch jobs
 
@@ -175,21 +220,42 @@ of the [CSC Computing Environment course on batch jobs](https://csc-training.git
 #### Basic R batch job script
 
 Below is an example for submitting a serial R batch job that uses one core. Note that the `test` partition is used, which has a time limit of 15 minutes and is used for testing purposes only. 
-Actual R batch jobs should in most cases be run in the `small` partition. See here for details on the available batch job partitions [on Puhti](../computing/running/batch-job-partitions.md#puhti-partitions) and [on Mahti](../computing/running/batch-job-partitions.md#mahti-partitions).
+Actual R batch jobs should in most cases be run in the `small` partition. See here for details on the available batch job partitions on [Roihu](../computing/running/batch-job-partitions.md#roihu-partitions), [Puhti](../computing/running/batch-job-partitions.md#puhti-partitions) and [Mahti](../computing/running/batch-job-partitions.md#mahti-partitions).
 
 !!! info "More than one CPU core?"
     By default, R uses one CPU core. When you are working with an R script or package that can take advantage of multiple cores and parallel processing, take a look 
     at the examples of [parallel R batch job scripts](../support/tutorials/parallel-r-examples.md).
 
-We define the batch job script to execute the R script (here `myscript.R`) using the `apptainer_wrapper` command, which makes sure project directories are visible in the Apptainer container that `r-env` runs in.
+We define the batch job script to execute the R script (here `myscript.R`). On Puhti and Mahti, we use the `apptainer_wrapper` command, which makes sure project directories are visible in the Apptainer container that `r-env` runs in.
+
+=== "Roihu-CPU"
+    ``` bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_serial     # Job name
+    #SBATCH --account=<project>     # Define the billing project, e.g. project_2001234
+    #SBATCH --output=output_%j.txt  # File for storing output (%j will be job id)
+    #SBATCH --error=errors_%j.txt   # File for storing errors (%j will be job id)
+    #SBATCH --partition=test        # Job partition (queue), in general use 'small'
+    #SBATCH --time=00:05:00         # Max. duration of the job (hh:mm:ss)
+    #SBATCH --cpus-per-task=1       # Number of cores
+    #SBATCH --ntasks=1              # Number of tasks (only change this for multi-node/MPI jobs)
+    #SBATCH --nodes=1               # Number of nodes (only change this for multi-node/MPI jobs)
+    #SBATCH --mem-per-cpu=2000M     # Memory to reserve per CPU core
+
+    # Load the r-env module
+    module load r-env
+  
+    # Run the R script
+    srun Rscript --no-save myscript.R
+    ```
 
 === "Puhti"
     ``` bash
     #!/bin/bash -l
     #SBATCH --job-name=r_serial     # Job name
     #SBATCH --account=<project>     # Define the billing project, e.g. project_2001234
-    #SBATCH --output=output_%j.txt  # File for storing output (%j will be replaced by job id)
-    #SBATCH --error=errors_%j.txt   # File for storing errors
+    #SBATCH --output=output_%j.txt  # File for storing output (%j will be job id)
+    #SBATCH --error=errors_%j.txt   # File for storing errors (%j will be job id)
     #SBATCH --partition=test        # Job queue (partition): in general use 'small'
     #SBATCH --time=00:05:00         # Max. duration of the job (hh:mm:ss)
     #SBATCH --cpus-per-task=1       # Number of cores
@@ -217,8 +283,8 @@ We define the batch job script to execute the R script (here `myscript.R`) using
     #!/bin/bash -l
     #SBATCH --job-name=r_serial     # Job name
     #SBATCH --account=<project>     # Define the billing project, e.g. project_2001234
-    #SBATCH --output=output_%j.txt  # File for storing output (%j replaced by job id)
-    #SBATCH --error=errors_%j.txt   # File for storing errors (%j replaced by job id)
+    #SBATCH --output=output_%j.txt  # File for storing output (%j will be job id)
+    #SBATCH --error=errors_%j.txt   # File for storing errors (%j will be job id)
     #SBATCH --partition=test        # Job queue (partition), in general use 'small'
     #SBATCH --time=00:05:00         # Max. duration of the job (hh:mm:ss)
     #SBATCH --cpus-per-task=1       # Number of cores (1.875 GB of memory each)
@@ -240,16 +306,36 @@ We define the batch job script to execute the R script (here `myscript.R`) using
     srun apptainer_wrapper exec Rscript --no-save myscript.R
     ```
 
-In the above example, one task (`--ntasks=1`) is executed with 1 CPU core (`--cpus-per-task=1`), 2 GB of memory (`--mem-per-cpu=2000`) and a run time of five minutes (`--time=00:05:00`) reserved for the job.
+In the above example, one task (`--ntasks=1`) is executed with 1 CPU core (`--cpus-per-task=1`), 2 GB of memory (`--mem-per-cpu=2000M`) and a run time of five minutes (`--time=00:05:00`) reserved for the job.
 
 The command `module load r-env` loads the latest `r-env` version [available](#available). To specify which module version is loaded, use `module load r-env/<version>`, for example `module load r-env/452`.
 
-!!! warning "Important"
-    In R batch jobs, please make sure to specify a **temporary directory path** to the `scratch` directory of your project `/scratch/<project>` as in the example above. Or, if your job [reads and writes a lot of files](../computing/running/performance-checklist.md#mind-your-io-it-can-make-a-big-difference), 
-    use instead [the fast local disk](#using-fast-local-storage).  
+!!! warning "Important: make sure your R batch job has enough disk space for temporary files"
+    === "Roihu-CPU"
+        Each user has [20 GiB of temporary storage on the local disk](../computing/running/creating-job-scripts-roihu.md#local-temporary-storage) by default on the partitions `small`, `interactive`, and `test`.
+        This storage is accessed with the environment variable `$TMPDIR`.
+        
+        If your R jobs produce very many or very large temporary files exceeding 20 GiB, 
+        please direct temporary files to the `/scratch` directory of your project as below, or to the [fast local scratch storage](../computing/running/creating-job-scripts-roihu.md#fast-local-scratch-storage) (only available on Roihu for jobs using full nodes at the moment). Note that full node jobs on the 
+        `medium` partition provide 600 GiB of temporary storage by default.
+        
+        ```bash
+        # Add this line to the batch job script to direct temporary files to the /scratch directory of your 
+        # project (replace <project> with your project)
     
-    Otherwise temporary files will go to `/tmp`, which has limited space and fills up easily, harming your and other users' jobs.
-
+        echo "TMPDIR=/scratch/<project>" >> ~/.Renviron
+        ```
+    
+    === "Puhti"
+        Please make sure to specify a **temporary directory path** to the `scratch` directory of your project `/scratch/<project>` as in the example above. Or, if your job [reads and writes a lot of files](../computing/running/performance-checklist.md#mind-your-io-it-can-make-a-big-difference), 
+        use instead [the fast local disk](#using-fast-local-storage). Otherwise temporary files will go to `/tmp`, which has limited space and fills up easily, harming your and other users' jobs.
+    
+    === "Mahti"
+        Please make sure to specify a **temporary directory path** to the `scratch` directory of your project `/scratch/<project>` as in the example above. Or, if your job [reads and writes a lot of files](../computing/running/performance-checklist.md#mind-your-io-it-can-make-a-big-difference), 
+        use instead [the fast local disk](#using-fast-local-storage). Otherwise temporary files will go to `/tmp`, which has limited space and fills up easily, harming your and other users' jobs.
+    
+          
+    
 When ready, the batch job file is **submitted to the batch job system on a login node**:
 
 ``` bash
@@ -340,7 +426,11 @@ echo "R_LIBS=/projappl/<project>/project_rpackages_<rversion>" >> ~/.Renviron
 
 For jobs that read and write large numbers of files (I/O-intensive analyses), [fast local storage](../computing/running/creating-job-scripts-puhti.md#local-storage) can be used in non-interactive batch jobs with minor changes to the batch job file. Interactive R jobs use fast local storage by default.
 
-An example of a serial batch job using 10 GB of fast local storage (`--gres=nvme:10`) is given below. Here a temporary directory is specified using the environment variable `TMPDIR`, in contrast to the prior example where it was set as `/scratch/<project>`.
+An example of a serial batch job using 10 GB of fast local storage (`--gres=nvme:10`) on Puhti and Mahti is given below. Here a temporary directory is specified using the environment variable `TMPDIR`, in contrast to the prior example where it was set as `/scratch/<project>`.
+
+=== "Roihu-CPU"
+    On Roihu CPU partitions `small`, `interactive`, and `test`, **each user has 20 GiB of temporary local storage by default**. This storage is suitable for I/O-intensive tasks and accessed with
+    the environment variable `$TMPDIR`. For larger amounts of storage for I/O intensive tasks, see the [instructions on fast local scratch storage on Roihu](../computing/running/creating-job-scripts-roihu.md#fast-local-scratch-storage).
 
 === "Puhti"
     ``` bash
@@ -371,6 +461,11 @@ An example of a serial batch job using 10 GB of fast local storage (`--gres=nvme
     # Run the R script
     srun apptainer_wrapper exec Rscript --no-save myscript.R
     ```
+    Further to temporary file storage, data sets for analysis can be stored on a fast local drive in the location specified by the variable `LOCAL_SCRATCH`. To enable R to find your data, you will need to indicate this location in your R script. After launching R, you can print out the location using the following command:
+
+    ```         
+    Sys.getenv("LOCAL_SCRATCH")
+    ```
     
 === "Mahti"
     ``` bash
@@ -400,12 +495,11 @@ An example of a serial batch job using 10 GB of fast local storage (`--gres=nvme
     # Run the R script
     srun apptainer_wrapper exec Rscript --no-save myscript.R
     ```
+    Further to temporary file storage, data sets for analysis can be stored on a fast local drive in the location specified by the variable `LOCAL_SCRATCH`. To enable R to find your data, you will need to indicate this location in your R script. After launching R, you can print out the location using the following command:
 
-Further to temporary file storage, data sets for analysis can be stored on a fast local drive in the location specified by the variable `LOCAL_SCRATCH`. To enable R to find your data, you will need to indicate this location in your R script. After launching R, you can print out the location using the following command:
-
-```         
-Sys.getenv("LOCAL_SCRATCH")
-```
+    ```         
+    Sys.getenv("LOCAL_SCRATCH")
+    ```
 
 ### Using `r-env` with Stan
 
@@ -416,20 +510,52 @@ The `r-env` module includes several packages that provide an interface to [Stan]
 The `r-env` module comes with a separate [CmdStan](https://github.com/stan-dev/cmdstan) installation that is specific to [each module version](#available).
 To use it, one must set the correct path to CmdStan using `cmdstanr`. For example, for `r-env/452` this would be done as follows:
 
-```r
-cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/452-stan/cmdstan-2.38.0")
-```
+=== "Roihu-CPU"
+    ```r
+    cmdstanr::set_cmdstan_path("/appl/soft/manual/aida/x86_64/r-env/452-stan/cmdstan-2.38.0")
+    ```
+    If a model fails to compile, try running `module purge` before starting R.
+    
+=== "Puhti"   
+    ```r
+    cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/452-stan/cmdstan-2.38.0")
+    ```
+=== "Mahti"    
+    ```r
+    cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/452-stan/cmdstan-2.38.0")
+    ```
 
 If you are using CmdStan in an interactive session, the above command will work directly. For non-interactive batch jobs, the path to CmdStan needs to be separately set in the batch job file. This is done by including the following commands further to your other batch job file contents: 
 
-```r
-# Set R version
-export RVER=452
+=== "Roihu-CPU"
+    ```r
+    # Set R version
+    export RVER=452
+    
+    # Launch R after binding CmdStan
+    SING_FLAGS="$SING_FLAGS -B /appl/soft/manual/aida/x86_64/r-env/${RVER}-stan:/appl/soft/manual/aida/x86_64/r-env/${RVER}-stan"
+    srun Rscript --no-save script.R
+    ```
 
-# Launch R after binding CmdStan
-SING_FLAGS="$SING_FLAGS -B /appl/soft/math/r-env/${RVER}-stan:/appl/soft/math/r-env/${RVER}-stan"
-srun apptainer_wrapper exec Rscript --no-save script.R
-```
+=== "Puhti"
+    ```r
+    # Set R version
+    export RVER=452
+    
+    # Launch R after binding CmdStan
+    SING_FLAGS="$SING_FLAGS -B /appl/soft/math/r-env/${RVER}-stan:/appl/soft/math/r-env/${RVER}-stan"
+    srun apptainer_wrapper exec Rscript --no-save script.R
+    ```
+
+=== "Mahti"
+    ```r
+    # Set R version
+    export RVER=452
+    
+    # Launch R after binding CmdStan
+    SING_FLAGS="$SING_FLAGS -B /appl/soft/math/r-env/${RVER}-stan:/appl/soft/math/r-env/${RVER}-stan"
+    srun apptainer_wrapper exec Rscript --no-save script.R
+    ```
 
 Other details on using the CmdStan backend are package-specific. As one example, one could use it with the [`brms`](https://paul-buerkner.github.io/brms/) package:
 

--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -195,7 +195,7 @@ To launch the R console on a login node, run the following commands:
 === "Roihu-CPU"
     ``` bash
     module load r-env
-    apptainer exec --bind=$(csc-common-bind) R --no-save
+    R --no-save
     ```
 === "Puhti"
     ``` bash

--- a/docs/support/tutorials/parallel-r-examples.md
+++ b/docs/support/tutorials/parallel-r-examples.md
@@ -25,6 +25,28 @@ You may also wish to check the relevant R package manuals and [CSC's Geocomputin
 
 Array jobs can be used to handle [*embarrassingly parallel*](../../computing/running/array-jobs.md) tasks and to submit several concurrently running Slurm jobs. The example script below would submit a job involving ten independent subtasks on the `small` partition, with each requiring less than 45 minutes of computing time and less than 2 GB of memory.
 
+=== "Roihu-CPU"    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_array
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%A_%a.txt
+    #SBATCH --error=errors_%A_%a.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:45:00
+    #SBATCH --array=1-10
+    #SBATCH --ntasks=1
+    #SBATCH --nodes=1
+    #SBATCH --cpus-per-task=1
+    #SBATCH --mem-per-cpu=2000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun Rscript --no-save myscript.R $SLURM_ARRAY_TASK_ID
+    ```
+
 === "Puhti"
     ```bash
     #!/bin/bash -l
@@ -67,7 +89,7 @@ Array jobs can be used to handle [*embarrassingly parallel*](../../computing/run
     #SBATCH --array=1-10
     #SBATCH --ntasks=1
     #SBATCH --nodes=1
-    #SBATCH --cpus-per-task=1 # Each core gives 1.875 GB of memory
+    #SBATCH --cpus-per-task=1  # Each core gives 1.875 GB of memory
     
     # Load r-env
     module load r-env
@@ -83,6 +105,7 @@ Array jobs can be used to handle [*embarrassingly parallel*](../../computing/run
     # Run the R script
     srun apptainer_wrapper exec Rscript --no-save myscript.R $SLURM_ARRAY_TASK_ID
     ```
+
 
 If we wanted to access the array number `$SLURM_ARRAY_TASK_ID` within our R script, we could use the `commandArgs` or `Sys.getenv`function.
 
@@ -100,7 +123,29 @@ than about 30 minutes and the number of subtasks is up to 400. For larger array 
 
 ## Multi-core jobs
 
-The following batch job file shows how to submit a job employing multiple cores on a single [node](https://a3s.fi/CSC_training/02_environment.html#/notes-on-vocabulary). The job reserves a single task (`--ntasks=1`), eight cores (`--cpus-per-task=8`) and a total of 8 GB of memory (`--mem-per-cpu=1000)`. The run time is limited to five minutes.
+The following batch job file shows how to submit a job employing multiple cores on a single [node](https://a3s.fi/CSC_training/02_environment.html#/notes-on-vocabulary). 
+The job reserves a single task (`--ntasks=1`), eight cores (`--cpus-per-task=8`) and a total of 8 GB of memory (`--mem-per-cpu=1000M)`. The run time is limited to five minutes.
+
+=== "Roihu-CPU"
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_multicore
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:05:00
+    #SBATCH --ntasks=1
+    #SBATCH --nodes=1
+    #SBATCH --cpus-per-task=8
+    #SBATCH --mem-per-cpu=1000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun Rscript --no-save myscript.R
+    ```
 
 === "Puhti"
     ```bash
@@ -141,7 +186,7 @@ The following batch job file shows how to submit a job employing multiple cores 
     #SBATCH --time=00:05:00
     #SBATCH --ntasks=1
     #SBATCH --nodes=1
-    #SBATCH --cpus-per-task=8 # Each core gives 1.875 GB of memory
+    #SBATCH --cpus-per-task=8  # Each core gives 1.875 GB of memory
     
     # Load r-env
     module load r-env
@@ -205,7 +250,36 @@ By default, `r-env` is single-threaded. Certain R packages, including [`data.tab
 
 The module uses OpenMP threading technology and the number of threads can be controlled using the environment variable `OMP_NUM_THREADS`. In practice, the number of threads is set to match the number of cores used for the job. Because `r-env` is based on an Apptainer container, when specifying the number of OpenMP threads we need to use the environment variable `APPTAINERENV_OMP_NUM_THREADS`.
 
-An example batch job script can be found below. Here we submit a job using eight cores (and therefore eight threads) on a single node. Notice how we match the number of threads and cores using `APPTAINERENV_OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK`. By using `APPTAINERENV_OMP_PLACES=cores`, we bind each thread to a single core. We also use `APPTAINERENV_OMP_PROC_BIND=close` to ensure that threads are placed as closely as possible (to allow faster communication between threads). Note that [other options](https://theartofhpc.com/pcse/omp-affinity.html) for controlling thread affinity are also available, depending on your analysis.
+An example batch job script can be found below. Here we submit a job using eight cores (and therefore eight threads) on a single node. Notice how we match the number of threads and cores using `APPTAINERENV_OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK`. By using `APPTAINERENV_OMP_PLACES=cores`, we bind each thread to a single core. Note that [other options](https://theartofhpc.com/pcse/omp-affinity.html) for controlling thread affinity are also available, depending on your analysis.
+
+=== "Roihu-CPU"
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_multithread
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:05:00
+    #SBATCH --ntasks=1
+    #SBATCH --nodes=1
+    #SBATCH --cpus-per-task=8
+    #SBATCH --mem-per-cpu=2000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Match thread and core numbers
+    export APPTAINERENV_OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+    
+    # Place and bind threads to single cores
+    # Comment the following lines if binding is not desired
+    export APPTAINERENV_OMP_PLACES=cores
+    export APPTAINERENV_OMP_PROC_BIND=spread
+    
+    # Run the R script
+    srun Rscript --no-save myscript.R
+    ```
 
 === "Puhti"
     ```bash
@@ -254,7 +328,7 @@ An example batch job script can be found below. Here we submit a job using eight
     #SBATCH --time=00:05:00
     #SBATCH --ntasks=1
     #SBATCH --nodes=1
-    #SBATCH --cpus-per-task=8 # Each core gives 1.875 GB of memory
+    #SBATCH --cpus-per-task=8  # Each core gives 1.875 GB of memory
     
     # Load r-env
     module load r-env
@@ -276,7 +350,7 @@ An example batch job script can be found below. Here we submit a job using eight
     # Run the R script
     srun apptainer_wrapper exec Rscript --no-save myscript.R
     ```
-
+    
 In a multi-core interactive job, the number of threads can be automatically matched with the number of cores by running a multi-threaded version of the `start-r` or `start-rstudio-server` commands:
 
 ```bash
@@ -298,13 +372,30 @@ must specify one more task than the planned number of workers, as the master nee
 While otherwise the batch job file looks similar to that used for a multi-core job, we replace `--cpus-per-task=x` 
 with `--ntasks-per-node=x` and use `--nodes` to set the number of nodes. Number of workers generally equals `ntasks-per-node x nodes - 1`. In addition, we could modify the `srun` command at the end of the batch job file:
 
+=== "Roihu-CPU"
+    ```bash
+    # MPI jobs started with `snow`
+    srun RMPISNOW --no-save --slave myscript.R
+    
+    # MPI jobs started without `snow`
+    srun Rscript --no-save --slave myscript.R
+    ```
+
 === "Puhti"
     ```bash
+    # MPI jobs started with `snow`
+    srun apptainer_wrapper exec RMPISNOW --no-save --slave myscript.R
+    
+    # MPI jobs started without `snow`
     srun apptainer_wrapper exec Rscript --no-save --slave myscript.R
     ```
 
 === "Mahti"
     ```bash
+    # MPI jobs started with `snow`
+    srun apptainer_wrapper exec RMPISNOW --no-save --slave myscript.R
+    
+    # MPI jobs started without `snow`
     srun apptainer_wrapper exec Rscript --no-save --slave myscript.R
     ```
 
@@ -320,6 +411,50 @@ For more information, see the [general documentation on MPI jobs](../../computin
 To run multi-node analyses with `future`, we choose `plan(cluster)` and launch R using the command `RMPISNOW` from `snow`, instead of `Rscript`. We should specify enough tasks for both the master and worker processes.
 For example, for a job requiring as many workers as possible on two nodes, we could submit a `future` job as follows:
 
+=== "Roihu-CPU"
+    Multiple full nodes:
+    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_future
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=medium
+    #SBATCH --time=01:00:00
+    #SBATCH --ntasks-per-node=384 --cpus-per-task=1  # The product should be 384
+    #SBATCH --nodes=2  # 2 x 384 - 1 = 767 workers
+    #SBATCH --mem-per-cpu=1000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun RMPISNOW --no-save --slave -f myscript.R
+    ```
+    
+    Partial node MPI job:
+    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_future
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=medium
+    #SBATCH --time=01:00:00
+    #SBATCH --ntasks=8  # 8 CPU cores, 7 workers
+    #SBATCH --nodes=1
+    #SBATCH --mem-per-cpu=1000M
+    #SBATCH --hint=nomultithread
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun RMPISNOW --no-save --slave -f myscript.R
+    ```
+
 === "Puhti"
     ```bash
     #!/bin/bash -l
@@ -330,7 +465,7 @@ For example, for a job requiring as many workers as possible on two nodes, we co
     #SBATCH --partition=large
     #SBATCH --time=01:00:00
     #SBATCH --ntasks-per-node=40
-    #SBATCH --nodes=2 # 2 x 40 - 1 = 79 workers
+    #SBATCH --nodes=2  # 2 x 40 - 1 = 79 workers
     #SBATCH --mem-per-cpu=1000
     
     # Load r-env
@@ -357,7 +492,7 @@ For example, for a job requiring as many workers as possible on two nodes, we co
     #SBATCH --error=errors_%j.txt
     #SBATCH --partition=medium
     #SBATCH --time=01:00:00
-    #SBATCH --ntasks-per-node=128 # 2 x 128 - 1 = 255 workers
+    #SBATCH --ntasks-per-node=128  # 2 x 128 - 1 = 255 workers
     #SBATCH --nodes=2
     
     # Load r-env
@@ -392,6 +527,49 @@ stopCluster(cl)
 
 To launch a multi-node R job directly using `snow` that requires as many workers as possible on two nodes, we could submit it as follows. R is launched with `RMPISNOW`, and we must specify one more task than the planned number of `snow` workers, as the master needs its own task.
 
+=== "Roihu-CPU"
+    Multiple full nodes:
+    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_snow
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=medium
+    #SBATCH --time=01:00:00
+    #SBATCH --ntasks-per-node=384 --cpus-per-task=1  # The product should be 384
+    #SBATCH --nodes=2  # 2 x 384 - 1 = 767 workers
+    #SBATCH --mem-per-cpu=1000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun RMPISNOW --no-save --slave -f myscript.R
+    ```
+    
+    Partial node MPI job:
+    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_snow
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=medium
+    #SBATCH --time=01:00:00
+    #SBATCH --ntasks=8  # 8 CPU cores, 7 workers
+    #SBATCH --nodes=1
+    #SBATCH --mem-per-cpu=1000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun RMPISNOW --no-save --slave -f myscript.R
+    ```
+    
 === "Puhti"
     ```bash
     #!/bin/bash -l
@@ -402,7 +580,7 @@ To launch a multi-node R job directly using `snow` that requires as many workers
     #SBATCH --partition=large
     #SBATCH --time=01:00:00
     #SBATCH --ntasks-per-node=40
-    #SBATCH --nodes=2 # 2 x 40 - 1 = 79 workers
+    #SBATCH --nodes=2  # 2 x 40 - 1 = 79 workers
     #SBATCH --mem-per-cpu=1000
     
     # Load r-env
@@ -429,7 +607,7 @@ To launch a multi-node R job directly using `snow` that requires as many workers
     #SBATCH --error=errors_%j.txt
     #SBATCH --partition=medium
     #SBATCH --time=01:00:00
-    #SBATCH --ntasks-per-node=128 # 2 x 128 - 1 = 255 workers
+    #SBATCH --ntasks-per-node=128  # 2 x 128 - 1 = 255 workers
     #SBATCH --nodes=2
     
     # Load r-env
@@ -448,6 +626,20 @@ To launch a multi-node R job directly using `snow` that requires as many workers
     ```
 
 Only the master process runs the R script. The R script must contain the call `getMPIcluster()` that is used to produce a reference to the cluster which can then be passed onto other functions. Upon completion of the analysis, the cluster is stopped using `stopCluster()`. For example:
+
+=== "Roihu-CPU"    
+    ```r
+    cl <- getMPIcluster()
+    
+    funtorun <- function(k) {
+      system.time(sort(runif(1e7)))
+    }
+    
+    system.time(a <- clusterApply(cl, 1:767, funtorun))
+    a
+    
+    stopCluster(cl)
+    ```
 
 === "Puhti"
     ```r
@@ -483,7 +675,87 @@ The `foreach` package implements a for-loop that uses iterators and allows for p
 on multiple cores using many different adapters, such as `doParallel` for the built-in R package `parallel`and `doFuture` for `future`. Multi-node and MPI jobs with `foreach` can 
 be run with the parallel backend of the `doMPI` package. 
 
-Unlike when using `snow`, jobs using `doMPI` launch a number of R sessions equal to the number of reserved tasks that all begin to execute the given R script (here eight). It is important to 
+Unlike when using `snow`, jobs using `doMPI` launch a number of R sessions equal to the number of reserved tasks that all begin to execute the given R script (here eight). 
+
+=== "Roihu-CPU"
+
+    Partial node MPI job:
+    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_dompi
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:05:00
+    #SBATCH --ntasks=8
+    #SBATCH --nodes=1
+    #SBATCH --mem-per-cpu=1000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun Rscript --no-save --slave myscript.R
+    ```
+
+=== "Puhti"
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_dompi
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:05:00
+    #SBATCH --ntasks=8
+    #SBATCH --nodes=1
+    #SBATCH --mem-per-cpu=1000
+    
+    # Load r-env
+    module load r-env
+    
+    # Clean up .Renviron file in home directory
+    if test -f ~/.Renviron; then
+        sed -i '/TMPDIR/d' ~/.Renviron
+    fi
+    
+    # Specify a temporary directory path (replace <project> with your project)
+    echo "TMPDIR=/scratch/<project>" >> ~/.Renviron
+    
+    # Run the R script
+    srun apptainer_wrapper exec Rscript --no-save myscript.R
+    ```
+
+=== "Mahti"    
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_dompi
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:05:00
+    #SBATCH --ntasks=8
+    #SBATCH --nodes=1
+    
+    # Load r-env
+    module load r-env
+    
+    # Clean up .Renviron file in home directory
+    if test -f ~/.Renviron; then
+        sed -i '/TMPDIR/d' ~/.Renviron
+    fi
+    
+    # Specify a temporary directory path (replace <project> with your project)
+    echo "TMPDIR=/scratch/<project>" >> ~/.Renviron
+    
+    # Run the R script
+    srun apptainer_wrapper exec Rscript --no-save myscript.R
+    ```
+
+It is important to 
 include the `startMPIcluster()` call near the beginning of the R script as anything before it will be executed by all available processes (while only the master process continues 
 after it). Upon completion, the cluster is closed using `closeCluster()`. The `mpi.quit()` function can then be used to terminate the MPI execution environment and to quit R:
 
@@ -502,7 +774,29 @@ mpi.quit()
 
 ### Multi-node jobs using `pbdMPI`
 
-In analyses using the `pbdMPI` package, each process runs the same copy of the program as every other process while operating on its own data. In other words, there is no separate master process as in `snow` or `doMPI`. Executing batch jobs using `pbdMPI` can be done using the `srun apptainer_wrapper exec Rscript` command. For example, we could submit a job using all the cores of two nodes (with one half of the total tasks allocated to each node):
+In analyses using the `pbdMPI` package, each process runs the same copy of the program as every other process while operating on its own data. In other words, there is no separate master process as in `snow` or `doMPI`. Executing batch jobs using `pbdMPI` can be done using the `Rscript` command without `snow`. For example, we could submit a job using all the cores of two nodes (with one half of the total tasks allocated to each node):
+
+=== "Roihu-CPU"
+    Multiple full nodes:
+   
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_pbdmpi
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=medium
+    #SBATCH --time=00:05:00
+    #SBATCH --ntasks-per-node=384 --cpus-per-task=1  # The product should be 384
+    #SBATCH --nodes=2
+    #SBATCH --mem-per-cpu=2000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Run the R script
+    srun Rscript --no-save --slave myscript.R
+    ```
 
 === "Puhti"
     ```bash
@@ -574,7 +868,7 @@ finalize()
 
 ## OpenMP / MPI hybrid jobs
 
-Further to [executing multi-threaded R jobs on a single node](../tutorials/parallel-r-examples.md#improving-performance-using-threading), these can also be run on multiple nodes. In such cases, one must specify the number of:
+Further to [executing multi-threaded R jobs on a single node](#improving-performance-using-threading), these can also be run on multiple nodes. In such cases, one must specify the number of:
 
 - Nodes (`--nodes`) 
 
@@ -584,7 +878,36 @@ Further to [executing multi-threaded R jobs on a single node](../tutorials/paral
 
 When listing these in a batch job file, note that `--ntasks-per-node × --cpus-per-task` must be less than or equal to the maximum number of cores available on a single node. For large multi-node jobs, aim to use full nodes, i.e. use all cores in each node. Further to selecting a suitable number of OpenMP threads, identifying the optimal number and division of MPI processes will require experimentation due to these being job-specific. 
 
-As an example of an OpenMP / MPI hybrid job, the submission below would use a total of four MPI processes (two tasks per node with two nodes reserved), with each process employing eight OpenMP threads. Overall, on Puhti the job would use 32 cores (`--cpus-per-task × --ntasks-per-node × --nodes`). As with multi-threaded jobs running on a single node, the number of threads and cores is matched using `APPTAINERENV_OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK`. We also use the same variables for thread affinity control.
+As an example of an OpenMP / MPI hybrid job, the submission below would use a total of four MPI processes (two tasks per node with two nodes reserved), with each process employing multiple OpenMP threads (`--cpus-per-task`). Overall, the job would use `--cpus-per-task × --ntasks-per-node × --nodes` cores. As with multi-threaded jobs running on a single node, the number of threads and cores is matched using `APPTAINERENV_OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}`. We also use the same variables for thread affinity control.
+
+=== "Roihu-CPU"
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_multithread_multinode
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j.txt
+    #SBATCH --error=errors_%j.txt
+    #SBATCH --partition=medium
+    #SBATCH --time=00:05:00
+    #SBATCH --nodes=2
+    #SBATCH --ntasks-per-node=2
+    #SBATCH --cpus-per-task=25
+    #SBATCH --mem-per-cpu=2000M
+    
+    # Load r-env
+    module load r-env
+    
+    # Match thread and core numbers
+    export APPTAINERENV_OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+    
+    # Place and bind threads to single cores
+    # Comment the following lines if binding is not desired
+    export APPTAINERENV_OMP_PLACES=cores
+    export APPTAINERENV_OMP_PROC_BIND=spread
+    
+    # Run the R script
+    srun Rscript --no-save myscript.R
+    ```
 
 === "Puhti"
     ```bash
@@ -632,7 +955,7 @@ As an example of an OpenMP / MPI hybrid job, the submission below would use a to
     #SBATCH --time=00:05:00
     #SBATCH --nodes=2
     #SBATCH --ntasks-per-node=2 
-    #SBATCH --cpus-per-task=64 # ntasks-per-node x cpus-per-task should equal 128
+    #SBATCH --cpus-per-task=64  # ntasks-per-node x cpus-per-task should equal 128
     
     # Load r-env
     module load r-env
@@ -674,6 +997,35 @@ To perform our analysis efficiently, we could take advantage of a module includi
 - We use `-j $SLURM_CPUS_PER_TASK -k`  to tell GNU parallel to keep running 4 applications in parallel, while ensuring that the job output order matches the input order.  The number of simultaneous parallel applications is defined using `--cpus-per-task`.
 
 - For a real-life analysis, we would likely need much more time and memory (determined by what we do within our R script).
+
+=== "Roihu-CPU"
+    ```bash
+    #!/bin/bash -l
+    #SBATCH --job-name=r_array_gnupara
+    #SBATCH --account=<project>
+    #SBATCH --output=output_%j_%a.txt
+    #SBATCH --error=errors_%j_%a.txt
+    #SBATCH --partition=small
+    #SBATCH --time=00:05:00
+    #SBATCH --array=0-9
+    #SBATCH --ntasks=1
+    #SBATCH --nodes=1
+    #SBATCH --cpus-per-task=4
+    #SBATCH --mem-per-cpu=2000M
+    
+    # Load parallel and r-env
+    module load parallel
+    module load r-env
+    
+    # Split runs into arrays and run the R script
+    (( from_run = SLURM_ARRAY_TASK_ID * 150 + 1 ))
+    (( to_run = SLURM_ARRAY_TASK_ID * 150 + 150 ))
+    
+    sed -n "${from_run},${to_run}p" mylist.txt | \
+        parallel -j $SLURM_CPUS_PER_TASK -k \
+            Rscript --no-save myscript.R \
+                    $SLURM_ARRAY_TASK_ID
+    ```
 
 === "Puhti"
     ```bash
@@ -724,7 +1076,7 @@ To perform our analysis efficiently, we could take advantage of a module includi
     #SBATCH --array=0-9
     #SBATCH --ntasks=1
     #SBATCH --nodes=1
-    #SBATCH --cpus-per-task=4 # Each core gives 1.875 GB of memory
+    #SBATCH --cpus-per-task=4  # Each core gives 1.875 GB of memory
     
     # Load parallel and r-env
     module load parallel

--- a/docs/support/tutorials/parallel-r-examples.md
+++ b/docs/support/tutorials/parallel-r-examples.md
@@ -246,11 +246,11 @@ packages in the script section that is run in parallel and use `clusterExport` t
 
 `r-env` has been compiled using the Intel® oneAPI Math Kernel Library (oneMKL), enabling the execution of data analysis tasks using multiple threads. For more information on threading, [see the Intel® website](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2025-0/improving-performance-with-threading.html). 
 
-By default, `r-env` is single-threaded. Certain R packages, including [`data.table`](https://r-datatable.com/), [`mgcv`](https://stat.ethz.ch/R-manual/R-devel/library/mgcv/html/mgcv-parallel.html) and [`ranger`](https://cran.r-project.org/web/packages/ranger/ranger.pdf), offer direct support for multithreading. Jobs using other types of R packages could also benefit from multithreading, depending on the analysis. For example, multithreading can help speed up linear algebra routines. To find out whether multithreading benefits a specific analysis, we encourage experimenting with different thread numbers and benchmarking your code using a small example data set and, for example, the R package [`microbenchmark`](https://cran.r-project.org/web/packages/microbenchmark/index.html).
+By default, `r-env` is single-threaded. Certain R packages, including [`data.table`](https://r-datatable.com/), [`mgcv`](https://stat.ethz.ch/R-manual/R-devel/library/mgcv/html/mgcv-parallel.html) and [`ranger`](https://cran.r-project.org/web/packages/ranger/ranger.pdf), offer direct support for multithreading. Jobs using other types of R packages could also benefit from multithreading, depending on the analysis. For example, multithreading can help speed up linear algebra routines. To find out whether multithreading benefits a specific analysis, we encourage experimenting with different thread numbers and benchmarking your code using a small example data set and, for example, the R package [`microbenchmark`](https://cran.r-project.org/web/packages/microbenchmark/index.html). 
 
-The module uses OpenMP threading technology and the number of threads can be controlled using the environment variable `OMP_NUM_THREADS`. In practice, the number of threads is set to match the number of cores used for the job. Because `r-env` is based on an Apptainer container, when specifying the number of OpenMP threads we need to use the environment variable `APPTAINERENV_OMP_NUM_THREADS`.
+The module uses OpenMP threading technology and the number of threads can be controlled using the environment variable `OMP_NUM_THREADS`. In practice, the number of threads is set to match the number of cores used for the job. Note that `OMP_NUM_THREADS` should not be used in all multicore R jobs but only in those using packages that support OpenMP threads. By default, `OMP_NUM_THREADS` is set to 1.
 
-An example batch job script can be found below. Here we submit a job using eight cores (and therefore eight threads) on a single node. Notice how we match the number of threads and cores using `APPTAINERENV_OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK`. By using `APPTAINERENV_OMP_PLACES=cores`, we bind each thread to a single core. Note that [other options](https://theartofhpc.com/pcse/omp-affinity.html) for controlling thread affinity are also available, depending on your analysis.
+An example batch job script can be found below. Here we submit a job using eight cores (and therefore eight threads) on a single node. Notice how we match the number of threads and cores using `OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK`. By using `OMP_PLACES=cores`, we bind each thread to a single core. Note that [other options](https://theartofhpc.com/pcse/omp-affinity.html) for controlling thread affinity are also available, depending on your analysis.
 
 === "Roihu-CPU"
     ```bash
@@ -270,12 +270,12 @@ An example batch job script can be found below. Here we submit a job using eight
     module load r-env
     
     # Match thread and core numbers
-    export APPTAINERENV_OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+    export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
     
     # Place and bind threads to single cores
     # Comment the following lines if binding is not desired
-    export APPTAINERENV_OMP_PLACES=cores
-    export APPTAINERENV_OMP_PROC_BIND=spread
+    export OMP_PLACES=cores
+    export OMP_PROC_BIND=spread
     
     # Run the R script
     srun Rscript --no-save myscript.R

--- a/docs/support/tutorials/parallel-r-examples.md
+++ b/docs/support/tutorials/parallel-r-examples.md
@@ -878,7 +878,7 @@ Further to [executing multi-threaded R jobs on a single node](#improving-perform
 
 When listing these in a batch job file, note that `--ntasks-per-node × --cpus-per-task` must be less than or equal to the maximum number of cores available on a single node. For large multi-node jobs, aim to use full nodes, i.e. use all cores in each node. Further to selecting a suitable number of OpenMP threads, identifying the optimal number and division of MPI processes will require experimentation due to these being job-specific. 
 
-As an example of an OpenMP / MPI hybrid job, the submission below would use a total of four MPI processes (two tasks per node with two nodes reserved), with each process employing multiple OpenMP threads (`--cpus-per-task`). Overall, the job would use `--cpus-per-task × --ntasks-per-node × --nodes` cores. As with multi-threaded jobs running on a single node, the number of threads and cores is matched using `APPTAINERENV_OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}`. We also use the same variables for thread affinity control.
+As an example of an OpenMP / MPI hybrid job, the submission below would use a total of four MPI processes (two tasks per node with two nodes reserved), with each process employing multiple OpenMP threads (`--cpus-per-task`). Overall, the job would use `--cpus-per-task × --ntasks-per-node × --nodes` cores. As with multi-threaded jobs running on a single node, the number of threads and cores is matched using `OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}`. We also use the same variables for thread affinity control.
 
 === "Roihu-CPU"
     ```bash
@@ -898,12 +898,12 @@ As an example of an OpenMP / MPI hybrid job, the submission below would use a to
     module load r-env
     
     # Match thread and core numbers
-    export APPTAINERENV_OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
+    export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK:-1}
     
     # Place and bind threads to single cores
     # Comment the following lines if binding is not desired
-    export APPTAINERENV_OMP_PLACES=cores
-    export APPTAINERENV_OMP_PROC_BIND=spread
+    export OMP_PLACES=cores
+    export OMP_PROC_BIND=spread
     
     # Run the R script
     srun Rscript --no-save myscript.R


### PR DESCRIPTION
## Proposed changes

Roihu added to r-env documentation: Roihu tabs added for instructions on running (batch) jobs in addition to Puhti and Mahti tabs. Other smaller modifications made to make sure everything applied to Roihu too. To be checked especially: all batch job scripts for Roihu.

https://csc-guide-preview.2.rahtiapp.fi/origin/452-roihu/apps/r-env/
https://csc-guide-preview.2.rahtiapp.fi/origin/452-roihu/support/tutorials/parallel-r-examples/


## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
