### PR TITLE
Add a warning that email notifications are not enabled yet

### DIFF
--- a/docs/computing/running/creating-job-scripts-roihu.md
+++ b/docs/computing/running/creating-job-scripts-roihu.md
@@ -152,6 +152,10 @@ Other useful arguments (multiple arguments are separated by a comma) are `END`
 and `FAIL`. By default, the email will be sent to the email address linked to
 your CSC account. This can be overridden with the `--mail-user=` option.
 
+!!! warning "Notifications by email not enabled yet"
+    The notifications by email are not enabled yet and
+    the `--mail-type` option does not do anything at the moment.
+
 After defining all required resources in the batch job script, set up the
 required environment by loading suitable modules. Note that for modules to be
 available for batch jobs, they need to be loaded in the batch job script.


### PR DESCRIPTION
## Proposed changes

This PR will add a warning that email notifications are not enabled yet.
- https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-email/computing/running/creating-job-scripts-roihu/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
