### PR TITLE
Add x86_64 to RStudio user state reset

### DIFF
--- a/docs/computing/webinterface/rstudio.md
+++ b/docs/computing/webinterface/rstudio.md
@@ -22,7 +22,7 @@ threading](../../support/tutorials/parallel-r-examples.md#improving-performance-
 
 If an RStudio session fails to start or RStudio is extremely slow, first try resetting your
 RStudio user state as described below. These steps will clean up leftover data from previous interrupted RStudio
-sessions in two hidden folders in the user's home directory: `.config/rstudio` and `.local/share/rstudio`. These folders can be either renamed (to keep the contents) or deleted (if you are sure the contents are not needed).
+sessions in two hidden folders in the user's home directory: `.config/rstudio` and `.local/share/x86_64/rstudio` (`.local/share/rstudio` on Puhti ja Mahti). These folders can be either renamed (to keep the contents) or deleted (if you are sure the contents are not needed).
 
 
 === "Roihu-CPU"

--- a/docs/computing/webinterface/rstudio.md
+++ b/docs/computing/webinterface/rstudio.md
@@ -24,17 +24,46 @@ If an RStudio session fails to start or RStudio is extremely slow, first try res
 RStudio user state as described below. These steps will clean up leftover data from previous interrupted RStudio
 sessions in two hidden folders in the user's home directory: `.config/rstudio` and `.local/share/rstudio`. These folders can be either renamed (to keep the contents) or deleted (if you are sure the contents are not needed).
 
-**Option 1:** Use the file viewer in the web interface:
 
-1. In the top left corner of the web interface dashboard, choose **Files** and **Home Directory**.
-2. Click **Show dotfiles**.
-3. Delete or rename the `rstudio` folders under `.config` and `.local` -> `share`. 
+=== "Roihu-CPU"
+    **Option 1:** Use the file viewer in the web interface:
+    
+    1. In the top left corner of the web interface dashboard, choose **Files** and **Home Directory**.
+    2. Click **Show dotfiles**.
+    3. Delete or rename the `rstudio` folders 1) under `.config` and 2) under `.local` -> `share` -> `x86_64`. 
+    
+    **Option 2:** Use a terminal (for example a login node shell in the web interface) to delete or
+    rename these folders. Here is an example how renaming would work:
+    
+    `mv ~/.config/rstudio ~/.config/rstudio-old`  
+    `mv ~/.local/share/x86_64/rstudio ~/.local/share/x86_64/rstudio-old`
 
-**Option 2:** Use a terminal (for example a login node shell in the web interface) to delete or
-rename these folders. Here is an example how renaming would work:
+=== "Puhti"
+    **Option 1:** Use the file viewer in the web interface:
+    
+    1. In the top left corner of the web interface dashboard, choose **Files** and **Home Directory**.
+    2. Click **Show dotfiles**.
+    3. Delete or rename the `rstudio` folders under `.config` and `.local` -> `share`. 
+    
+    **Option 2:** Use a terminal (for example a login node shell in the web interface) to delete or
+    rename these folders. Here is an example how renaming would work:
+    
+    `mv ~/.config/rstudio ~/.config/rstudio-old`  
+    `mv ~/.local/share/rstudio ~/.local/share/rstudio-old`
+    
+=== "Mahti"
+    **Option 1:** Use the file viewer in the web interface:
+    
+    1. In the top left corner of the web interface dashboard, choose **Files** and **Home Directory**.
+    2. Click **Show dotfiles**.
+    3. Delete or rename the `rstudio` folders under `.config` and `.local` -> `share`. 
+    
+    **Option 2:** Use a terminal (for example a login node shell in the web interface) to delete or
+    rename these folders. Here is an example how renaming would work:
+    
+    `mv ~/.config/rstudio ~/.config/rstudio-old`  
+    `mv ~/.local/share/rstudio ~/.local/share/rstudio-old`
 
-`mv ~/.config/rstudio ~/.config/rstudio-old`  
-`mv ~/.local/share/rstudio ~/.local/share/rstudio-old`
 
 If after this RStudio still fails to start or remains very slow, please [contact CSC Service
 Desk](../../support/contact.md).


### PR DESCRIPTION
## Proposed changes

Fix RStudio user reset state path for Roihu by adding x86_64 to the .share path:

https://csc-guide-preview.2.rahtiapp.fi/origin/RStudio_pathfix/computing/webinterface/rstudio/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
