### PR TITLE
Update stan and GNU parallel instructions

### DIFF
--- a/docs/apps/r-env.md
+++ b/docs/apps/r-env.md
@@ -513,9 +513,7 @@ To use it, one must set the correct path to CmdStan using `cmdstanr`. For exampl
 === "Roihu-CPU"
     ```r
     cmdstanr::set_cmdstan_path("/appl/soft/manual/aida/x86_64/r-env/452-stan/cmdstan-2.39.0")
-    ```
-    If a model fails to compile, try running `module purge` before starting R.
-    
+    ```    
 === "Puhti"   
     ```r
     cmdstanr::set_cmdstan_path("/appl/soft/math/r-env/452-stan/cmdstan-2.38.0")


### PR DESCRIPTION
Remove the mention to use module purge if a cmdstan model doesn't compile (shouldn't be needed anymore). Add note that GNU parallel is not available on Roihu, use xargs instead.

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
