### PR TITLE
Add Roihu FirecREST HPC API documentation

### DIFF
--- a/docs/accounts/how-to-create-new-user-account.md
+++ b/docs/accounts/how-to-create-new-user-account.md
@@ -64,17 +64,18 @@ If you need assistance, please [contact CSC Service Desk](../support/contact.md)
 
 ## Getting a machine-to-machine robot account
 
-If you are a registered CSC user and need another account for managing
-services that you run in the CSC services, we can create a
-machine-to-machine robot account for you. Please note that each service requires its own unique robot account. Send the following
-information to servicedesk@csc.fi.
+If you are a registered CSC user and need another account for managing services that you run in the CSC services, we can create a machine-to-machine robot account for you. Please note that each service requires its own unique robot account.
+Send the following information to servicedesk@csc.fi:
+
 
 * Project identifier (e.g. 2001679, uef4713) of the project your
   service uses
 * The CSC service your service uses (e.g. cPouta, Rahti)
 * Your mobile number (to which the password is sent via SMS)
 
-Once the account has been created, if you are using it with a CSC supercomputer, you also need to
+On Roihu, computing resources can be accessed with a robot account using [FirecREST HPC API](../computing/firecrest/connecting.md#connecting-with-a-robot-account). Direct SSH terminal login with a robot account is not available.
+
+If you are using the robot account with another CSC supercomputer, you also need to
 [generate a new SSH key pair](../computing/connecting/ssh-keys.md#generating-ssh-keys) for the robot
 account. Note that this cannot be set via MyCSC as with normal user accounts, as robot accounts
 cannot log in to MyCSC. Instead the project PI must log in to the supercomputer with the robot

--- a/docs/computing/connecting/index.md
+++ b/docs/computing/connecting/index.md
@@ -9,6 +9,8 @@ There are two main ways of connecting to CSC supercomputers.
 2. We also offer a [web interface](#using-the-web-interface) to our systems,
    which enables running both graphical applications and command-line shells.
 
+Additionally, we also offer a [RESTful HTTP API](#using-the-firecrest-hpc-api) based on [FirecREST v2](https://eth-cscs.github.io/firecrest-v2/), which is the primary interface for [machine-to-machine robot account](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) usage.
+
 For instructions on connecting to the LUMI supercomputer, please see the
 [Get Started page in the LUMI user guide](https://docs.lumi-supercomputer.eu/firststeps/getstarted/).
 
@@ -34,6 +36,10 @@ connection. The shell applications are especially convenient for users whose
 workstation has a Windows operating system, since Windows does not
 typically come with a pre-installed SSH client. See the instructions for
 [connecting to HPC web interfaces](../webinterface/connecting.md).
+
+## Using the FirecREST HPC API
+
+The [FirecREST HPC API](../firecrest/index.md) provides a standardized RESTful interface for accessing computing resources from web-based software. It offers APIs for managing jobs through Slurm scheduler, performing file system operations over personal and project data, and for transferring large amounts of data to or from the system.
 
 ## Using an SSH client
 

--- a/docs/computing/firecrest/connecting.md
+++ b/docs/computing/firecrest/connecting.md
@@ -1,0 +1,75 @@
+# Connecting to Roihu FirecREST HPC API
+
+!!! warning "Access tokens are secrets"
+    Access tokens issued for FirecREST HPC API allow the token holder to interact with Slurm jobs, and read, manipulate and transfer data with your privileges. Don't share your access token with anyone.
+
+Roihu FirecREST HPC API endpoints can be found under the URL [https://api.roihu.csc.fi](https://api.roihu.csc.fi). The service uses versioned URL scheme, where the first element of the URL path represents the API generation. The current, latest API generation is `v1`. It is based on the latest release of FirecREST v2.
+
+Possible major or breaking changes to the API will be released as new API generation. By default, a new release will not replace any existing APIs. Earlier generations will be maintained and kept available.
+
+## Subsystems
+
+FirecREST HPC API supports multiple subsystems with different configuration options, identified by subsystem identifier in API endpoint URLs (e.g. `/v1/compute/<subsystem>/jobs`).
+
+API and subsystem configuration on `api.roihu.csc.fi`:
+
+| API generation | API subsystem | Partitions | Data transfer |
+|----------------|---------------|-----------|---------------|
+| `v1` | `cpu` | All *CPU* partitions | S3 via Allas, pre-signed URLs |
+| `v1` | `gpu` | All *GPU* partitions | S3 via Allas, pre-signed URLs |
+
+## API documentation
+
+Up-to-date API specification for `v1` is available in OpenAPI format at [https://api.roihu.csc.fi/v1/openapi.json](https://api.roihu.csc.fi/v1/openapi.json) and it can be viewed through FirecREST's Swagger UI at [https://api.roihu.csc.fi/v1/docs/](https://api.roihu.csc.fi/v1/docs).
+
+## Connecting to the API
+
+FirecREST HPC API uses JWT bearer tokens as authorization method. Accepted tokens are issued by CSC authentication and authorization infrastructure (AAI) identity provider (IdP). Only those tokens that have been specifically issued to be used with FirecREST HPC API (indicated by `aud` member in the JWT) are accepted by the API.
+
+In order to connect to an API endpoint, tokens are sent to FirecREST using standard `Authorization` header, example:
+
+```
+access_token="<JWT>"
+curl -X GET https://api.roihu.csc.fi/v1/compute/cpu/jobs \
+  -H "Authorization: Bearer ${access_token}"
+```
+
+Authorization header must be present in every API request sent to FirecREST. Token validity is verified on server-side for each request. An attempt to use invalid access token will result in a `HTTP 401 Unauthorized` return code, with a specific error message recorded in a JSON document in the response body.
+
+All requests sent to the API are executed on Roihu using the same user account that was used to retrieve the access token. For example, with a personal access token, all commands run via FirecREST are executed as you on the target system.
+
+## Connecting with a personal access token
+
+FirecREST HPC API can be used with personal access tokens, which allow access to same computing resources and projects as your direct terminal access. Personal access tokens are useful for running desktop applications or automation utilities in interactive terminals, that integrate with HPC resources using [PyFirecREST](pyfirecrest.md) Python SDK, for example.
+
+As the name suggests, personal access tokens are intended for personal use. A [project-specific robot account](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) should be used for implementing machine-to-machine HPC API integration for headless non-interactive systems, such as CI pipelines.
+
+A personal access token can be retrieved from MyCSC portal. Personal access tokens generated at MyCSC are valid for 24 hours at a time.
+
+You can view and revoke your active tokens at [CSC IdP federated personal profile page](https://user-auth.csc.fi/idp/profile/userprofile), under *Connected organizations* -> *Firecrest-access-tokens*.
+
+## Connecting with a robot account
+
+[Machine-to-machine robot accounts](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) can access computing resources on Roihu using FirecREST HPC API.
+
+Similarly to personal access tokens, connecting to the API using a robot account also requires supplying a JWT bearer token as authorization credential. Robot accounts can request a suitable JWT from the token endpoint on CSC IdP using standard [OAuth 2.0 Client Credentials Grant](https://oauth.net/2/grant-types/client-credentials/).
+
+Settings typically required for client credentials configuration:
+
+| Setting | Value |
+|---------|-------|
+| Client ID | Username of your robot account |
+| Client Secret | Password of your robot account |
+| Token URL | `https://user-auth.csc.fi/idp/profile/oidc/token` |
+| Scope | `openid` |
+
+You can, for example, retrieve an access token for a robot account with a simple `curl` call:
+
+```
+curl -X POST https://user-auth.csc.fi/idp/profile/oidc/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "Accept: application/json" \
+  -d "client_id=${my_robot_username}&client_secret=${my_robot_password}&scope=openid&grant_type=client_credentials"
+```
+
+A successful call returns a JSON document with the access token and associated metadata (token type, scope and lifetime).

--- a/docs/computing/firecrest/connecting.md
+++ b/docs/computing/firecrest/connecting.md
@@ -42,13 +42,16 @@ All requests sent to the API are executed on Roihu using the same user account t
 
 FirecREST HPC API can be used with personal access tokens, which allow access to same computing resources and projects as your direct terminal access. Personal access tokens are useful for running desktop applications or automation utilities in interactive terminals, that integrate with HPC resources using [PyFirecREST](pyfirecrest.md) Python SDK, for example.
 
-As the name suggests, personal access tokens are intended for personal use. A [project-specific robot account](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) should be used for implementing machine-to-machine HPC API integration for headless non-interactive systems, such as CI pipelines.
+As the name suggests, personal access tokens are intended for personal use. A [project-specific robot account](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) should be used for implementing machine-to-machine HPC API integration for headless non-interactive systems.
 
 A personal access token can be retrieved from MyCSC portal. Personal access tokens generated at MyCSC are valid for 24 hours at a time.
 
 You can view and revoke your active tokens at [CSC IdP federated personal profile page](https://user-auth.csc.fi/idp/profile/userprofile), under *Connected organizations* -> *Firecrest-access-tokens*.
 
 ## Connecting with a robot account
+
+!!! Note 
+    Robot accounts are not yet supported, support coming in Q3 2026.
 
 [Machine-to-machine robot accounts](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) can access computing resources on Roihu using FirecREST HPC API.
 

--- a/docs/computing/firecrest/data-transfer-s3.md
+++ b/docs/computing/firecrest/data-transfer-s3.md
@@ -1,0 +1,16 @@
+# Large file transfer using S3
+
+FirecREST HPC API implements asynchronous large file transfer model using an S3 object storage as a staging medium. On Roihu, the S3 storage used is [Allas](../../data/Allas/index.md). FirecREST uses its own dedicated tenant with dynamically created user-specific buckets.
+
+## How it works
+
+Upon sending an API request to [upload](https://api.roihu.csc.fi/v1/docs#/filesystem/post_upload_filesystem__system_name__transfer_upload_post) or [download](https://api.roihu.csc.fi/v1/docs#/filesystem/post_download_filesystem__system_name__transfer_download_post) task, FirecREST:
+
+- Creates a user-specific bucket in its own Allas tenant.
+- Generates pre-signed S3 URLs for the data transfer, using multi-part model if necessitated by the given `fileSize`.
+- Schedules a new Slurm DataTransferJob using `account` (your project) defined in the API request, to either transfer files from Allas to Roihu after your upload is completed, or from Roihu to Allas for you to download.
+- Returns pre-signed URLs to API client for transferring the data.
+
+## Examples
+
+Various detailed examples for implementing S3 data transfer using bash, .NET and PyFirecREST can be found in [FirecREST v2 user guide](https://eth-cscs.github.io/firecrest-v2/user_guide/#using-s3-transfer-method).

--- a/docs/computing/firecrest/index.md
+++ b/docs/computing/firecrest/index.md
@@ -1,0 +1,27 @@
+# FirecREST HPC API
+
+The FirecREST HPC API provides a standardized RESTful HTTP interface for accessing computing resources on Roihu. It offers APIs for managing jobs through Slurm scheduler, performing file system operations over personal and project data, and for transferring large amounts of data to or from the system.
+
+It is an ideal solution for building automated access to computing resources, as well as for creating and running personal web-based client applications that consume computing resources.
+
+## How to get access to the API?
+
+All Roihu users can use the FirecREST HPC API using time-limited personal access tokens. This effectively allows using the REST API as an alternative to a direct SSH connection, as all API operations are executed on Roihu using your CSC identity and privileges. Personal access tokens can be generated in MyCSC portal.
+
+In order to use the REST API for building more serious integrations, such as CI pipelines or building web applications, you can request for a [machine-to-machine robot account](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) to be created for your project.
+
+!!! info "About robot accounts"
+    Robot accounts are tied to a specific project. They have access to the same computing resources, and consume your project's resource allocations, as any regular project member would.
+
+    FirecREST HPC API does not impose any additional restrictions for robot account. It can schedule any Slurm job, or perform any data transfer or file system operation within the scope of your project.
+
+    If a robot account is used to provide a HPC backend for a web application intended for humans, please be mindful of having sufficient guardrails, input validation and user authorization in the application itself to prevent unauthorized workloads or commands being run under your project's privileges.
+
+## Getting started
+
+Check out the following documentation to get started with FirecREST HPC API on Roihu:
+
+1. [Connect to FirecREST HPC API](connecting.md)
+2. [FirecREST API documentation](https://api.roihu.csc.fi/v1/docs/)
+3. [Transfer data with FirecREST](data-transfer-s3.md)
+4. [Set up PyFirecREST](pyfirecrest.md) for use with Python applications

--- a/docs/computing/firecrest/pyfirecrest.md
+++ b/docs/computing/firecrest/pyfirecrest.md
@@ -1,0 +1,97 @@
+# PyFirecREST
+
+PyFirecREST is a Python SDK library for interacting with FirecREST API, and the HPC resources available via the API.
+
+The package is available in [PyPI](https://pypi.org/project/pyfirecrest/). It can be installed with a simple `pip` call:
+
+```
+python3 -m pip install pyfirecrest
+```
+
+Please see the [PyFirecREST documentation from CSCS](https://pyfirecrest.readthedocs.io/en/stable/index.html) for tutorials and API reference. FirecREST HPC API on Roihu only supports [PyFirecREST API v2](https://pyfirecrest.readthedocs.io/en/stable/reference_v2_index.html).
+
+
+## Using with personal access tokens
+
+The PyFirecREST library ships with one built-in authorization class, `ClientCredentialsAuth`, which is suitable for use with robot accounts. 
+
+In order to use the library with personal access token, a separate Authorization object needs to be created for the `firecrest.v2.Firecrest` client. In this example, we create a "pass-through" authorization class which reads the token from environment variable `FIRECREST_TOKEN`, makes sure it has not expired, and then hands it over to the `firecrest.v2.Firecrest` client as-is:
+
+```
+import os
+import time
+import jwt
+
+class TokenAuth:
+  def __init__(self):
+    pass
+
+  # Use PyJWT to decode the token and verify expiration time.
+  # Return False if decoding fails (input is not valid JWT) or if the token has expired
+  def _is_token_valid(self, token: str) -> bool:
+    try:
+      payload = jwt.decode(token, options={"verify_signature": False, "verify_exp": False, "verify_aud": False})
+      return time.time() <= payload["exp"]
+    except Exception:
+      return False
+
+  # A PyFirecREST Authorization object is required to have method get_access_token(),
+  # which, when called, will return a valid JWT access token.
+  def get_access_token(self):
+    token = os.getenv('FIRECREST_TOKEN', None)
+    if not token:
+      raise RuntimeError("Environment variable FIRECREST_TOKEN is not defined.")
+    if not self._is_token_valid(token):
+      raise RuntimeError("Token is invalid or has expired.")
+    return token
+
+import firecrest as fc
+firecrest = fc.v2.Firecrest(firecrest_url="https://api.roihu.csc.fi/v1", authorization=TokenAuth())
+
+# Example: Call the userinfo endpoint on Roihu CPU subsystem to verify FirecREST API connection
+try:
+    userinfo = firecrest.userinfo(system_name="cpu")
+    print(f"Userinfo endpoint returned:\n{userinfo}")
+except fc.FirecrestException as e:
+    print(f"FirecREST error: {e}")
+except Exception as e:
+    print(f"System error: {e}")
+
+```
+
+## Using with Robot accounts
+
+You can use the built-in `ClientCredentialsAuth` class with a robot account, with configuration as described on [connecting to Roihu FirecREST API](connecting.md#connecting-with-a-robot-account), for example:
+
+```
+import firecrest as fc
+authorization = fc.ClientCredentialsAuth(
+  client_id="my_robot_username",
+  client_secret="my_robot_password",
+  token_uri="https://user-auth.csc.fi/idp/profile/oidc/token"
+)
+firecrest = fc.v2.Firecrest(firecrest_url="https://api.roihu.csc.fi/v1", authorization=authorization)
+```
+
+Please refer to the [PyFirecREST Authorization reference](https://pyfirecrest.readthedocs.io/en/stable/reference_auth.html) for all configuration options for the built-in `ClientCredentialsAuth` class.
+
+
+## FirecREST CLI
+
+PyFirecREST also ships with a handy command line utility `firecrest` for interacting with FirecREST APIs. It implements support for OIDC client credentials based authentication, which can be used with robot accounts, as well as support for getting or setting an access token with an arbitrary shell command starting from version `v3.8.0`.
+
+### Using CLI with personal acces token
+
+We can use the `--token-command` (env `FIRECREST_TOKEN_COMMAND`) option of `firecrest` CLI to supply the personal access token to the utility:
+
+```
+# Copied and pasted access token from MyCSC
+access_token="<JWT>"
+
+# Set up URL and token command using environment variables.
+export FIRECREST_URL=https://api.roihu.csc.fi/v1
+export FIRECREST_TOKEN_COMMAND="echo ${access_token}"
+
+# Example: query the userinfo endpoint on Roihu-CPU
+firecrest id -s cpu
+```

--- a/docs/computing/firecrest/pyfirecrest.md
+++ b/docs/computing/firecrest/pyfirecrest.md
@@ -17,7 +17,7 @@ The PyFirecREST library ships with one built-in authorization class, `ClientCred
 
 In order to use the library with personal access token, a separate Authorization object needs to be created for the `firecrest.v2.Firecrest` client. In this example, we create a "pass-through" authorization class which reads the token from environment variable `FIRECREST_TOKEN`, makes sure it has not expired, and then hands it over to the `firecrest.v2.Firecrest` client as-is:
 
-```
+```python
 import os
 import time
 import jwt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -390,6 +390,11 @@ nav:
           - Technical details: computing/quantum-computing/specs.md
           - FiQCI partition: computing/quantum-computing/fiqci-partition.md
           - Running quantum jobs: computing/quantum-computing/running-quantum-jobs.md
+      - FirecREST HPC API:
+          - computing/firecrest/index.md
+          - Connecting: computing/firecrest/connecting.md
+          - Data transfer over S3: computing/firecrest/data-transfer-s3.md
+          - Python SDK: computing/firecrest/pyfirecrest.md
   - Cloud Services:
       - cloud/index.md
       - Noppe:


### PR DESCRIPTION
## Proposed changes

Added initial documentation for the new FirecREST API that is available for Roihu.

https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-firecrest/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
