### PR TITLE
Add link to retrieve access token

### DIFF
--- a/docs/computing/firecrest/connecting.md
+++ b/docs/computing/firecrest/connecting.md
@@ -44,7 +44,7 @@ FirecREST HPC API can be used with personal access tokens, which allow access to
 
 As the name suggests, personal access tokens are intended for personal use. A [project-specific robot account](../../accounts/how-to-create-new-user-account.md#getting-a-machine-to-machine-robot-account) should be used for implementing machine-to-machine HPC API integration for headless non-interactive systems.
 
-A personal access token can be retrieved from MyCSC portal. Personal access tokens generated at MyCSC are valid for 24 hours at a time.
+A personal access token can be retrieved from the [MyCSC portal](https://my.csc.fi/firecrest-token). Note that there's no direct link from the portal itself yet. Personal access tokens are valid for 24 hours at a time.
 
 You can view and revoke your active tokens at [CSC IdP federated personal profile page](https://user-auth.csc.fi/idp/profile/userprofile), under *Connected organizations* -> *Firecrest-access-tokens*.
 


### PR DESCRIPTION
## Proposed changes

There was no link to the page from which the access token can be retrieved. This is not linked either from the myCSC portal, which makes it impossible for users to access  the API.


 [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-access-token-update) of your branch.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
