### PR TITLE
Clarify Roihu CPU/GPU availability in Gaussian documentation

### DIFF
--- a/docs/apps/gaussian.md
+++ b/docs/apps/gaussian.md
@@ -22,7 +22,7 @@ electronic structure modeling.
 
 - Puhti: `G16RevC.02`
 - Mahti: `G16RevC.02`
-- Roihu: `G16RevC.02`
+- Roihu-CPU: `G16RevC.02`
 
 ## License
 


### PR DESCRIPTION
Gaussian is only available on roihu-cpu
https://csc-guide-preview.2.rahtiapp.fi/origin/gaussian-roihu-cpu-clarification/

## Proposed changes

Briefly describe the changes you've made here. Remember to add a link to the [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) of your branch.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
