### PR TITLE
Roihu cpu clarification chemistry apps

### DIFF
--- a/docs/apps/molpro.md
+++ b/docs/apps/molpro.md
@@ -25,7 +25,7 @@ associated methods.
 
 - Puhti: 2024.3
 - Mahti: 2024.3
-- Roihu: 2025.4, 2026.1 (default)
+- Roihu-CPU: 2025.4, 2026.1 (default)
 
 ## License
 

--- a/docs/apps/orca.md
+++ b/docs/apps/orca.md
@@ -27,7 +27,7 @@ for academic use at academic institutions.
 
 - Puhti: 6.0.0
 - Mahti: 6.0.0
-- Roihu: 6.1.1
+- Roihu-CPU: 6.1.1
 
 Note that due to licensing issues every user has to install their own copy of the program.
 

--- a/docs/apps/turbomole.md
+++ b/docs/apps/turbomole.md
@@ -25,7 +25,7 @@ for efficient study of large systems.
 
 - Puhti: 7.5.1, 7.6, 7.7, 7.8
 - Mahti: 7.5.1, 7.6, 7.7, 7.8
-- Roihu: 8.0
+- Roihu-CPU: 8.0
 
 ## License
 


### PR DESCRIPTION
## Proposed changes
Adjusted "Roihu" to "Roihu-CPU" in the Available section for Turbomole, Molpro and ORCA.

Preview:
https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-cpu-clarification-chemistry-apps/

## Checklist before requesting a review

- [ ] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [ ] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
