### PR TITLE
Fix translation build

### DIFF
--- a/translation/translator/pages.py
+++ b/translation/translator/pages.py
@@ -86,7 +86,7 @@ class MovedTranslation(PageTranslation):
 
     def __handle_move(self):
         mkparents(self.__dest_path)
-        self.__src_path.unlink(missing_ok=True, follow_symlinks=False)
+        self.__src_path.unlink(missing_ok=True)
         self.__dest_path.write_text(self.__content, encoding="utf-8")
         logger.info("Moved '%s' to '%s'.",
                     self.__docs_src,


### PR DESCRIPTION
## Proposed changes

The translation build was failing. I checked the logs of the pods:

```
$ oc logs pods/docs-csc-translation-fi-1783593388446-gw2n5 -c translator-fi
restoring snapshot fec165c1 of [/tmp/docs/fi] at 2026-06-28 21:00:42.027056653 +0000 UTC by 1001690000@docs.csc.fi to /tmp/translation
Summary: Restored 672 files/dirs (3.999 MiB) in 0:00
Cloning into '/tmp/csc-user-guide'...
Already on 'master'
Your branch is up to date with 'origin/master'.
Cloning into '/tmp/csc-user-guide-config'...
Already on 'master'
Your branch is up to date with 'origin/master'.
2026-07-09 10:36:49,090 - INFO - OpenAI client initialized.
2026-07-09 10:36:49,099 - INFO - Handling diff f8f4b092b1b879a9ef047eedce51495f5b4872fa...cc16cd5eddd8c6169325a5dea69639f0ccec884c.
2026-07-09 10:36:50,246 - INFO - No cached translations.
2026-07-09 10:36:51,681 - INFO - Deleted 'support/faq/how-to-move-data-between-puhti-and-allas.md'.
Traceback (most recent call last):
  File "/work/refresh_translation.py", line 80, in <module>
    _main(sys.argv[1], sys.argv[2], sys.argv[3])
  File "/work/refresh_translation.py", line 61, in _main
    page.pending_operation()
  File "/work/translator/pages.py", line 89, in __handle_move
    self.__src_path.unlink(missing_ok=True, follow_symlinks=False)
TypeError: Path.unlink() got an unexpected keyword argument 'follow_symlinks'
```

Indeed `follow_symlinks` doesn't seem to be a valid argument. For reference: https://docs.python.org/3/library/pathlib.html#pathlib.Path.unlink

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
