### PR TITLE
Fix internal link to roihu local scratch

### DIFF
--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -146,7 +146,7 @@ The amount of local storage available to a single user depends on the [partition
 | Hugemem (XL) nodes | 1.6 TiB        | 6700 / 4000 MB/s    |
 | VIZ nodes          | 6.5 TiB        | 6700 / 4000 MB/s    |
 
-Read more about: [Local storage on Roihu nodes](../disk.md#temporary-local-disk-areas)
+Read more about: [Local storage on Roihu nodes](../roihu-disk.md#temporary-local-disk-areas)
 
 ## Puhti partitions
 


### PR DESCRIPTION
## Proposed changes

Fix an internal link pointing to Mahti/Puhti storage instead of Roihu
https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-storage/computing/running/batch-job-partitions/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
