### PR TITLE
Add visitor statistics page

### DIFF
--- a/csc-overrides/partials/footer.html
+++ b/csc-overrides/partials/footer.html
@@ -44,6 +44,7 @@
           <ul>
             <li>{{ footer_link("Maintenance breaks", "https://research.csc.fi/service-breaks/" ) }}</li>
             <li>{{ footer_link("Accessibility statement", page_url("support/accessibility.md"), target="_self") }}</li>
+            <li>{{ footer_link("Visitor statistics", page_url("support/visitor-statistics.md"), target="_self") }}</li>
             <li>{{ footer_link("User communications archives", page_url("support/contact.md")+"#archives", target="_self") }}</li>
           </ul>
         </div>
@@ -82,6 +83,7 @@
           <ul>
             <li>{{ footer_link("Huoltokatkot (englanniksi)", "https://research.csc.fi/service-breaks/" ) }}</li>
             <li>{{ footer_link("Saavutettavuusseloste", page_url("support/accessibility.md"), target="_self") }}</li>
+            <li>{{ footer_link("Kävijätilastot (englanniksi)", page_url("support/visitor-statistics.md"), target="_self") }}</li>
             <li>{{ footer_link("Käyttäjätiedotearkisto (englanniksi)", page_url("support/contact.md")+"#archives", target="_self") }}</li>
           </ul>
         </div>

--- a/docs/support/visitor-statistics.md
+++ b/docs/support/visitor-statistics.md
@@ -1,0 +1,48 @@
+# Visitor statistics
+
+To understand how our documentation is used and to keep improving it,
+we collect anonymous visitor statistics. This explains what we collect
+and how.
+
+## We do not use cookies
+
+Collecting these statistics does **not** require cookies, and docs.csc.fi
+does not set any tracking or analytics cookies on your device. You do not
+need to accept anything to browse the site, which is why the site does not
+show a cookie consent banner.
+
+## What we collect
+
+We use [Matomo](https://matomo.org/), a privacy-friendly web analytics tool,
+operated on servers managed by CSC. Because no cookies are used, visitors are
+not tracked across sessions or across other sites. For each visit, Matomo records
+information such as:
+
+- pages you visit and the order in which you visit them
+- the page or search engine that referred you to the site
+- clicks on outbound links and downloads of files
+- your approximate location (country or city), derived from an anonymized IP address
+- technical information about your browser, operating system, device type,
+  screen resolution and browser language
+- the date and time of your visit
+
+To count visits without cookies, Matomo generates a short-lived, anonymized
+identifier from your IP address and browser details. This identifier is changed
+regularly and cannot be used to identify you or to follow you over longer periods.
+
+We also collect the anonymous feedback you give with the "Do you find this page useful?"
+buttons at the bottom of each page.
+
+## What we do not do
+
+- We do not collect data that identifies you personally
+- We do not track you across other websites
+- We do not use the data for advertising, and we do not sell or share it with third
+  parties for their own purposes
+
+
+## More information
+
+For more information on how CSC processes data, see the [CSC Privacy Notice](https://research.csc.fi/security/).
+
+If you have questions about the statistics we collect, contact us at servicedesk@csc.fi


### PR DESCRIPTION
## Proposed changes

Docs has no existing information about Matomo. This PR adds a page with information about what we track, as well as a link in the footer. Maybe a small popup (like on the preview pages) could be nice, but this requires additional work.
Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/visitor-statistics/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
