### PR TITLE
Add puhti shutdown disclaimer into top box in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ extra:
         <p>Puhti and Mahti are being decommissioned in stages, and their storage areas will become fully unavailable from <strong>15 October 2026</strong>. Clean up unnecessary files and move any data you need to keep by <strong>31 August 2026</strong>. See the <a href="{{ base_url }}/support/tutorials/roihu-data/">Roihu data migration guide</a> for instructions on transferring your data to Roihu.</p>
       </div>
       <div>
-        <p><strong>Puhti computing services will be decommissioned on 31 July 2026.</strong> No new jobs will be executed on the compute nodes after that date. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
+        <p><strong>Puhti computing services will be decommissioned on 31 July 2026</strong> and no new jobs will be executed on its compute nodes. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
       </div>
   landing_banner:
     path: https://a3s.fi/docs-files/banners/ # Put the image file in this bucket; Don't touch this value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ extra:
         <p>Puhti and Mahti are being decommissioned in stages, and their storage areas will become fully unavailable from <strong>15 October 2026</strong>. Clean up unnecessary files and move any data you need to keep by <strong>31 August 2026</strong>. See the <a href="{{ base_url }}/support/tutorials/roihu-data/">Roihu data migration guide</a> for instructions on transferring your data to Roihu.</p>
       </div>
       <div>
-        <p><strong>Puhti computing services will be decommissioned on 31 July 2026</strong> and no new jobs will be executed on its compute nodes. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
+        <p><strong>Puhti computing services will be decommissioned on 31 July 2026</strong> and no new jobs will be executed on its compute nodes after. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
       </div>
   landing_banner:
     path: https://a3s.fi/docs-files/banners/ # Put the image file in this bucket; Don't touch this value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ extra:
         <p>Puhti and Mahti are being decommissioned in stages, and their storage areas will become fully unavailable from <strong>15 October 2026</strong>. Clean up unnecessary files and move any data you need to keep by <strong>31 August 2026</strong>. See the <a href="{{ base_url }}/support/tutorials/roihu-data/">Roihu data migration guide</a> for instructions on transferring your data to Roihu.</p>
       </div>
       <div>
-        <p>Puhti scratch is very full: keep only active data there and move or delete everything else. No new Puhti scratch quota will be granted.</p>
+        <p><strong>Puhti computing services will be decommissioned on 31 July 2026.</strong> No new jobs will be executed on the compute nodes after that date. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
       </div>
   landing_banner:
     path: https://a3s.fi/docs-files/banners/ # Put the image file in this bucket; Don't touch this value.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ extra:
         <p>Puhti and Mahti are being decommissioned in stages, and their storage areas will become fully unavailable from <strong>15 October 2026</strong>. Clean up unnecessary files and move any data you need to keep by <strong>31 August 2026</strong>. See the <a href="{{ base_url }}/support/tutorials/roihu-data/">Roihu data migration guide</a> for instructions on transferring your data to Roihu.</p>
       </div>
       <div>
-        <p><strong>Puhti computing services will be decommissioned on 31 July 2026</strong> and no new jobs will be executed on its compute nodes after. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
+        <p><strong>Puhti computing services will be decommissioned on 31 July 2026 at 12:00</strong> and no new jobs will be accepted or executed on its compute nodes after. Puhti login nodes and storage services will remain available until 15 October 2026.</p>
       </div>
   landing_banner:
     path: https://a3s.fi/docs-files/banners/ # Put the image file in this bucket; Don't touch this value.


### PR DESCRIPTION
## Proposed changes

Change the top box in docs to include puhti shutdown 31 July 2026

https://csc-guide-preview.2.rahtiapp.fi/origin/puhti-shutdown-disclaimer/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
