### PR TITLE
Pukki: new MariaDB version, new pgsql extension

### DIFF
--- a/docs/cloud/dbaas/postgres-extensions.md
+++ b/docs/cloud/dbaas/postgres-extensions.md
@@ -80,6 +80,7 @@ SELECT '| ' || name  AS name, comment || ' |' as comment FROM pg_available_exten
  | tsm_system_time                | TABLESAMPLE method which accepts time in milliseconds as a limit |
  | unaccent                       | text search dictionary that removes accents |
  | uuid-ossp                      | generate universally unique identifiers (UUIDs) |
+ | vector                         | vector data type and ivfflat and hnsw access methods |
  | xml2                           | XPath querying and XSLT |
 
 

--- a/docs/support/wn/cloud-new.md
+++ b/docs/support/wn/cloud-new.md
@@ -1,5 +1,9 @@
 # Cloud services
 
+## MariaDB 12.3.2 available in Pukki, 28.7.2026
+
+A new LTS major version of MariaDB is now available in Pukki DBaaS, 12.3.2. See [MariaDB's documentation](https://mariadb.com/docs/release-notes/community-server) for release notes.
+
 ## New Ubuntu cloud image Resolute Raccoon 26.04, 11.05.2026
 
 The newest LTS (Long-Term Support) Ubuntu cloud image, Ubuntu-26.04, has been added to Pouta.

--- a/docs/support/wn/cloud-new.md
+++ b/docs/support/wn/cloud-new.md
@@ -1,6 +1,6 @@
 # Cloud services
 
-## MariaDB 12.3.2 available in Pukki, 28.7.2026
+## MariaDB 12.3.2 available in Pukki, 30.7.2026
 
 A new LTS major version of MariaDB is now available in Pukki DBaaS, 12.3.2. See [MariaDB's documentation](https://mariadb.com/docs/release-notes/community-server) for release notes.
 


### PR DESCRIPTION
## Proposed changes

https://csc-guide-preview.2.rahtiapp.fi/origin/DBAAS-615/

Add a news item for MariaDB 12.3.2 in Pukki. https://csc-guide-preview.2.rahtiapp.fi/origin/DBAAS-615/support/wn/cloud-new/#mariadb-1232-available-in-pukki-2872026

Update pgsql extensions page, as pgvector was added. https://csc-guide-preview.2.rahtiapp.fi/origin/DBAAS-615/cloud/dbaas/postgres-extensions/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
