### PR TITLE
Clarify local storage difference between XL and other nodes

### DIFF
--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -143,7 +143,7 @@ The amount of local storage available to a single user depends on the [partition
 | R (shared nodes)   | 20 GiB         | 5000 / 1400 MB/s    |
 | N (full nodes)     | 600 GiB        | 5000 / 1400 MB/s    |
 | G (GPU nodes)      | 150 GiB        | 5000 / 1400 MB/s    |
-| Hugemem (XL) nodes | 1.6 TiB        | 6700 / 4000 MB/s    |
+| Hugemem (XL) nodes | 13 TiB         | 6700 / 4000 MB/s    |
 | VIZ nodes          | 6.5 TiB        | 6700 / 4000 MB/s    |
 
 Read more about: [Local storage on Roihu nodes](../roihu-disk.md#temporary-local-disk-areas)

--- a/docs/computing/systems-roihu.md
+++ b/docs/computing/systems-roihu.md
@@ -138,21 +138,22 @@ See [Roihu dataset project](roihu-dataset-project.md) for details.
 
 ### Local storage capacity
 
-Each Roihu CPU and GPU node have a small 960 GB local disk suitable for
-storing temporary files during jobs. High-performance local storage is
-available on the high-memory (XL) and visualization (VIZ) nodes, where each
-node includes a total of 13 TiB of fast NVMe disks.
+Each Roihu CPU and GPU node provides 960 GB of local NVMe storage
+for temporary files created during jobs.
+
+High-memory (XL) and visualization (VIZ) nodes provide additional capacity and
+faster performance in their local storage, with a total of 13 TiB of local NVMe storage per node.
 
 The available storage quota that a single user can access in their jobs depends
 on the system [partition](running/batch-job-partitions.md) they use:
 
-| Allocation type         | Quota per user |
-|:------------------------|---------------:|
-| R (shared nodes)        | 20 GiB         |
-| N (full nodes)          | 600 GiB        |
-| G (GPU nodes)           | 150 GiB        |
-| Hugemem (XL) nodes      | 1.6 TiB        |
-| V (visualization nodes) | 6.5 TiB        |
+| Allocation type         | Quota per user | Read / Write speeds |
+|:------------------------|---------------:|---------------------|
+| R (shared nodes)        | 20 GiB         | 5000 / 1400 MB/s    |
+| N (full nodes)          | 600 GiB        | 5000 / 1400 MB/s    |
+| G (GPU nodes)           | 150 GiB        | 5000 / 1400 MB/s    |
+| Hugemem (XL) nodes      | 13 TiB         | 6700 / 4000 MB/s    |
+| V (visualization nodes) | 6.5 TiB        | 6700 / 4000 MB/s    |
 
 As a new feature, users can also request local disk mounts from a
 centralized pool of fast storage resources. This fast storage capacity is


### PR DESCRIPTION
## Proposed changes

Clarify difference of IO in local storage between M/L/GPU nodes and XL/Viz nodes

https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-local-disk/computing/running/batch-job-partitions/
https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-local-disk/computing/systems-roihu/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
