### PR TITLE
Prioritize zstd, remove pbzip2

### DIFF
--- a/docs/support/tutorials/env-guide/packing-and-compression-tools.md
+++ b/docs/support/tutorials/env-guide/packing-and-compression-tools.md
@@ -6,11 +6,15 @@ file) and *compress* (i.e., reduce its size without losing any data) the
 data. Archiving makes file transfer easier and compressed files
 require less storage space and are thus faster to move from one system
 to another. In this chapter we will introduce
-**tar**, **gzip**, **bzip2**, **zip**, **7zip** and **Zstandard** tools
-that are frequently used for archiving and compression.
+**Zstandard**, **tar**, **gzip**, **bzip2**, **zip** and **7zip** tools
+that are frequently used for archiving and compression. Of these,
+**Zstandard (zstd)** is the recommended default for most use cases. It
+is dramatically faster than gzip/bzip2/zip while achieving comparable
+or better compression ratios.
 
 | Type                           | Extension                                 |
 |--------------------------------|-------------------------------------------|
+| A Zstandard compressed file    | `.zst`                                    |
 | A zip archive                  | `.zip`, `.ZIP`, or `.Z`                   |
 | A gzip compressed file         | `.gz`                                     |
 | A bzip2 compressed file        | `.bz2`, or `.bz`                          |
@@ -18,7 +22,6 @@ that are frequently used for archiving and compression.
 | A gzip compressed tar archive  | `.tar.gz`, or `.tgz`                      |
 | A bzip2 compressed tar archive | `.tar.bz2`, `.tar.bz`, `.tbz`, or `.tbz2` |
 | A 7zip compressed file         | `.7z`                                     |
-| A Zstandard compressed file    | `.zst`                                    |
 
 ## tar: packing several files into one file
 
@@ -122,17 +125,25 @@ write to. The file name must follow right after the option, thus it is
 commonly the last option given. Below are some frequently used tar
 options.
 
-| Option | Function                                                                    |
-|--------|-----------------------------------------------------------------------------|
-| `f`    | Use the given file name as the source or target archive                     |
-| `v`    | Be verbose, i.e. list processed files to the screen while processing        |
-| `z`    | Use gzip compression/decompression while creating or extracting an archive  |
-| `j`    | Use bzip2 compression/decompression while creating or extracting an archive |
+| Option   | Function                                                                        |
+|----------|---------------------------------------------------------------------------------|
+| `f`      | Use the given file name as the source or target archive                         |
+| `v`      | Be verbose, i.e. list processed files to the screen while processing            |
+| `z`      | Use gzip compression/decompression while creating or extracting an archive      |
+| `j`      | Use bzip2 compression/decompression while creating or extracting an archive     |
+| `--zstd` | Use Zstandard compression/decompression while creating or extracting an archive |
+
+With option `--zstd` you can filter the archive through `zstd` to 
+(de)compress the archive on the fly. Since Zstandard is the recommended
+default, this is generally the best option to reach for:
+
+```bash
+tar --zstd cvf project_3.tar.zst project_3
+```
 
 With options `z` (zip) or `j` (no meaning, it was chosen because no
-meaningful letter was available) you can filter the archive
-through `gzip` or `bzip2`, respectively, to (de)compress the archive on
-the fly:
+meaningful letter was available) you can similarly filter the archive
+through `gzip` or `bzip2`, respectively:
 
 ```bash
 tar cvzf project_3.tar.gz project_3
@@ -204,6 +215,60 @@ these four methods in the Roihu supercomputer using default command settings.
 | `gzip`     | 5.11 GB| 25.1 min| 1.9 min |
 | `bzip2`    | 4.25 GB| 15 min  | 9.7 min |
 | `zip`      | 5.11 GB| 24.7 min| 1.9 min |
+
+### Zstandard compression tool
+
+**Zstandard** is a fast compression tool and a sensible default in most cases.
+In Roihu, Zstandard compression can be done with command `zstd`. For
+example, to compress file `data.txt`, give command:
+
+```bash
+zstd data.txt
+```
+
+The above command produces a compressed file named as `data.txt.zst`.
+By default, `zstd` uses compression level 3, which offers a good balance
+between speed and compression ratio. You can adjust the level with `-#`,
+where `#` ranges from `1` (fastest, lowest ratio) to `19`
+(slowest, highest ratio):
+
+```bash
+zstd -19 data.txt
+```
+
+For even higher compression at the cost of memory and speed, use the
+`--ultra` flag together with levels 20-22:
+
+```bash
+zstd --ultra -22 data.txt
+```
+
+For larger data files you can speed up the compression by using multiple
+computing cores (threads). The number of threads is defined with option
+`-T`. In the login nodes of Roihu, it is recommended that you use just
+one thread that is the default setting, but, for example, in an interactive
+session you could use four threads:
+
+```bash
+zstd -T4 data.txt
+```
+
+Additionally, large files with long-range repetition (e.g. genomic data
+or structured logs) may benefit from the `--long` option, which enables
+long-distance matching. The number given (`--long=#`) sets the window size
+as a power of two in bytes, so `--long=28` means a 256 MB window (2^28 bytes).
+Large windows can improve compression ratio significantly for such files, but
+increase memory usage accordingly.
+
+```bash
+zstd --long=28 data.txt
+```
+
+Decompression is defined by adding option `-d` to the command:
+
+```bash
+zstd -d data.txt.zst
+```
 
 ### gzip and gunzip
 
@@ -314,29 +379,6 @@ bunzip2 < file_name.bz2 > file_name
 
 Note that a file compressed with bzip2 can not be uncompressed with
 gunzip and vice versa.
-
-In addition to the standard bzip2 and bunzip2 programs, you can also use
-the parallel versions of `bzip2`
-command: `pbzip2` and `pbunzip2`. When these commands are
-used, the user must use option `-p` to define the number of processor
-cores to be used. For example, compressing the file `my_data.dat` using
-four cores can be done with command:
-
-```bash
-pbzip2 -p4 my_data.dat
-```
-
-Similarly, to decompress the file with two cores you can use command:
-
-```bash
-bunzip2 -p2 my_data.dat.bz2
-```
-
-The `pbzip2` and `pbunzip2` commands scale well for small core numbers.
-Already with two cores the `pbzip2` is about as fast as `gzip`. The number
-of processors used does not affect to the actual output file. Thus, a
-file that has been compressed with parallel `pbzip2` can be uncompressed
-with normal `bunzip2` command and vice versa.
 
 ### zip and unzip: the combined compression and file archiving tool
 
@@ -623,31 +665,5 @@ The output directory of the extracted files can be defined with option
 7z e -oproject_3 project_3_backup.7z
 ```
 
-### Zstandard compression tool
-
-**Zstandard** is a fast compression tool. In Roihu,
-Zstandard compression can be done with command `zstd`. For
-example, to compress file `data.txt`, give command:
-
-```bash
-zstd data.txt
-```
-
-The above command produces a compressed file named as `data.txt.zst`.
-For larger data files you can speed up the compression by using multiple
-computing cores (threads). The number of threads is defined with option
-`-T`. In the login nodes of Roihu, it is recommended that you use just
-one thread that is the default setting, but, for example, in an interactive
-session you could use four threads:
-
-```bash
-zstd -T4 data.txt
-```
-
-Decompression is defined by adding option `-d` to the command:
-
-```bash
-zstd -d data.txt.zst
-```
 
 See also: [Interactive sessions on Roihu](../../../computing/running/interactive-usage.md).


### PR DESCRIPTION
## Proposed changes

Make zstd the default compression method and add additional flag information. Remove pbzip2, as it is no longer available on any of the CSC supercomputers. Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/compression-updates/support/tutorials/env-guide/packing-and-compression-tools/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
