### PR TITLE
Update outdated csc-env-eff link

### DIFF
--- a/docs/computing/connecting/ssh-windows.md
+++ b/docs/computing/connecting/ssh-windows.md
@@ -135,7 +135,7 @@ supercomputer.
     where `<algorithm>` is either `ed25519` or `rsa`.
 
     Alternatively, you may
-    [connect using the GUI following this tutorial](https://csc-training.github.io/csc-env-eff/hands-on/connecting/ssh-puhti.html#connecting-from-windows).
+    [connect using the GUI following this tutorial](https://csc-training.github.io/csc-env-eff/hands-on/connecting/ssh-roihu.html#connecting-from-windows).
 
 === "PuTTY"
 


### PR DESCRIPTION
## Proposed changes

Update link referring to Puhti-specific env-eff-page that no longer exists. Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/env-eff-link-fix/computing/connecting/ssh-windows/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
