### PR TITLE
Roihu doc corrections: local storage tables, GPU examples, typos

### DIFF
--- a/docs/computing/allas-in-roihu.md
+++ b/docs/computing/allas-in-roihu.md
@@ -43,7 +43,7 @@ The project specific access key pair is stored to the configuration files of *aw
 
 In case of **aws** and **s3cmd**, only one connection is defined and running allas-conf overwrites the old default connections.  
 
-In case of **rclone**, two endpoints are defined **s3allas:** and **s3allas-project-_proj-number_**. Both endpoints refer to the same Allas project. When a new project is defined with allas-conf, a3allas: endpoint is changed to refer to the new project, but the older project specific endpoint is preserved in addition to the new project specific endpoint that gets generated. 
+In case of **rclone**, two endpoints are defined **s3allas:** and **s3allas-project-_proj-number_**. Both endpoints refer to the same Allas project. When a new project is defined with allas-conf, s3allas: endpoint is changed to refer to the new project, but the older project specific endpoint is preserved in addition to the new project specific endpoint that gets generated. 
 
 For example after commands:
 
@@ -58,15 +58,15 @@ Following connections are in use:
 |--------------------------------|----------------|
 | a-commands, aws and s3cmd	     | project_200222 |
 | rclone s3allas:                | project_200222 |
-| rclone a3allas-project_200111: | project_200111 |
-| rclone a3allas-project_200222: | project_200222 |
+| rclone s3allas-project_200111: | project_200111 |
+| rclone s3allas-project_200222: | project_200222 |
 
 And with these settings all the commands below list the Allas buckets of project 200222.
 
 ```txt
 a-list
 rclone lsd s3allas:
-rclone lsd a3allas-project_200222:
+rclone lsd s3allas-project_200222:
 s3cmd ls s3://
 aws s3 ls
 ```

--- a/docs/computing/compiling-roihu.md
+++ b/docs/computing/compiling-roihu.md
@@ -134,8 +134,8 @@ compiler environments for building C/C++ and Fortran applications under the foll
 
 | Compiler suite               | Modules                                                  |
 | :--------------------------- | :------------------------------------------------------- |
-| GNU 14.3.0 + CUDA 12.9.1     | `gcc/14.3.0 cuda/12.9.1 openmpi/5.0.8 openblas/0.3.30`   |
-| GNU 15.2.0 + CUDA 13.1.1     | `gcc/15.2.0 cuda/13.1.1 openmpi/5.0.8 openblas/0.3.30`   |
+| GNU 14.3.0 + CUDA 12.9.1     | `gcc/14.3.0 cuda/12.9.1 openmpi/5.0.10 openblas/0.3.30`  |
+| GNU 15.2.0 + CUDA 13.1.1     | `gcc/15.2.0 cuda/13.1.1 openmpi/5.0.10 openblas/0.3.30`  |
 | NVIDIA HPC 26.3              | `nvhpc/26.3`                                             |
 
 The first compiler suite is loaded by default.

--- a/docs/computing/hpc-billing.md
+++ b/docs/computing/hpc-billing.md
@@ -37,7 +37,10 @@ On GPU partitions the pricing is always based on the amount of reserved GPUs. CP
 and memory are not billed separately, each job will at most be able to reserve a corresponding
 share of CPU and memory resources of the node.
 
-For all partitions local disk usage is billed additionally to the above BUs.
+For all partitions, *reserved* local storage — disaggregated storage, and
+local scratch reserved with the `--gres=nvme` option — is billed in addition
+to the above BUs. The automatic local temporary storage (`$TMPDIR`) is free
+of charge.
 
 See details of the different [CPU and GPU partitions on Roihu](running/batch-job-partitions.md#roihu-partitions).
 

--- a/docs/computing/roihu-disk.md
+++ b/docs/computing/roihu-disk.md
@@ -295,7 +295,7 @@ For example, to reserve the maximum amount of 13 TB, use:
 ```
 
 Local scratch in a job can be accessed through the environment variable `$LOCAL_SCRATCH`, which points to a user and job-id specific disk area
-you can use in `/local_scrach/${USER}/${SLURM_JOB_ID}/`.
+you can use in `/local_scratch/${USER}/${SLURM_JOB_ID}/`.
 
 ??? info "Example Slurm script for using local scratch memory in hugemem nodes"
      ```

--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -147,20 +147,25 @@ The amount of local storage available to a single user depends on the [partition
 
 === "Automatic (`$TMPDIR`)"
 
-    | Allocation type    | Available per user | Read / Write speeds |
-    |:-------------------|-------------------:|---------------------|
-    | R (shared nodes)   | 20 GiB             | 5000 / 1400 MB/s    |
-    | N (full nodes)     | 600 GiB            | 5000 / 1400 MB/s    |
-    | G (GPU nodes)      | 150 GiB            | 5000 / 1400 MB/s    |
-    | Hugemem (XL) nodes | 578 GiB            | 6700 / 4000 MB/s    |
-    | VIZ nodes          | 14 TiB             | 6700 / 4000 MB/s    |
+    | Allocation type         | Available per user | Read / Write speeds |
+    |:------------------------|-------------------:|---------------------|
+    | R (shared nodes)        | 20 GiB             | 5000 / 1400 MB/s    |
+    | N (full nodes)          | 600 GiB            | 5000 / 1400 MB/s    |
+    | G (GPU nodes)           | 150 GiB            | 5000 / 1400 MB/s    |
+    | Hugemem (XL) nodes      | 578 GiB            | 6700 / 4000 MB/s    |
+    | V (visualization nodes) | 14 TiB             | 6700 / 4000 MB/s    |
+
+    Reservable local scratch has not yet been implemented on visualization nodes (V).
+    Until it is available, jobs on these nodes can use the full `$TMPDIR` allocation shown above.
+
+    Once reservable local scratch is implemented, the amount of `$TMPDIR` available per user on visualization nodes will be reduced.
 
 === "Reservable (`$LOCAL_SCRATCH`)"
 
-    | Node type          | Maximum reservable | Read / Write speeds |
-    |:-------------------|-------------------:|---------------------|
-    | Hugemem (XL) nodes | 13 TiB             | 6700 / 4000 MB/s    |
-    | VIZ nodes          | 6.5 TiB per user   | 6700 / 4000 MB/s    |
+    | Node type               | Maximum reservable | Read / Write speeds |
+    |:------------------------|-------------------:|---------------------|
+    | Hugemem (XL) nodes      | 13 TiB             | 6700 / 4000 MB/s    |
+    | V (visualization nodes) | 6.5 TiB per user   | 6700 / 4000 MB/s    |
 
     Reserving local scratch on the visualization nodes is not yet
     implemented; use `$TMPDIR` on these nodes until this feature is added.

--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -127,7 +127,7 @@ Roihu also features the following partition for interactive use and data visuali
 |------------------|-----------------|------------|-------|-----------|-----------------------------------------|
 | `vizinteractive` | G               | 12 hours   | 1     | 2 per job | V                                       |
 
-Each node in the partition has 2 Nvidia L40 GPUs with 44 GiB of memory and two 32-core AMD EPYC 9335 CPUs.
+Each node in the partition has 2 Nvidia L40 GPUs with 48 GB of memory and two 32-core AMD Turin 9335 CPUs.
 Each reserved GPU grants access to up to 32 CPU cores and 183 GiB of CPU memory.
 
 ### Local storage on Roihu nodes
@@ -136,15 +136,33 @@ Local storage on Roihu M, L, and GPU nodes is meant for storing temporary files 
 
 High-performance local storage is available on Roihu XL and V nodes, which is ideal for I/O-intensive jobs.
 
+There are two kinds of node-local storage: **automatic temporary storage**
+(`$TMPDIR`), available in every job without a reservation and free of charge,
+and **reservable local scratch** (`$LOCAL_SCRATCH`), which is only available
+on the XL and V nodes, is reserved through Slurm with the `--gres=nvme`
+option, and consumes billing units.
+
 The amount of local storage available to a single user depends on the [partition](#roihu-partitions) used:
 
-| Allocation type    | Quota per user | Read / Write speeds |
-|:-------------------|---------------:|---------------------|
-| R (shared nodes)   | 20 GiB         | 5000 / 1400 MB/s    |
-| N (full nodes)     | 600 GiB        | 5000 / 1400 MB/s    |
-| G (GPU nodes)      | 150 GiB        | 5000 / 1400 MB/s    |
-| Hugemem (XL) nodes | 13 TiB         | 6700 / 4000 MB/s    |
-| VIZ nodes          | 6.5 TiB        | 6700 / 4000 MB/s    |
+=== "Automatic (`$TMPDIR`)"
+
+    | Allocation type    | Available per user | Read / Write speeds |
+    |:-------------------|-------------------:|---------------------|
+    | R (shared nodes)   | 20 GiB             | 5000 / 1400 MB/s    |
+    | N (full nodes)     | 600 GiB            | 5000 / 1400 MB/s    |
+    | G (GPU nodes)      | 150 GiB            | 5000 / 1400 MB/s    |
+    | Hugemem (XL) nodes | 578 GiB            | 6700 / 4000 MB/s    |
+    | VIZ nodes          | 14 TiB             | 6700 / 4000 MB/s    |
+
+=== "Reservable (`$LOCAL_SCRATCH`)"
+
+    | Node type          | Maximum reservable | Read / Write speeds |
+    |:-------------------|-------------------:|---------------------|
+    | Hugemem (XL) nodes | 13 TiB             | 6700 / 4000 MB/s    |
+    | VIZ nodes          | 6.5 TiB per user   | 6700 / 4000 MB/s    |
+
+    Reserving local scratch on the visualization nodes is not yet
+    implemented; use `$TMPDIR` on these nodes until this feature is added.
 
 Read more about: [Local storage on Roihu nodes](../roihu-disk.md#temporary-local-disk-areas)
 

--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -112,8 +112,9 @@ and automatically provides a GPU slice when run from a Roihu-GPU login node.
 | `gpuinteractive`  | G               | 12 hours   | 1      | TBA       | TBA            | GPU (slice)                             |
 
 !!! info "What is a GPU slice?"
-    The Roihu `gpuinteractive` partition uses GH200 superchips divided into 48 smaller slices.
-    Each slice has one-seventh of the compute capacity and one-eighth of the GPU memory capacity (12 GiB) of a full GH200 superchip.
+    The Roihu gpuinteractive partition consists of two nodes, each containing four GH200 GPUs.
+    Each GPU can be divided into up to seven 1g.12gb MIG slices, providing up to 56 GPU slices across the partition.
+    Each slice provides one-seventh of the GPU compute capacity and one-eighth of the GPU memory capacity (12 GiB) of a full GH200 GPU.
 
 !!! note "GPU slices not yet fully configured"
     GPU slices are not yet configured on the system, and reserving GPUs through `sinteractive`, or through Slurm on the partition

--- a/docs/computing/running/creating-job-scripts-roihu.md
+++ b/docs/computing/running/creating-job-scripts-roihu.md
@@ -332,9 +332,12 @@ Note that the `--gres` reservation is on a per-node basis. There are 4 GPUs per 
     The MIGs are not configured yet.
 
 In `gpuinteractive` partition, the GH200 GPUs are sliced into smaller Multi-Instance GPUs (MIG).
-Each MIG here has one XXXth of the compute and memory capacity of a full GH200 GPU.
-For each GPU slice you can reserve at most XXX CPU cores and for each GPU slice the job is allocated XXX GiB of CPU memory.
-Also note that you can reserve at most one GPU slice per job. The GPU slices are available using the options:
+Each MIG has one-seventh of the compute capacity and one-eighth of the GPU memory capacity of a full GH200 GPU, providing 12 GiB of GPU memory.
+
+The maximum number of CPU cores and the amount of CPU memory available to a job is less than on a partition with full GPUs.
+These limits will be documented once the MIG configuration has been finalized.
+
+You can reserve at most one GPU slice per job. GPU slices are requested using the following options::
 
 ```bash
 #SBATCH --partition=gpuinteractive

--- a/docs/computing/running/example-job-scripts-roihu.md
+++ b/docs/computing/running/example-job-scripts-roihu.md
@@ -161,7 +161,7 @@ srun myprog <options>
 
 ## Roihu-GPU
 
-### Partial GPU nodes: 1-16 GPUs
+### Partial GPU nodes: 1-4 GPUs
 
 ```bash
 #!/bin/bash
@@ -185,7 +185,7 @@ export OMP_PROC_BIND=spread
 srun myprog <options>
 ```
 
-### Full GPU nodes: 16 or more GPUs
+### Full GPU nodes: 4 or more GPUs
 
 ```bash
 #!/bin/bash

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -51,10 +51,16 @@ Roihu and Mahti due to differences in hardware.
 There are two interactive partitions available on Roihu; `interactive` for CPU 
 resources and `gpuinteractive` for GPU resources. See the
 [Roihu `interactive` partition details](./batch-job-partitions.md#roihu-partitions)
-for information on the available resources. The Roihu `gpuinteractive` partition 
-features GH200 superchips that are divided into a total of 48 smaller slices that 
-have one-seventh of the compute capacity and one-eighth of the GPU memory capacity 
-(12 GiB) of a full GH200 superchip. `sinteractive` will select the correct partition
+for information on the available resources.
+
+Once GPU slicing is implemented, the GH200 GPUs in the `gpuinteractive` partition
+will be divided into smaller Multi-Instance GPU (MIG) slices. Each slice will provide
+one-seventh of the GPU compute capacity and one-eighth of the GPU memory capacity
+of a full GH200 GPU, giving each slice 12 GiB of GPU memory. With two nodes, four
+GPUs per node, and up to seven slices per GPU, the partition can provide up to
+56 GPU slices in total.
+
+`sinteractive` will select the correct partition
 based on your resource request, and will automatically provide you with a GPU if
 run from the GPU login node without additional parameters.
 

--- a/docs/computing/running/performance-checklist.md
+++ b/docs/computing/running/performance-checklist.md
@@ -44,7 +44,7 @@ see poor I/O performance even if the total volume is not that big. Please
 consider the following items to mitigate potential bottlenecks:
 
 * Use local storage for especially AI workloads instead of scratch. Only some
-  nodes have [fast local disk](creating-job-scripts-puhti.md#local-storage),
+  nodes have [fast local disk](creating-job-scripts-roihu.md#local-temporary-storage),
   but we've seen 10-fold performance improvement by switching to use it. Check
   your performance: don't use the resource if it doesn't help.
   [AI batch job example](../../support/tutorials/ml-data.md#fast-local-drive-puhti-and-mahti-only)

--- a/docs/computing/systems-roihu.md
+++ b/docs/computing/systems-roihu.md
@@ -162,6 +162,11 @@ they use:
     | Hugemem (XL) nodes      | 578 GiB            | 6700 / 4000 MB/s    |
     | V (visualization nodes) | 14 TiB             | 6700 / 4000 MB/s    |
 
+    Reservable local scratch has not yet been implemented on visualization nodes (V).
+    Until it is available, jobs on these nodes can use the full `$TMPDIR` allocation shown above.
+
+    Once reservable local scratch is implemented, the amount of `$TMPDIR` available per user on visualization nodes will be reduced.
+
 === "Reservable (`$LOCAL_SCRATCH`)"
 
     | Node type               | Maximum reservable | Read / Write speeds |

--- a/docs/computing/systems-roihu.md
+++ b/docs/computing/systems-roihu.md
@@ -144,16 +144,33 @@ for temporary files created during jobs.
 High-memory (XL) and visualization (VIZ) nodes provide additional capacity and
 faster performance in their local storage, with a total of 13 TiB of local NVMe storage per node.
 
-The available storage quota that a single user can access in their jobs depends
-on the system [partition](running/batch-job-partitions.md) they use:
+There are two kinds of node-local storage. **Automatic temporary storage**
+(`$TMPDIR`) is available in every job without a reservation and free of
+charge. **Reservable local scratch** (`$LOCAL_SCRATCH`) is only available on
+the XL and V nodes, is reserved through Slurm with the `--gres=nvme` option,
+and consumes billing units. The amounts that a single user can access in
+their jobs depend on the system [partition](running/batch-job-partitions.md)
+they use:
 
-| Allocation type         | Quota per user | Read / Write speeds |
-|:------------------------|---------------:|---------------------|
-| R (shared nodes)        | 20 GiB         | 5000 / 1400 MB/s    |
-| N (full nodes)          | 600 GiB        | 5000 / 1400 MB/s    |
-| G (GPU nodes)           | 150 GiB        | 5000 / 1400 MB/s    |
-| Hugemem (XL) nodes      | 13 TiB         | 6700 / 4000 MB/s    |
-| V (visualization nodes) | 6.5 TiB        | 6700 / 4000 MB/s    |
+=== "Automatic (`$TMPDIR`)"
+
+    | Allocation type         | Available per user | Read / Write speeds |
+    |:------------------------|-------------------:|---------------------|
+    | R (shared nodes)        | 20 GiB             | 5000 / 1400 MB/s    |
+    | N (full nodes)          | 600 GiB            | 5000 / 1400 MB/s    |
+    | G (GPU nodes)           | 150 GiB            | 5000 / 1400 MB/s    |
+    | Hugemem (XL) nodes      | 578 GiB            | 6700 / 4000 MB/s    |
+    | V (visualization nodes) | 14 TiB             | 6700 / 4000 MB/s    |
+
+=== "Reservable (`$LOCAL_SCRATCH`)"
+
+    | Node type               | Maximum reservable | Read / Write speeds |
+    |:------------------------|-------------------:|---------------------|
+    | Hugemem (XL) nodes      | 13 TiB             | 6700 / 4000 MB/s    |
+    | V (visualization nodes) | 6.5 TiB per user   | 6700 / 4000 MB/s    |
+
+    Reserving local scratch on the visualization nodes is not yet
+    implemented; use `$TMPDIR` on these nodes until this feature is added.
 
 As a new feature, users can also request local disk mounts from a
 centralized pool of fast storage resources. This fast storage capacity is


### PR DESCRIPTION
## Proposed changes

- [systems-roihu.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/systems-roihu), [batch-job-partitions.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/running/batch-job-partitions): split the node-local storage tables into "Automatic ($TMPDIR)" and "Reservable ($LOCAL_SCRATCH)" tabs. The old single "quota per user" table mixed the two kinds of storage (automatic $TMPDIR on M/L/G vs Slurm-reserved $LOCAL_SCRATCH on XL/V), which made the pages look contradictory against roihu-disk.md.
- [example-job-scripts-roihu.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/running/example-job-scripts-roihu): GPU section headings said "1-16 GPUs" / "16 or more GPUs"; gpumedium allows at most 4 GPUs per job, so the headings now read "1-4 GPUs" / "4 or more GPUs".
- [batch-job-partitions.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/running/batch-job-partitions): vizinteractive L40 memory 44 GiB -> 48 GB, and "AMD EPYC 9335" -> "AMD Turin 9335" to match the naming used everywhere else (whether the docs should say EPYC instead of Turin overall is left for PR discussion).
- [compiling-roihu.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/compiling-roihu): GPU compiler suites listed openmpi/5.0.8; the modules on the system are openmpi/5.0.10 (as also shown in modules.md).
- [hpc-billing.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/hpc-billing): "for all partitions local disk usage is billed additionally" implied automatic $TMPDIR is billed; clarified that only reserved storage (disaggregated, --gres=nvme) bills and $TMPDIR is free, consistent with roihu-disk.md and creating-job-scripts-roihu.md.
- [performance-checklist.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/running/performance-checklist): "fast local disk" pointed at the Puhti page; now points at the Roihu local-storage section.
- [roihu-disk.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/roihu-disk): typo /local_scrach/ -> /local_scratch/.
- [allas-in-roihu.md](https://csc-guide-preview.2.rahtiapp.fi/origin/roihu-related-corrections/computing/allas-in-roihu): rclone remote written as "a3allas"/"a3allas-project_*" in the table and examples while introduced as "s3allas"; unified to s3allas. TODO before merging: check whether the a3allas name was around for a reason (e.g. an older or alternate allas-conf remote name) rather than being a typo.

## Additional possible issues

- There are some "XXX" placeholders in `creating-job-scripts-roihu.md`
- `batch-job-partitions.md`: "48 smaller slices", but with 7 compute slices per GPU and 4 GPUs per node it would be 28, so maybe a typo?

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
