### PR TITLE
Add changelog for www-Roihu R2

### DIFF
--- a/docs/computing/webinterface/accelerated-visualization.md
+++ b/docs/computing/webinterface/accelerated-visualization.md
@@ -1,5 +1,5 @@
 # Accelerated visualization
-The Accelerated visualization app enables using visualization applications with GPU acceleration on a compute node, and is available on Roihu and Puhti.
+The Accelerated visualization app enables using visualization applications with GPU acceleration on a compute node, and is available on Roihu.
 
 ## Available applications
 
@@ -9,17 +9,6 @@ The Accelerated visualization app enables using visualization applications with 
 * [CloudCompare](../../apps/cloudcompare.md)
 * [COMSOL](../../apps/comsol.md)
 * [ParaView](../../apps/paraview.md)
-* [VisIt](../../apps/visit.md)
-
-### Puhti
-
-* [Abaqus CAE](../../apps/abaqus.md)
-* [Ansys Workbench](../../apps/ansys.md)
-* [Blender](../../apps/blender.md)
-* [COMSOL](../../apps/comsol.md)
-* [CloudCompare](../../apps/cloudcompare.md)
-* [ParaView](../../apps/paraview.md)
-* [VMD](../../apps/vmd.md)
 * [VisIt](../../apps/visit.md)
 
 

--- a/docs/computing/webinterface/desktop.md
+++ b/docs/computing/webinterface/desktop.md
@@ -1,5 +1,5 @@
 # Desktop
-The desktop enables using graphical applications on a Roihu, Puhti, or Mahti compute node.
+The desktop enables using graphical applications on a Roihu or Mahti compute node.
 
 ## Available applications
 
@@ -17,18 +17,6 @@ applications:
 * [SAGA GIS](../../apps/saga-gis.md)
 * [SNAP](../../apps/snap.md)
 
-### Puhti
-
-* [COMSOL](../../apps/comsol.md)
-* [CloudCompare](../../apps/cloudcompare.md)
-* [GRASS GIS](../../apps/grass.md)
-* [Grace](../../apps/grace.md)
-* [MATLAB](../../apps/matlab.md)
-* [Maestro](../../apps/maestro.md)
-* [QGIS](../../apps/qgis.md)
-* [SAGA GIS](../../apps/saga-gis.md)
-* [SNAP](../../apps/snap.md)
-* [VMD](../../apps/vmd.md)
 
 ### Mahti
 
@@ -37,7 +25,7 @@ applications:
 
 Only CPU rendering is supported in the graphical applications launched from the desktop.
 See [here how to enable GPU-accelerated visualization](accelerated-visualization.md)
-for selected applications on Roihu and Puhti.
+for selected applications on Roihu.
 
 
 ## Launching

--- a/docs/computing/webinterface/index.md
+++ b/docs/computing/webinterface/index.md
@@ -119,10 +119,10 @@ specific instructions, see the [Interactive apps](apps.md) page.
     requires longer jobs than that, we recommend that you run your software as
     [batch jobs](../running/getting-started.md).
 
-In the **Roihu web interface**, the `interactive`, `small`, `test`, and `gputest` partitions are
-available. In the [Accelerated Visualization app](accelerated-visualization.md), the
-`vizinteractive` partition is used, and will reserve one Nvidia L40 GPU. On the `gputest` partition,
-one Nvidia GH200 GPU will be allocated. See the [Roihu partitions
+In the **Roihu web interface**, the `interactive`, `small`, `test`, `gpuinteractive`, and `gputest`
+partitions are available. In the [Accelerated Visualization app](accelerated-visualization.md), the
+`vizinteractive` partition is used, and will reserve one Nvidia L40 GPU. On the `gpuinteractive` and
+`gputest` partitions, one Nvidia GH200 GPU will be allocated. See the [Roihu partitions
 page](../running/batch-job-partitions.md#roihu-partitions) for general information about queues on
 Roihu.
 

--- a/docs/computing/webinterface/index.md
+++ b/docs/computing/webinterface/index.md
@@ -42,7 +42,7 @@ Please note that logging in to Roihu, Puhti, and Mahti web interfaces requires
     - View running batch jobs
     - View disk quotas and project status
     - Launch interactive apps and connect to them directly from the browser:
-        - Accelerated Visualization with applications such as Blender and ParaView (Roihu and Puhti only)
+        - Accelerated Visualization with applications such as Blender and ParaView (Roihu only)
         - Desktop with applications such as Maestro and VMD
         - Julia-Jupyter
         - Jupyter

--- a/docs/computing/webinterface/julia-on-jupyter.md
+++ b/docs/computing/webinterface/julia-on-jupyter.md
@@ -5,7 +5,7 @@
 ![ood application menu](../../img/julia-jupyter/ood-application-menu.png)
 
 We can use [Julia](../../apps/julia.md) on Jupyter through the
-[Puhti](https://www.puhti.csc.fi) and [Mahti](https://www.mahti.csc.fi) web
+[Roihu](https://www.roihu.csc.fi) and [Mahti](https://www.mahti.csc.fi) web
 interfaces by selecting the **Julia-Jupyter** application from the menu.
 
 ## Launching Julia-Jupyter

--- a/docs/computing/webinterface/jupyter-for-courses.md
+++ b/docs/computing/webinterface/jupyter-for-courses.md
@@ -15,10 +15,8 @@ In the form for launching the application:
 ## Creating a course environment
 
 The files for course environments (modules) can be created in
-`/projappl/<project>/www_roihu_modules/` on Roihu,
-`/projappl/<project>/www_puhti_modules/` on Puhti, and
-`/projappl/<project>/www_mahti_modules` on Mahti. The directories can be created
-if they do not exist.
+`/projappl/<project>/www_roihu_modules/` on Roihu, and `/projappl/<project>/www_mahti_modules` on
+Mahti. The directories can be created if they do not exist.
 
 The course environment is only visible for the project that it was created for.
 Note that you may need to *Restart Web Server* in the *Help* menu in the web interface if the course

--- a/docs/computing/webinterface/jupyter.md
+++ b/docs/computing/webinterface/jupyter.md
@@ -9,13 +9,12 @@ In the app launch form you can define the Python environment,
 Jupyter interface type (Jupyter Notebook or JupyterLab),
 working directory as well as some more advanced settings.
 
-For more information about working with different Python environments on Roihu,
-Puhti, and Mahti, see our [Python application page](../../apps/python.md)
-and [Python usage guide](../../support/tutorials/python-usage-guide.md).
-Note that all the modules listed on the Python app page are not guaranteed to
-work with the Jupyter interactive app. Additionally, installation of
-Python packages works differently from the general instructions in
-the usage guide.
+For more information about working with different Python environments on Roihu
+and Mahti, see our [Python application page](../../apps/python.md) and [Python
+usage guide](../../support/tutorials/python-usage-guide.md). Note that all the
+modules listed on the Python app page are not guaranteed to work with the
+Jupyter interactive app. Additionally, installation of Python packages works
+differently from the general instructions in the usage guide.
 
 ### Supported Python environments on Roihu
 
@@ -33,7 +32,7 @@ Note that the Python module dropdown will only show the modules available on the
 partition.
 
 
-### Supported Python environments on Puhti and Mahti
+### Supported Python environments on Mahti
 
  - geoconda
  - python-data
@@ -49,7 +48,7 @@ this, you must enable either the *User packages* or the *Virtual environment* op
 options are shown after enabling the *Enable advanced settings* option at the end of the form.
 
 If you do not define an installation path, the packages will be installed under
-`$HOME/.local/lib` on Puhti and Mahti, and `$HOME/.local/x86_64/lib` or `$HOME/.local/aarch64/lib/`
+`$HOME/.local/lib` on Mahti, and `$HOME/.local/x86_64/lib` or `$HOME/.local/aarch64/lib/`
 on Roihu. However, **this is not recommended** as the home directory
 storage quota is limited.
 
@@ -82,7 +81,7 @@ requires using virtual environments.
 
 
 To use a Tykky installation with Jupyter, first [include Jupyter packages in your Tykky
-installation](../containers/tykky.md#using-jupyter-with-a-tykky-installation). Then, open the Roihu, Puhti,
+installation](../containers/tykky.md#using-jupyter-with-a-tykky-installation). Then, open the Roihu
 or Mahti web interface and navigate to the Jupyter app page. In the form, select the `Custom path`
 option from the Python dropdown. Then, enter the full path to the Python interpreter of your Tykky
 installation. So, if you created an installation with the command `conda-containerize new

--- a/docs/computing/webinterface/rstudio.md
+++ b/docs/computing/webinterface/rstudio.md
@@ -22,7 +22,7 @@ threading](../../support/tutorials/parallel-r-examples.md#improving-performance-
 
 If an RStudio session fails to start or RStudio is extremely slow, first try resetting your
 RStudio user state as described below. These steps will clean up leftover data from previous interrupted RStudio
-sessions in two hidden folders in the user's home directory: `.config/rstudio` and `.local/share/x86_64/rstudio` (`.local/share/rstudio` on Puhti ja Mahti). These folders can be either renamed (to keep the contents) or deleted (if you are sure the contents are not needed).
+sessions in two hidden folders in the user's home directory: `.config/rstudio` and `.local/share/x86_64/rstudio` (`.local/share/rstudio` on Mahti). These folders can be either renamed (to keep the contents) or deleted (if you are sure the contents are not needed).
 
 
 === "Roihu-CPU"
@@ -38,19 +38,7 @@ sessions in two hidden folders in the user's home directory: `.config/rstudio` a
     `mv ~/.config/rstudio ~/.config/rstudio-old`  
     `mv ~/.local/share/x86_64/rstudio ~/.local/share/x86_64/rstudio-old`
 
-=== "Puhti"
-    **Option 1:** Use the file viewer in the web interface:
-    
-    1. In the top left corner of the web interface dashboard, choose **Files** and **Home Directory**.
-    2. Click **Show dotfiles**.
-    3. Delete or rename the `rstudio` folders under `.config` and `.local` -> `share`. 
-    
-    **Option 2:** Use a terminal (for example a login node shell in the web interface) to delete or
-    rename these folders. Here is an example how renaming would work:
-    
-    `mv ~/.config/rstudio ~/.config/rstudio-old`  
-    `mv ~/.local/share/rstudio ~/.local/share/rstudio-old`
-    
+
 === "Mahti"
     **Option 1:** Use the file viewer in the web interface:
     

--- a/docs/computing/webinterface/vscode.md
+++ b/docs/computing/webinterface/vscode.md
@@ -1,6 +1,6 @@
 # Visual Studio Code
-The Visual Studio Code interactive app can be used for editing and running code on Roihu, Puhti, or
-Mahti. Make sure to load the correct modules before launching the session for the debugger to work
+The Visual Studio Code interactive app can be used for editing and running code on Roihu or Mahti.
+Make sure to load the correct modules before launching the session for the debugger to work
 correctly.
 
 In the form, you will be able to select the VSCode version as well as any modules you would like to
@@ -48,7 +48,7 @@ To install the extension:
    installed, the download option may not be available.  
 ![downloading cpptools VSIX](../../img/ood-vscode-cpptools-vsix.png).
 3. Select the *Linux x64* version in the menu that appears.
-4. Upload the extension package, e.g. `ms-vscode.cpptools-1.x.x@linux-x64.vsix` to Puhti or Mahti,
+4. Upload the extension package, e.g. `ms-vscode.cpptools-1.x.x@linux-x64.vsix` to Roihu or Mahti,
    for example using the file browser in the web interface.
 5. Open VSCode __in the web interface__ and navigate to the extensions tab.
 6. In the extensions tab in VS Code, click the three dots at the top to open a menu.

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,13 @@
 # Computing environment
 
+## Roihu web interface updated to release 2, 18.8.2026
+
+* The gpuinteractive partition is now available.
+* /dataset is now supported.
+* Roihu usage metrics graphs have been added.
+* Plugins in CloudCompare in Accelerated Visualization now work.
+* Open OnDemand updated to 4.2.3.
+
 ## Puhti compute services decommissioned, 31.7.2026
 
 Compute services in Puhti have been decommissioned as of 31 July 2026 at 12:00 EEST.

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -3,7 +3,7 @@
 ## Roihu web interface updated to release 2, 18.8.2026
 
 * The gpuinteractive partition is now available.
-* /dataset is now supported.
+* The `/dataset` path is now accessible in the web interface's file browser and Desktop app.
 * Roihu usage metrics graphs have been added.
 * Plugins in CloudCompare in Accelerated Visualization now work.
 * Open OnDemand updated to 4.2.3.


### PR DESCRIPTION
Adds the change log for Roihu web interface release 2, and removes unnecessary mentions of Puhti in the interactive app documentation (apps are now disabled).

https://csc-guide-preview.2.rahtiapp.fi/origin/wwwroihu-r2/
