### PR TITLE
AMS-GUI: Roihu 2026.105 update; remove decommissioned Puhti/Mahti

### DIFF
--- a/docs/apps/ams-gui.md
+++ b/docs/apps/ams-gui.md
@@ -8,8 +8,6 @@ catalog:
   disciplines:
     - Chemistry
   available_on:
-    - Puhti
-    - Mahti
     - Roihu
 ---
 
@@ -28,90 +26,46 @@ See [the License section of AMS](ams.md#license).
 
 ### Use via your browser
 
-=== "Roihu-CPU"
+Go to the [Roihu web interface](../computing/webinterface/index.md) using
+a web browser and login using your CSC user account.
 
-    Go to the [Roihu web interface](../computing/webinterface/index.md) using
-    a web browser and login using your CSC user account.
+1. From there [launch a Desktop](../computing/webinterface/desktop.md#launching).
+   When launching, request a few CPU cores (e.g. 4) for your Desktop
+   session if you intend to run short jobs directly from the GUI — this
+   also makes the 3D display noticeably smoother.
+2. Open a `Terminal` and move to a suitable working directory.
+3. Load the AMS module `module load ams/2026.105`.
+4. Start the input builder with `ams_ood` (not bare `amsinput`), which runs
+   the pre-optimizer and short `File-> Run` jobs correctly on the web Desktop.
+   Startup may take some time.
+5. Build your job and save it (`File-> Save`).
 
-    1. From there [launch a Desktop](../computing/webinterface/desktop.md#launching).
-       When launching, request a few CPU cores (e.g. 4) for your Desktop
-       session if you intend to run short jobs directly from the GUI — this
-       also makes the 3D display noticeably smoother.
-    2. Open a `Terminal` and move to a suitable working directory.
-    3. Load the AMS module `module load ams/2026.104`.
-    4. Start the input builder `amsinput`. The startup may take some time, so
-       please be patient.
+Short jobs can be started directly from the GUI (`File-> Run`), but longer
+jobs should be submitted to the batch queue. All saved jobs, both
+calculated and uncalculated, can be found in the GUI under `SCM-> Jobs`.
+Before you submit a job to the batch queue you have to define what
+resources it needs (time, memory, number of cores etc.)
 
-        !!! info "Note"
-            The message `Slurm setup failed: SLURM_TASKS_PER_NODE is not set`
-            printed at startup is harmless and can be ignored.
+1. Under `SCM-> Jobs`, select `Queue -> New -> SLURM`
+2. `Queue Name: My_testqueue`. You can save queues with different names
+   corresponding to different resource requests
+3. `Remote host:`. Leave empty
+4. `Remote user:`. Leave empty
+5. `Remote job directory:`. Leave empty
+6. `Run command: sbatch --partition=test --ntasks=8 --mem-per-cpu=1500M --account=<yourproject> --time=00:15:00 "$job"`
+   Please replace `<yourproject>` with a proper project name. You can use
+   the same command line options as in the
+   [AMS batch script examples](ams.md#example-batch-scripts). Note that
+   on Roihu memory is requested independently of the number of cores,
+   e.g. with `--mem-per-cpu`.
+7. `Use Local Batch: yes`
+8. `Prolog command: export SCM_TMPDIR=/scratch/<yourproject>; source /appl/soft/manual/chem/x86_64/AMS/ams2026.105/ams_csc.bash`
+   This initiates the AMS environment. Set `SCM_TMPDIR` to the scratch
+   directory you want to use; if you belong to several projects, choose
+   the appropriate `/scratch/project_XXXXXXX`.
 
-    5. Build your job and save it (`File-> Run`).
-
-    Short jobs can be started directly from the GUI (`File-> Run`), but longer
-    jobs should be submitted to the batch queue. All saved jobs, both
-    calculated and uncalculated, can be found in the GUI under `SCM-> Jobs`.
-    Before you submit a job to the batch queue you have to define what
-    resources it needs (time, memory, number of cores etc.)
-
-    1. Under `SCM-> Jobs`, select `Queue -> New -> SLURM`
-    2. `Queue Name: My_testqueue`. You can save queues with different names
-       corresponding to different resource requests
-    3. `Remote host:`. Leave empty
-    4. `Remote user:`. Leave empty
-    5. `Remote job directory:`. Leave empty
-    6. `Run command: sbatch --partition=test --ntasks=8 --mem-per-cpu=1500M --account=<yourproject> --time=00:15:00 "$job"`
-       Please replace `<yourproject>` with a proper project name. You can use
-       the same command line options as in the
-       [AMS batch script examples](ams.md#example-batch-scripts). Note that
-       on Roihu memory is requested independently of the number of cores,
-       e.g. with `--mem-per-cpu`.
-    7. `Use Local Batch: yes`
-    8. `Prolog command: export SCM_TMPDIR=/scratch/<yourproject>; source /appl/soft/manual/chem/x86_64/AMS/ams2026.104/ams_csc.bash`
-       This initiates the AMS environment. Set `SCM_TMPDIR` to the scratch
-       directory you want to use; if you belong to several projects, choose
-       the appropriate `/scratch/project_XXXXXXX`.
-
-    Select the job you want to submit (`SCM-> Jobs`), the queue you want to
-    use (`Queue`) and submit the job `Job-> Run`.
-
-=== "Puhti"
-
-    !!! warning
-        Puhti is being decommissioned in stages during 2026. New work should
-        be started on Roihu.
-
-    Go to [puhti.csc.fi](https://puhti.csc.fi) using a web browser and login
-    using your CSC user account.
-
-    1. From there [launch a Desktop](../computing/webinterface/desktop.md#launching).
-    2. Open a `Terminal` and move to a suitable working directory.
-    3. Load the AMS module `module load ams/2025.105`.
-    4. Start the input builder `amsinput`. The startup may take some time, so
-       please be patient.
-    5. Build your job and save it (`File-> Save As ...`).
-
-    Short jobs can be started directly from the GUI (`File-> Run`), but longer
-    jobs should be submitted to the batch queue. All saved jobs, both
-    calculated and uncalculated, can be found in the GUI under `SCM-> Jobs`.
-    Before you submit a job to the batch queue you have to define what
-    resources it needs (time, memory, number of cores etc.)
-
-    1. Under `SCM-> Jobs`, select `Queue -> New -> SLURM`
-    2. `Queue Name: My_testqueue`. You can save queues with different names
-       corresponding to different resource requests
-    3. `Remote host:`. Leave empty
-    4. `Remote user:`. Leave empty
-    5. `Remote job directory:`. Leave empty
-    6. `Run command: sbatch --partition=test --nodes=1 --ntasks-per-node=40 --account=<yourproject> --time=00:10:00 "$job"`
-       Please replace `<yourproject>` with a proper project name. You can use
-       the same command line options as in a normal batch job script.
-    7. `Use Local Batch: yes`
-    8. `Prolog command: source /appl/profile/zz-csc-env.sh; module load ams/2025.105; export SCM_TMPDIR=$PWD; export FORT_TMPDIR=$SCM_TMPDIR`
-       This initiates the AMS environment.
-
-    Select the job you want to submit (`SCM-> Jobs`), the queue you want to
-    use (`Queue`) and submit the job `Job-> Run`.
+Select the job you want to submit (`SCM-> Jobs`), the queue you want to
+use (`Queue`) and submit the job `Job-> Run`.
 
 ### Install your own GUI
 
@@ -139,23 +93,20 @@ Get the right binary for your machine from
 - **SCM User ID:** `<the User ID you got from servicedesk@csc.fi>`
 - **Password:** `<the password you got from servicedesk@csc.fi>`
 
-The download starts without entering a user ID and the password for users of
-Safari on Mac.
-
 #### 3. Install
 
-*a. Windows:* run the exe with Administrator privileges, accepting all defaults.
-*b. Mac:* open the dmg and drag the AMS2026.xxx item to the Applications directory.
-*c. Linux:* untar the tgz and source the `amsbashrc.sh` in the AMS installation directory.
+- **Windows:** run the exe with Administrator privileges, accepting all defaults.
+- **Mac:** open the dmg and drag the AMS2026.xxx item to the Applications directory.
+- **Linux:** untar the tgz and source the `amsbashrc.sh` in the AMS installation directory.
 
 For more detailed information, see the
 [AMS installation manual](https://www.scm.com/doc/Installation/index.html).
 
 #### 4. Run
 
-*a. Windows:* double-click the **AMSjobs** shortcut
-*b. Mac:* run the **AMS2026.xxx** application
-*c. Linux:* set up your environment (`source $HOME/ams2026.xxx/amsbashrc.sh`), run `amsjobs`
+- **Windows:** double-click the **AMSjobs** shortcut
+- **Mac:** run the **AMS2026.xxx** application
+- **Linux:** set up your environment (`source $HOME/ams2026.xxx/amsbashrc.sh`), run `amsjobs`
 
 When you start AMS for the first time you will be prompted for your username,
 password, and email address. The license should be automatically fetched from
@@ -179,31 +130,16 @@ All saved jobs, both calculated and uncalculated, can be found in the GUI
 under `SCM-> Jobs`. Before you submit a job to the batch queue you have to
 define what resources it needs (time, memory, number of cores etc.)
 
-=== "Roihu-CPU"
+1. Select `Queue -> New -> SLURM`
+2. `Queue Name: My_testqueue`. You can save queues with different names
+   corresponding to different resource requests
+3. `Remote host: roihu-cpu.csc.fi`.
+4. `Remote user: <your CSC username>`
+5. `Remote job directory: /scratch/<yourproject>`
+6. `Run command: sbatch --partition=test --ntasks=8 --mem-per-cpu=1500M --account=<yourproject> --time=00:15:00 "$job"`
+   Please replace `<yourproject>` with a proper project name. You can use
+   the same command line options as in the
+   [AMS batch script examples](ams.md#example-batch-scripts).
+7. `Use Local Batch: no`
+8. `Prolog command: export SCM_TMPDIR=/scratch/<yourproject>; source /appl/soft/manual/chem/x86_64/AMS/ams2026.105/ams_csc.bash`
 
-    1. Select `Queue -> New -> SLURM`
-    2. `Queue Name: My_testqueue`. You can save queues with different names
-       corresponding to different resource requests
-    3. `Remote host: roihu-cpu.csc.fi`.
-    4. `Remote user: <your CSC username>`
-    5. `Remote job directory: /scratch/<yourproject>`
-    6. `Run command: sbatch --partition=test --ntasks=8 --mem-per-cpu=1500M --account=<yourproject> --time=00:15:00 "$job"`
-       Please replace `<yourproject>` with a proper project name. You can use
-       the same command line options as in the
-       [AMS batch script examples](ams.md#example-batch-scripts).
-    7. `Use Local Batch: no`
-    8. `Prolog command: export SCM_TMPDIR=/scratch/<yourproject>; source /appl/soft/manual/chem/x86_64/AMS/ams2026.104/ams_csc.bash`
-
-=== "Puhti"
-
-    1. Select `Queue -> New -> SLURM`
-    2. `Queue Name: My_testqueue`. You can save queues with different names
-       corresponding to different resource requests
-    3. `Remote host: puhti.csc.fi`.
-    4. `Remote user: <your CSC username>`
-    5. `Remote job directory: /scratch/<yourproject>`
-    6. `Run command: sbatch --partition=test --nodes=1 --ntasks-per-node=40 --account=<yourproject> --time=00:10:00 "$job"`
-       Please replace `<yourproject>` with a proper project name. You can use
-       the same command line options as in a normal batch job script.
-    7. `Use Local Batch: no`
-    8. `Prolog command: source /appl/profile/zz-csc-env.sh;source /appl/soft/chem/AMS/ams2025.105/ams_csc.bash;export SCM_TMPDIR=/scratch/<yourproject>; export FORT_TMPDIR=$SCM_TMPDIR`


### PR DESCRIPTION
## Proposed changes
Update the AMS-GUI page for Roihu (2026.105) and remove decommissioned Puhti/Mahti.

- Module and prolog paths → `ams/2026.105` (already the default on Roihu).
- Launch the web-Desktop GUI with `ams_ood` instead of `amsinput` (fixes the pre-optimizer / short `File-> Run` stall); replaces the old Slurm-message note.
- Step 5: `File-> Save` (was `File-> Run`).
- Remove Puhti/Mahti (decommissioned); minor rendering/cleanup fixes.

Preview: https://csc-guide-preview.2.rahtiapp.fi/origin/ams_gui_update/apps/ams-gui/

## Checklist before requesting a review

- [X] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [X] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [X] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
