### PR TITLE
WIP: Add example ssh config for automating certificate update

### DIFF
--- a/docs/computing/connecting/ssh-keys.md
+++ b/docs/computing/connecting/ssh-keys.md
@@ -220,6 +220,7 @@ following instructions illustrate only basic usage.
             - The signed certificate is saved as
               `<key>-cert.pub` (e.g., `~/.ssh/id_ed25519-cert.pub`).
         6. You now have everything ready to **[connect to Roihu following these instructions](ssh-unix.md#basic-usage)**.
+        7. (Optional) You can further automate the use of the tool by [integrating it to the ssh config](ssh-unix.md#configuring-ssh-client).
 
     === "Windows"
 

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -280,6 +280,7 @@ fi
 ```
 
 Note that the following needs to be edited in this script for it to work:
+
 - Path to the `csc_cert.py` python script
 - CSC username and path to the public key
 - Command to launch the terminal. The `gnome-terminal` command here works with GNOME desktop environment

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -231,3 +231,55 @@ or:
 ```bash
 ssh roihu-gpu
 ```
+
+### Automating certificate update
+
+The ssh config can be further extended to run
+the [CSC certificate helper tool](ssh-keys.md#option-2-certificate-helper-tool)
+automatically when the certificate has expired.
+
+This can be achieved by extending the ssh config
+with the following `Match` pattern:
+
+```bash
+Host roihu*
+    User <csc-username>
+    IdentityFile <path-to-private-key>
+    CertificateFile <path-to-certificate>  # Required for Roihu only
+
+Host roihu-cpu
+    HostName roihu-cpu.csc.f1
+
+Host roihu-gpu
+    HostName roihu-gpu.csc.fi
+
+Match originalhost roihu* exec ~/bin/csc-cert
+```
+
+This config means that the script `~/bin/csc-cert` is executed
+every time when `ssh roihu-cpu` or `ssh roihu-gpu` is done.
+
+Below is an example script `~/bin/csc-cert` that
+first checks if the certificate is still valid, and if not,
+then opens a new terminal window to run the certificate
+helper tool to create a new certificate.
+Store this script as `~/bin/csc-cert` and make executable (`chmod a+x ~/bin/csc-cert`):
+
+```bash
+#!/bin/bash
+
+set -eu
+
+cert_helper="python3 $HOME/certificate-helper-tool/csc_cert.py -u <csc-username> <path-to-public-key>"
+
+# Check status
+if ! $cert_helper -S 2>&1 | grep -q valid; then
+    # Certificate not valid; request a new one
+    gnome-terminal --wait -- bash -c "$cert_helper"
+fi
+```
+
+Note that the following needs to be edited in this script for it to work:
+- Path to the `csc_cert.py` python script
+- CSC username and path to the public key
+- Command to launch the terminal. The `gnome-terminal` command here works with GNOME desktop environment

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -212,6 +212,7 @@ Host roihu*
     User <csc-username>
     IdentityFile <path-to-private-key>
     CertificateFile <path-to-certificate>  # Required for Roihu only
+    IdentitiesOnly yes
 
 Host roihu-cpu
     HostName roihu-cpu.csc.f1
@@ -246,6 +247,7 @@ Host roihu*
     User <csc-username>
     IdentityFile <path-to-private-key>
     CertificateFile <path-to-certificate>  # Required for Roihu only
+    IdentitiesOnly yes
 
 Host roihu-cpu
     HostName roihu-cpu.csc.f1

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -255,38 +255,11 @@ Host roihu-cpu
 Host roihu-gpu
     HostName roihu-gpu.csc.fi
 
-Match originalhost roihu* exec "~/bin/csc-cert %r <path-to-public-key>"
+Match originalhost roihu* exec "python3 <path-to-certificate-helper-tool>/csc_cert.py -s -a none -u %r <path-to-public-key>"
 ```
 
-This config means that the script `~/bin/csc-cert` is executed
-every time when `ssh roihu-cpu` or `ssh roihu-gpu` is done.
+This config means that the certificate tool is executed
+every time when `ssh roihu-cpu` or `ssh roihu-gpu` is done, and
+the tool requests certificate renewal only when the current certificate has expired.
 
-Below is an example script `~/bin/csc-cert` that
-first checks if the certificate is still valid, and if not,
-then opens a new terminal window to run the certificate
-helper tool to create a new certificate.
-Store this script as `~/bin/csc-cert` and make executable (`chmod a+x ~/bin/csc-cert`):
-
-```bash
-#!/bin/bash
-
-set -eu
-
-if [ $# -lt 2 ]; then
-    echo "Usage: $0 <username> <path-to-public-key>" >&2
-    exit 1
-fi
-
-cert_helper="python3 $HOME/certificate-helper-tool/csc_cert.py -u \"$1\" \"$2\""
-
-# Check status
-if ! $cert_helper -S 2>&1 | grep -q valid; then
-    # Certificate not valid; request a new one
-    gnome-terminal --wait -- bash -c "$cert_helper"
-fi
-```
-
-Note that the following needs to be edited in this script for it to work:
-
-- Path to the `csc_cert.py` python script
-- Command to launch the terminal. The `gnome-terminal` command here works with GNOME desktop environment
+Note that the agent handling is disabled (`-a none`), assuming that the agent already has the keys.

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -85,22 +85,8 @@ these files. Use option `-i` as follows:
 ssh <username>@<host>.csc.fi -i <path-to-private-key> -i <path-to-certificate>
 ```
 
-Alternatively, you may specify the key location in the `~/.ssh/config` file:
-
-```bash
-Host <host>
-  HostName <host>.csc.fi
-  User <csc-username>
-  IdentityFile <path-to-private-key>
-  CertificateFile <path-to-certificate>
-```
-
-The `~/.ssh/config` file above would allow you to log in to `<host>` simply
-using:
-
-```bash
-ssh <host>
-```
+Alternatively, you may specify the key location in the SSH configuration file
+as described in the section on [configuring SSH client](#configuring-ssh-client).
 
 ## Graphical connection
 

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -255,7 +255,7 @@ Host roihu-cpu
 Host roihu-gpu
     HostName roihu-gpu.csc.fi
 
-Match originalhost roihu* exec ~/bin/csc-cert
+Match originalhost roihu* exec "~/bin/csc-cert %r <path-to-public-key>"
 ```
 
 This config means that the script `~/bin/csc-cert` is executed
@@ -272,7 +272,12 @@ Store this script as `~/bin/csc-cert` and make executable (`chmod a+x ~/bin/csc-
 
 set -eu
 
-cert_helper="python3 $HOME/certificate-helper-tool/csc_cert.py -u <csc-username> <path-to-public-key>"
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <username> <path-to-public-key>" >&2
+    exit 1
+fi
+
+cert_helper="python3 $HOME/certificate-helper-tool/csc_cert.py -u \"$1\" \"$2\""
 
 # Check status
 if ! $cert_helper -S 2>&1 | grep -q valid; then
@@ -284,5 +289,4 @@ fi
 Note that the following needs to be edited in this script for it to work:
 
 - Path to the `csc_cert.py` python script
-- CSC username and path to the public key
 - Command to launch the terminal. The `gnome-terminal` command here works with GNOME desktop environment

--- a/docs/computing/connecting/ssh-unix.md
+++ b/docs/computing/connecting/ssh-unix.md
@@ -205,16 +205,29 @@ You can save yourself some time by adding host-specific options for CSC
 supercomputers in an [SSH config file](https://www.ssh.com/academy/ssh/config)
 (e.g. `~/.ssh/config`).
 
+An example config for Roihu:
+
 ```bash
-Host <host>  # e.g. "roihu-cpu"
-    HostName <host>.csc.fi
+Host roihu*
     User <csc-username>
     IdentityFile <path-to-private-key>
     CertificateFile <path-to-certificate>  # Required for Roihu only
+
+Host roihu-cpu
+    HostName roihu-cpu.csc.f1
+
+Host roihu-gpu
+    HostName roihu-gpu.csc.fi
 ```
 
-Now you can connect to the host simply by running:
+Now you can connect to the Roihu by running:
 
 ```bash
-ssh <host>
+ssh roihu-cpu
+```
+
+or:
+
+```bash
+ssh roihu-gpu
 ```


### PR DESCRIPTION
## Proposed changes

This PR will add example ssh config for automating certificate update:
- https://csc-guide-preview.2.rahtiapp.fi/origin/cert-ssh-config/computing/connecting/ssh-unix/#configuring-ssh-client
- Link added to https://csc-guide-preview.2.rahtiapp.fi/origin/cert-ssh-config/computing/connecting/ssh-keys/#option-2-certificate-helper-tool

This PR should not be merged before https://github.com/CSCfi/certificate-helper-tool/pull/8 is merged to the certificate helper tool.

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
