### PR TITLE
Update docs after Mahti retirement (draft)

### DIFF
--- a/csc-overrides/assets/snippets/mahti-retirement-running-notice.md
+++ b/csc-overrides/assets/snippets/mahti-retirement-running-notice.md
@@ -1,0 +1,5 @@
+!!! warning "Mahti computing services have been retired"
+     Mahti computing services have been retired and no new jobs are accepted or executed
+     on its compute nodes. Any jobs sent through Slurm will be stuck in a pending state.
+
+     Mahti login nodes and storage services are planned to remain available until 15 October 2026.

--- a/docs/computing/compiling-mahti.md
+++ b/docs/computing/compiling-mahti.md
@@ -1,5 +1,7 @@
 # Compiling applications in Mahti
 
+--8<-- "mahti-retirement-running-notice.md"
+
 ## General instructions
 
 

--- a/docs/computing/index.md
+++ b/docs/computing/index.md
@@ -6,7 +6,7 @@
     capabilities.
 
     * Puhti computing services have been shut down since 31 July 2026.
-    * Mahti computing services will be shut down by 31 August 2026 at 12:00 EEST.
+    * Mahti computing services have been shut down since 31 August 2026.
     * Puhti and Mahti storage and login nodes are planned to remain accessible until 15 October 2026 at 12:00 EEST.
     * Users are strongly encouraged to move any required data from these systems by the end of August 2026, as storage access cannot be fully guaranteed after that.
 
@@ -17,6 +17,8 @@ since 2 September 2019 and Mahti has been available since 26 August 2020. LUMI i
 one of the pan-European pre-exascale supercomputers, located in CSC's data
 center in Kajaani. The CPU partition of LUMI (LUMI-C) has been available since
 early 2022, and the full system with the large LUMI-G partition has been available since early 2023.
+
+Puhti and Mahti computing services have been shut down. Their login nodes and storage services are planned to remain accessible until 15 October 2026.
 
 Puhti contains CPU nodes with a range of memory sizes as well as a large GPU
 partition (Puhti AI), while Mahti contains homogeneous CPU nodes and is meant
@@ -172,8 +174,6 @@ csc-workspaces
   supercomputers
 * Installing and compiling your applications:
     * [Installing software](installing.md)
-    * [Compiling on Puhti](compiling-puhti.md)
-    * [Compiling on Mahti](compiling-mahti.md)
     * [Compiling on Roihu](compiling-roihu.md)
 * [Debugging applications](debugging.md): How to debug your applications
 * [Performance analysis](performance.md): How to understand the performance of

--- a/docs/computing/running/batch-job-partitions.md
+++ b/docs/computing/running/batch-job-partitions.md
@@ -174,6 +174,11 @@ Read more about: [Local storage on Roihu nodes](../roihu-disk.md#temporary-local
 
 ## Mahti partitions
 
+!!! note
+    This section is deprecated
+
+--8<-- "mahti-retirement-running-notice.md"
+
 ### Mahti CPU partitions with node-based allocation
 
 Mahti features the following partitions for submitting jobs to CPU nodes. Jobs

--- a/docs/computing/running/creating-job-scripts-mahti.md
+++ b/docs/computing/running/creating-job-scripts-mahti.md
@@ -6,14 +6,6 @@ Please have a look at the [Puhti documentation](creating-job-scripts-puhti.md)
 for the general introduction to batch scripts in the CSC supercomputing
 environment. On this page we focus on Mahti-specific topics.
 
-!!! Note
-    Full nodes are allocated for jobs, with the exception of jobs in `small`,
-    [`interactive`](interactive-usage.md#sinteractive-on-mahti) and GPU partitions,
-    [see also below](#using-interactive-partition-for-non-parallel-pre-or-post-processing).
-    Many options also work differently on Mahti compared to Puhti, so it is not
-    advisable to copy scripts from Puhti to Mahti without appropriate
-    modifications.
-
 [TOC]
 
 ## Basic MPI batch jobs

--- a/docs/computing/running/creating-job-scripts-mahti.md
+++ b/docs/computing/running/creating-job-scripts-mahti.md
@@ -1,5 +1,7 @@
 # Creating a batch job script for Mahti
 
+--8<-- "mahti-retirement-running-notice.md"
+
 Please have a look at the [Puhti documentation](creating-job-scripts-puhti.md)
 for the general introduction to batch scripts in the CSC supercomputing
 environment. On this page we focus on Mahti-specific topics.

--- a/docs/computing/running/example-job-scripts-mahti.md
+++ b/docs/computing/running/example-job-scripts-mahti.md
@@ -1,5 +1,7 @@
 # Example batch job scripts for Mahti
 
+--8<-- "mahti-retirement-running-notice.md"
+
 Example job scripts for running different types of programs:
 
 [TOC]

--- a/docs/computing/running/interactive-usage.md
+++ b/docs/computing/running/interactive-usage.md
@@ -82,24 +82,6 @@ logged into the system:
 sinteractive --help
 ```
 
-### `sinteractive` on Mahti
-
-On Mahti, each user can have up to 8 active sessions on the `interactive`
-partition. See the
-[Mahti `interactive` partition details](batch-job-partitions.md#mahti-cpu-partitions-with-core-based-allocation)
-for information on the available resources. It is also possible to request a
-a [GPU slice](./batch-job-partitions.md#mahti-gpu-slices) for interactive work by
-using the `-g` flag, which submits the job to the `gpusmall` partition. Note
-that using a GPU slice restricts the amount of CPU cores and memory that is
-available for your job.
-
-As with Roihu, you can see the Mahti-specific command options by running the
-following while logged into the system:
-
-```bash
-sinteractive --help
-```
-
 ### Example: Running a Jupyter notebook or RStudio server via `sinteractive`
 
 See the tutorial on

--- a/docs/computing/systems-mahti.md
+++ b/docs/computing/systems-mahti.md
@@ -10,47 +10,42 @@ search:
     next-generation supercomputer offering enhanced performance and
     capabilities.
 
-    Mahti computing services will be shut down on 31 August 2026 at 12:00 EEST. Storage and
+    Mahti computing services have been shut down on 31 August 2026. Storage and
     login nodes are planned to remain accessible until midday 15 October 2026, but
-    users are strongly encouraged to move any required data from the system by
-    the end of August 2026.
+    users are strongly encouraged to move any required data from the system without delay.
 
     [Learn more about Roihu :material-arrow-right:](systems-roihu.md)
 
 ## Compute nodes
 
-**Mahti** has a total of **1404** CPU nodes and **24** GPU nodes. The
+**Mahti** had a total of **1404** CPU nodes and **24** GPU nodes. The
 theoretical peak performance is 7.5 petaflops for the CPU nodes and 2.0
 petaflops for the GPU nodes, in total 9.5 petaflops.
 
-Both CPU and GPU nodes have two AMD Rome 7H12 CPUs with 64 cores each,
-making the total core count about 180 000. The CPUs are based on AMD Zen 2
+Both CPU and GPU nodes had two AMD Rome 7H12 CPUs with 64 cores each,
+making the total core count about 180 000. The CPUs were based on AMD Zen 2
 architecture, supporting the AVX2 vector instruction set, and run at 2.6 GHz
 base frequency (max boost up to 3.3 GHz). The CPUs support simultaneous
 multithreading (SMT) where each core can run two hardware threads. When SMT is
 enabled, the total thread count per node is 256 threads.
 
-The CPU nodes are equipped with 256 GB of memory and the vast majority
-have no local disks. There are in total 60 nodes that are equipped
-with a local 3.8 TB NVMe drive. These are available in the `small` and
-`interactive` partitions.
+The CPU nodes were equipped with 256 GB of memory and the vast majority
+had no local disks. There were in total 60 nodes that were equipped
+with a local 3.8 TB NVMe drive.
 
-The GPU nodes are equipped with 512 GB of memory and a local 3.8 TB NVMe drive.
-They also have four Nvidia Ampere A100 GPUs. In a subset of the nodes the A100
-GPUs have been split into multiple smaller GPUs with a fraction of the compute
-and memory capacity of the A100 GPUs. These are useful for interactive work,
-courses and for code development.
+The GPU nodes were equipped with 512 GB of memory and a local 3.8 TB NVMe drive.
+They also had four Nvidia Ampere A100 GPUs.
 
 ### NUMA configuration
 
-Mahti node has a highly hierarchical structure. There are two sockets in the
+Mahti node had a highly hierarchical structure. There were two sockets in the
 node, each containing a single CPU and memory DIMMs. All the memory within the
-node is shared, but memory performance depends on the distance of the core to
-the memory. In order to provide slightly increased memory performance we run
-each CPU in NPS4 (NUMA per socket 4) mode that further splits each CPU into 4
-NUMA domains. Each NUMA domain has 16 cores, and two memory controllers with 32
-GiB of memory in total. Core 0 runs threads 0 and 128, core 1 threads 1 and 129
-and so on. The figure below shows how the threads are distributed over each of
+node was shared, but memory performance depended on the distance of the core to
+the memory. In order to provide slightly increased memory performance we ran
+each CPU in NPS4 (NUMA per socket 4) mode that further split each CPU into 4
+NUMA domains. Each NUMA domain had 16 cores, and two memory controllers with 32
+GiB of memory in total. Core 0 ran threads 0 and 128, core 1 threads 1 and 129
+and so on. The figure below shows how the threads were distributed over each of
 the cores and NUMA nodes.
 
 !["NUMA configuration"](../img/mahti_numa.png)
@@ -93,11 +88,11 @@ then connected to each other using all to all links.
 
 !["Simplified dragonfly+ topology"](../img/mahti_df_ex.png)
 
-In Mahti there are 234 nodes in each dragonfly group and the internal fat tree
-has a blocking factor of 1.7:1, with 20 or 18 nodes connected per leaf switch
-and each leaf switch has 12 links going to the spine switch in the group, all
-links are 200 Gbps links. There are in total 6 groups, and between the groups
-there is fully non-blocking all-to-all connectivity, with 5 200 Gbps links
+In Mahti there were 234 nodes in each dragonfly group and the internal fat tree
+had a blocking factor of 1.7:1, with 20 or 18 nodes connected per leaf switch
+and each leaf switch had 12 links going to the spine switch in the group, all
+links were 200 Gbps links. There were in total 6 groups, and between the groups
+there was fully non-blocking all-to-all connectivity, with 5 200 Gbps links
 going from each spine switch to one spine switch in every other group.
 
 !["Mahti dragonfly+ topology"](../img/mahti_df.png)

--- a/docs/computing/systems-puhti.md
+++ b/docs/computing/systems-puhti.md
@@ -15,30 +15,29 @@ search:
 
     Storage and
     login nodes are planned to remain accessible until midday 15 October 2026, but
-    users are strongly encouraged to move any required data from the system
-    by the end of August 2026.
+    users are strongly encouraged to move any required data from the system without delay.
 
     [Learn more about Roihu :material-arrow-right:](systems-roihu.md)
 
 ## Compute
 
-**Puhti** has a total of **682 CPU nodes**, with a theoretical peak
+**Puhti** had a total of **682 CPU nodes**, with a theoretical peak
 performance of 1,8 petaflops. Each node is equipped with two Intel
 Xeon processors, code name _Cascade Lake_, with 20 cores each running
-at 2,1 GHz. The cores support AVX-512 vector instructions and VNNI
-instructions for AI _inference_ workloads. The interconnect is based
+at 2,1 GHz. The cores supported AVX-512 vector instructions and VNNI
+instructions for AI _inference_ workloads. The interconnect was based
 on Mellanox HDR InfiniBand. The
-nodes are connected with a 100 Gbps HDR100 link, and the topology is a
+nodes were connected with a 100 Gbps HDR100 link, and the topology was a
 fat tree with a blocking factor of approximately 2:1.
 
-The **Puhti AI** artificial intelligence partition has a total of **80 GPU
-nodes** with a total peak performance of 2,7 petaflops. Each node has
+The **Puhti AI** artificial intelligence partition had a total of **80 GPU
+nodes** with a total peak performance of 2,7 petaflops. Each node had
 two Intel Xeon processors, code name _Cascade Lake_,
-with 20 cores each running at 2,1 GHz. They also have four Nvidia
-Volta V100 GPUs with 32 GB of memory each. The nodes are equipped with
+with 20 cores each running at 2,1 GHz. They also had four Nvidia
+Volta V100 GPUs with 32 GB of memory each. The nodes were equipped with
 384 GB of main memory and 3,6 TB of fast local storage. This partition
-is engineered to allow GPU-intensive workloads to scale well across
-multiple nodes. The interconnect is based on a dual-rail HDR100
+was engineered to allow GPU-intensive workloads to scale well across
+multiple nodes. The interconnect was based on a dual-rail HDR100
 interconnect network connectivity providing 200 Gbps of aggregate
 bandwidth in a non-blocking fat-tree topology.
 

--- a/docs/computing/systems-roihu.md
+++ b/docs/computing/systems-roihu.md
@@ -37,6 +37,7 @@ graph LR;
     style B fill:#dceeceff;
     style C fill:#dceeceff;
     style D fill:#dceeceff;
+    style E fill:#dceeceff;
 ```
 
 **Roihu** is installed in the same datacenter as LUMI, meaning that the
@@ -51,12 +52,12 @@ means that jobs will not run on Puhti's compute nodes anymore. Puhti's storage a
 however, remain accessible until midday October 15th 2026, after which Puhti will be retired
 completely.
 
-Mahti will be closed in a similar two-stage process. Mahti’s computing services will be shut down on 31 August 2026 at 12:00 EEST, and jobs will not run on Mahti after this date.
+Mahti will be closed in a similar two-stage process. Mahti’s computing services have been shut down on 31 August 2026 at 12:00 EEST, and jobs will not run on Mahti anymore.
 Its storage and login nodes will remain accessible until midday 15 October 2026, after which Mahti will be retired completely.
 
 Between September and October 2026, the storage services will not be covered by service contracts.
 As a result, we cannot guarantee that they will remain accessible throughout this period.
-We strongly encourage all users to prioritize moving their data by the end of August 2026.
+We strongly encourage all users to prioritize moving their data without delay.
 
 ### Prepare for data migration from Mahti and Puhti to Roihu
 

--- a/docs/computing/webinterface/desktop.md
+++ b/docs/computing/webinterface/desktop.md
@@ -1,5 +1,5 @@
 # Desktop
-The desktop enables using graphical applications on a Roihu or Mahti compute node.
+The desktop enables using graphical applications on a Roihu compute node.
 
 ## Available applications
 
@@ -16,16 +16,6 @@ applications:
 * [QGIS](../../apps/qgis.md)
 * [SAGA GIS](../../apps/saga-gis.md)
 * [SNAP](../../apps/snap.md)
-
-
-### Mahti
-
-* [Maestro](../../apps/maestro.md)
-* [VMD](../../apps/vmd.md)
-
-Only CPU rendering is supported in the graphical applications launched from the desktop.
-See [here how to enable GPU-accelerated visualization](accelerated-visualization.md)
-for selected applications on Roihu.
 
 
 ## Launching

--- a/docs/computing/webinterface/index.md
+++ b/docs/computing/webinterface/index.md
@@ -34,7 +34,7 @@ Please note that logging in to Roihu, Puhti, and Mahti web interfaces requires
 
 ## Available features
 
-- **Features available in the Roihu and Mahti web interfaces:**
+- **Features available in the Roihu web interface:**
     - View, download, upload and move files between Allas, the supercomputer
       and your local computer
     - Open a shell on the login node
@@ -42,21 +42,21 @@ Please note that logging in to Roihu, Puhti, and Mahti web interfaces requires
     - View running batch jobs
     - View disk quotas and project status
     - Launch interactive apps and connect to them directly from the browser:
-        - Accelerated Visualization with applications such as Blender and ParaView (Roihu only)
+        - Accelerated Visualization with applications such as Blender and ParaView
         - Desktop with applications such as Maestro and VMD
         - Julia-Jupyter
         - Jupyter
         - Jupyter for courses: An interactive Jupyter session specifically for
           courses
-        - marimo (Roihu only)
+        - marimo
         - MATLAB
         - MLflow
-        - R-Jupyter (Roihu and Mahti only)
+        - R-Jupyter
         - RStudio
         - TensorBoard
         - Visual Studio Code
-- **Features available in the Puhti web interface:**
-    - Puhti compute services have been decommissioned. Use the Puhti web interface only for login node
+- **Features available in the Puhti and Mahti web interfaces:**
+    - Puhti and Mahti compute services have been decommissioned. Use the web interfaces only for login node
       connections, or for inspecting or moving data from the file system.
 
 ### Shell
@@ -126,12 +126,6 @@ partitions are available. In the [Accelerated Visualization app](accelerated-vis
 page](../running/batch-job-partitions.md#roihu-partitions) for general information about queues on
 Roihu.
 
-In the **Mahti web interface**, the `interactive`, `small` and `gpusmall`
-partitions are available. Selecting the `gpusmall` partition will allocate a
-split Nvidia A100 GPU (a100_1g.5g) with 1/7th of the compute capacity of a full
-A100. For more details about the split GPUs on Mahti, see the
-[Mahti partitions page](../running/batch-job-partitions.md#mahti-partitions).
-
-Puhti computing services have been retired as of 31 July 2026, so in the
-**Puhti web interface**, you can only access login node resources and inspect the
+Puhti and Mahti computing services have been retired, so in the
+**Puhti and Mahti web interfaces**, you can only access login node resources and inspect the
 storage in the system, until full retirement on 15 October 2026.

--- a/docs/support/faq/roihu.md
+++ b/docs/support/faq/roihu.md
@@ -9,16 +9,16 @@ and [more information on Roihu](../../computing/systems-roihu.md).
 
 ### 1. When will Puhti/Mahti be shut down?
 
-Puhti compute resources will be shut down one month after Roihu general
-availability, by 31 July 2026. After this, jobs can no longer be submitted on
+Puhti compute resources were shut down one month after Roihu general
+availability, on 31 July 2026. Jobs can no longer be submitted on
 Puhti. Puhti storage and login nodes are planned to remain accessible until
 15 October 2026.
 
-Mahti compute resources will be shut down on 31 August 2026. Mahti storage and
+Mahti compute resources were shut down on 31 August 2026. Mahti storage and
 login nodes are planned to remain accessible until 15 October 2026.
 
-We strongly encourage users to move any required data by the end of August
-2026, as Mahti and Puhti storage services will not be covered by service contracts between
+We strongly encourage users to move any required data without delay,
+as Mahti and Puhti storage services will not be covered by service contracts between
 September and October, and availability cannot be fully guaranteed.
 
 [Read more about the shutdown schedule here](../../computing/systems-roihu.md#schedule).

--- a/docs/support/tutorials/roihu-data.md
+++ b/docs/support/tutorials/roihu-data.md
@@ -19,9 +19,7 @@
 !!! warning "Mahti and Puhti shutdown in Fall 2026"
      Mahti and Puhti are being decommissioned by October 2026.
 
-     * Puhti computing services will be shut down 31 July 2026 at 12:00 EEST.
-     * Mahti computing services will be shut down 31 August 2026 at 12:00 EEST.
-     * Puhti and Mahti storage and login nodes are planned to remain accessible until 15 October 2026 at 12:00 EEST.
+     * Puhti and Mahti computing services have been shut down.
 
      Puhti and Mahti storage services will be decommissioned 15 October 2026 at 12:00 EEST, but
      are not covered by service contracts after end of August.

--- a/docs/support/wn/comp-new.md
+++ b/docs/support/wn/comp-new.md
@@ -1,5 +1,12 @@
 # Computing environment
 
+## Mahti compute services decommissioned, 31.8.2026
+
+Compute services in Mahti have been decommissioned as of 31 August 2026 at 12:00 EEST.
+No new jobs will be accepted or executed on its compute nodes.
+
+Puhti and Mahti login nodes and storage services are planned to remain available until 15 October 2026.
+
 ## Roihu web interface updated to release 2, 18.8.2026
 
 * The gpuinteractive partition is now available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,10 +16,7 @@ extra:
     content: |-
       <p>Warning!</p>
       <div>
-        <p>Puhti and Mahti are being decommissioned in stages, and their storage areas will become fully unavailable from <strong>15 October 2026</strong>. Clean up unnecessary files and move any data you need to keep by <strong>31 August 2026</strong>. See the <a href="{{ base_url }}/support/tutorials/roihu-data/">Roihu data migration guide</a> for instructions on transferring your data to Roihu.</p>
-      </div>
-      <div>
-        <p><strong>Puhti computing services have been decommissioned</strong> and no new jobs are accepted or executed on its compute nodes. Puhti login nodes and storage services are planned to remain available until 15 October 2026.</p>
+        <p><strong>Puhti and Mahti computing services have been decommissioned</strong> and no new jobs are accepted or executed on its compute nodes. Puhti and Mahti login nodes and storage services are planned to remain available until 15 October 2026. Clean up unnecessary files and move any data you need to keep by <strong>31 August 2026</strong>. See the <a href="{{ base_url }}/support/tutorials/roihu-data/">Roihu data migration guide</a> for instructions on transferring your data to Roihu.</p></p>
       </div>
   landing_banner:
     path: https://a3s.fi/docs-files/banners/ # Put the image file in this bucket; Don't touch this value.


### PR DESCRIPTION
## Proposed changes

Update the docs after Mahti compute retirement end of August.

Update top warning box in docs:
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/

Add a computing news section about Mahti retirement:
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/support/wn/comp-new/

Remove Mahti web interface computing sections:
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/webinterface/
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/webinterface/desktop/

Update computing sections (Mahti will be shut down -> Mahti has been shut down):
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/systems-roihu/
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/systems-puhti/

Add a warning label to mahti compilation and running instructions:
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/compiling-mahti/
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/running/batch-job-partitions/
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/running/creating-job-scripts-mahti/
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/running/example-job-scripts-mahti/

Change from present to past tense in Mahti system information:
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/systems-mahti/

Remove Mahti sinteractive use information:
https://csc-guide-preview.2.rahtiapp.fi/origin/mahti-post-shutdown/computing/running/interactive-usage

_Note that you may create a Draft Pull Request if your proposed changes are not ready to be merged yet._

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [ ] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
