### PR TITLE
Tensorflow CPU version + news item

### DIFF
--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -9,8 +9,6 @@ catalog:
     - Data Analytics and Machine Learning
   available_on:
     - LUMI
-    - Puhti
-    - Mahti
     - Roihu
 ---
 
@@ -20,45 +18,32 @@ Deep learning framework for Python.
 
 !!! info "News"
 
+    **3.9.2026** TensorFlow version 2.21 is now available on Roihu-CPU. Naturally 
+    this version does not support GPU acceleration. 
+
     **16.6.2026** TensorFlow is now available on Roihu-GPU, the module has been 
     renamed `python-tensorflow`.
     
-    **5.10.2022** Due to Puhti's update to Red Hat Enterprise Linux 8
-    (RHEL8), **the number of fully supported TensorFlow versions has been
-    reduced. Previously deprecated conda-based versions have been
-    removed.** Please [contact our servicedesk](../support/contact.md) if
-    you really need access to older versions.
-
-    **5.5.2022** Due to Mahti's update to Red Hat Enterprise Linux 8 (RHEL8),
-    the number of fully supported TensorFlow versions has been reduced. Please [contact our
-    servicedesk](../support/contact.md) if you really need access to other versions.
-
-    **4.2.2022** All old TensorFlow versions which were based on direct Conda
-    installations have been deprecated, and we encourage users to move to newer
-    versions. Read more on our separate [Conda deprecation page](../support/tutorials/conda.md).
-
 
 ## Available
 
 Currently supported TensorFlow versions:
 
-| Version | Module                   | Roihu-GPU | Puhti | Mahti | LUMI | Notes                   |
-|:--------|:-------------------------|-----------|:-----:|:-----:|:----:|-------------------------|
-| 2.21.0  | `python-tensorflow/2.21` | X         | -     | -     | -    | Default on Roihu-GPU    |
-| 2.18.0  | `tensorflow/2.18`        |           | X     | X     | -    | Default on Puhti, Mahti |
-| 2.17.0  | `tensorflow/2.17`        |           | X     | X     | -    |                         |
-| 2.16.1  | `tensorflow/2.16`        |           | -     | -     | X    | Default on LUMI         |
-| 2.15.0  | `tensorflow/2.15`        |           | X     | X     | -    |                         |
-| 2.14.0  | `tensorflow/2.14`        |           | X     | X     | -    |                         |
-| 2.13.0  | `tensorflow/2.13`        |           | X     | X     | -    |                         |
-| 2.12.0  | `tensorflow/2.12`        |           | X     | X     | X    |                         |
-| 2.11.0  | `tensorflow/2.11`        |           | X     | X     | X    |                         |
-| 2.10.0  | `tensorflow/2.10`        |           | X     | X     | X    |                         |
-| 2.9.0   | `tensorflow/2.9`         |           | X     | X     | X    |                         |
-| 2.8.0   | `tensorflow/2.8`         |           | X     | X     | X    |                         |
+| Version | Module                   | Roihu-GPU | Roihu-CPU | LUMI | Notes                |
+|:--------|:-------------------------|-----------|-----------|:----:|----------------------|
+| 2.21.0  | `python-tensorflow/2.21` | X         | X         |  -   | Default on Roihu-GPU |
+| 2.16.1  | `tensorflow/2.16`        |           |           |  X   | Default on LUMI      |
+| 2.12.0  | `tensorflow/2.12`        |           |           |  X   |                      |
+| 2.11.0  | `tensorflow/2.11`        |           |           |  X   |                      |
+| 2.10.0  | `tensorflow/2.10`        |           |           |  X   |                      |
+| 2.9.0   | `tensorflow/2.9`         |           |           |  X   |                      |
+| 2.8.0   | `tensorflow/2.8`         |           |           |  X   |                      |
 
 Includes [TensorFlow](https://www.tensorflow.org/) and
-[Keras](https://keras.io/) with GPU support via CUDA/ROCm.
+[Keras](https://keras.io/) with GPU support via CUDA/ROCm. The version
+on Roihu-CPU naturally does not support GPUs, but has been made
+available for light workloads and workloads that need x86_64 CPU
+architecture.
 
 If you find that some package is missing, you can often install it
 yourself using `pip install`. It is recommended to use Python virtual
@@ -72,19 +57,7 @@ servicedesk](../support/contact.md).
 All modules are based on containers using Apptainer (previously known
 as Singularity). Wrapper scripts have been provided so that common
 commands such as `python`, `python3`, `pip` and `pip3` should work as
-normal. For other commands, you need to prefix them with
-`apptainer_wrapper exec`, for example `apptainer_wrapper exec
-huggingface-cli`. For more information, see [CSC's general
-instructions on how to run Apptainer
-containers](../computing/containers/overview.md#running-containers).
-
-Some modules support [Horovod](https://horovod.ai/), which is our
-recommended framework for multi-node jobs, i.e., jobs needing more
-than 4 GPUs on Puhti and Mahti. Horovod can also be used with
-single-node jobs for 2-4 GPUs. For more information, read the
-[Multi-GPU section in our machine learning
-guide](../support/tutorials/ml-multi.md).
-
+normal.
 
 ## License
 
@@ -99,12 +72,6 @@ To use the default version of TensorFlow on Roihu-GPU, initialize it with:
 module load python-tensorflow
 ```
 
-To access PyTorch on Puhti or Mahti:
-
-```text
-module load tensorflow
-```
-
 To access TensorFlow on LUMI:
 
 ```text
@@ -117,7 +84,7 @@ versions](#available)), use:
 
 ```text
 module load python-tensorflow/2.21  # on Roihu-GPU
-module load tensorflow/2.12         # on other systems
+module load tensorflow/2.12         # on LUMI
 ```
 
 Please note that the modules already include CUDA/ROCm libraries, so
@@ -127,7 +94,7 @@ This command will also show all available versions:
 
 ```text
 module avail python-tensorflow  # on Roihu-GPU
-module avail tensorflow         # on other systems
+module avail tensorflow         # on LUMI
 ```
 
 To check the exact packages and versions included in the loaded module you can
@@ -163,34 +130,17 @@ the available CPU cores in a single node:
     srun python3 myprog.py <options>
     ```
 
-=== "Puhti"
+=== "Roihu-CPU"
     ```bash
     #!/bin/bash
     #SBATCH --account=<project>
-    #SBATCH --partition=gpu
-    #SBATCH --nodes=1
+    #SBATCH --partition=small
     #SBATCH --ntasks=1
-    #SBATCH --cpus-per-task=10
-    #SBATCH --mem=64G
+    #SBATCH --cpus-per-task=7
+    #SBATCH --mem=15G
     #SBATCH --time=1:00:00
-    #SBATCH --gres=gpu:v100:1
     
-    module load tensorflow/2.14
-    srun python3 myprog.py <options>
-    ```
-    
-=== "Mahti"
-    ```bash
-    #!/bin/bash
-    #SBATCH --account=<project>
-    #SBATCH --partition=gpusmall
-    #SBATCH --nodes=1
-    #SBATCH --ntasks=1
-    #SBATCH --cpus-per-task=32
-    #SBATCH --time=1:00:00
-    #SBATCH --gres=gpu:a100:1
-    
-    module load tensorflow/2.14
+    module load python-tensorflow/2.21
     srun python3 myprog.py <options>
     ```
 

--- a/docs/apps/tensorflow.md
+++ b/docs/apps/tensorflow.md
@@ -29,15 +29,15 @@ Deep learning framework for Python.
 
 Currently supported TensorFlow versions:
 
-| Version | Module                   | Roihu-GPU | Roihu-CPU | LUMI | Notes                |
-|:--------|:-------------------------|-----------|-----------|:----:|----------------------|
-| 2.21.0  | `python-tensorflow/2.21` | X         | X         |  -   | Default on Roihu-GPU |
-| 2.16.1  | `tensorflow/2.16`        |           |           |  X   | Default on LUMI      |
-| 2.12.0  | `tensorflow/2.12`        |           |           |  X   |                      |
-| 2.11.0  | `tensorflow/2.11`        |           |           |  X   |                      |
-| 2.10.0  | `tensorflow/2.10`        |           |           |  X   |                      |
-| 2.9.0   | `tensorflow/2.9`         |           |           |  X   |                      |
-| 2.8.0   | `tensorflow/2.8`         |           |           |  X   |                      |
+| Version | Module                   | Roihu-GPU | Roihu-CPU | LUMI | Notes            |
+|:--------|:-------------------------|-----------|-----------|:----:|------------------|
+| 2.21.0  | `python-tensorflow/2.21` | X         | X         |  -   | Default on Roihu |
+| 2.16.1  | `tensorflow/2.16`        |           |           |  X   | Default on LUMI  |
+| 2.12.0  | `tensorflow/2.12`        |           |           |  X   |                  |
+| 2.11.0  | `tensorflow/2.11`        |           |           |  X   |                  |
+| 2.10.0  | `tensorflow/2.10`        |           |           |  X   |                  |
+| 2.9.0   | `tensorflow/2.9`         |           |           |  X   |                  |
+| 2.8.0   | `tensorflow/2.8`         |           |           |  X   |                  |
 
 Includes [TensorFlow](https://www.tensorflow.org/) and
 [Keras](https://keras.io/) with GPU support via CUDA/ROCm. The version
@@ -66,7 +66,8 @@ TensorFlow is licensed under [Apache License
 
 ## Usage
 
-To use the default version of TensorFlow on Roihu-GPU, initialize it with:
+To use the default version of TensorFlow on Roihu-GPU or Roihu-CPU,
+initialize it with:
 
 ```text
 module load python-tensorflow
@@ -83,7 +84,7 @@ If you wish to have a specific version ([see above for available
 versions](#available)), use:
 
 ```text
-module load python-tensorflow/2.21  # on Roihu-GPU
+module load python-tensorflow/2.21  # on Roihu
 module load tensorflow/2.12         # on LUMI
 ```
 
@@ -93,7 +94,7 @@ Please note that the modules already include CUDA/ROCm libraries, so
 This command will also show all available versions:
 
 ```text
-module avail python-tensorflow  # on Roihu-GPU
+module avail python-tensorflow  # on Roihu
 module avail tensorflow         # on LUMI
 ```
 

--- a/docs/support/wn/apps-new.md
+++ b/docs/support/wn/apps-new.md
@@ -1,5 +1,12 @@
 # Applications
 
+## CPU versions of PyTorch and TensorFlow available on Roihu, 3.9.2026
+
+CPU editions of all installed [PyTorch](../../apps/pytorch.md) and
+[TensorFlow](../../apps/tensorflow.md) versions have been made
+available on Roihu. This is to better support interactive usage and
+hybrid workflows.
+
 ## PyTorch 2.13.0 available on Roihu-GPU, 31.8.2026
 
 PyTorch 2.13.0 is now available on Roihu-GPU in the [python-pytorch


### PR DESCRIPTION
## Proposed changes

- Add CPU version of TensorFlow to Roihu
- News item about CPU versions for PyTorch and TensorFlow

Previews:
- [TensorFlow app](https://csc-guide-preview.2.rahtiapp.fi/origin/tensorflow-cpu/apps/tensorflow/)
- [News item](https://csc-guide-preview.2.rahtiapp.fi/origin/tensorflow-cpu/support/wn/apps-new/#cpu-versions-of-pytorch-and-tensorflow-available-on-roihu-392026)

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
