### PR TITLE
Remove outdated quantum metadata section

### DIFF
--- a/docs/computing/quantum-computing/first-quantum-job.md
+++ b/docs/computing/quantum-computing/first-quantum-job.md
@@ -288,16 +288,10 @@ The full python script can be found below.
     transpiled_circuit = transpile(circuit, backend_q20)
 
     job = backend.run(transpiled_circuit, shots=shots)
-    result = job.result()
+    
+    print("Job ID: ", job.job_id())
 
-    # You can retrieve the job at a later date with backend.retrieve_job(job_id)
-    # Uncomment the following lines to get more information about your submitted job
-    # print("Job ID: ", job.job_id())
-	# print(result.circuits)
-    # exp_result = result._get_experiment("circuit_name")
-    # print("Calibration Set ID: ", exp_result.calibration_set_id)
-    # print(result.parameters.qubit_mapping)
-    # print(result.parameters.shots)
+    result = job.result()
 
     counts = result.get_counts()
     print(counts)
@@ -336,17 +330,15 @@ The full python script can be found below.
     transpiled_circuit = transpile(circuit, backend_q50)
     
     job = backend_q50.run(transpiled_circuit, shots=shots)
+    
+    print("Job ID: ", job.job_id())
+    
     result = job.result()
-
-    # You can retrieve the job at a later date with backend.retrieve_job(job_id)
-    # Uncomment the following lines to get more information about your submitted job
-    # print("Job ID: ", job.job_id())
-	# print(result.circuits)
-    # exp_result = job.result()._get_experiment("circuit_name")
-    # print("Calibration Set ID: ", result.parameters.calibration_set_id)
-    # print(result.parameters.qubit_mapping)
-    # print(result.parameters.shots)
 
     counts = result.get_counts()
     print(counts)
     ```
+
+!!! info "Save your Job ID!"
+    Note that there is currently no method to list previous Job ID's therefore it is recommended to always print your Job ID after job submission and save it somewhere!
+    The same applies for the calibration set id.

--- a/docs/computing/quantum-computing/running-quantum-jobs.md
+++ b/docs/computing/quantum-computing/running-quantum-jobs.md
@@ -261,7 +261,7 @@ To load the Cirq module use `module load fiqci-vtt-cirq`.
 
 ## Additional examples
 
-An additionalexamples for e.g querying additional job metadata can be found [here](https://github.com/FiQCI/fiqci-examples).
+Additional examples for e.g. querying additional job metadata can be found from [here](https://github.com/FiQCI/fiqci-examples).
 
 
 ## Simulated test runs

--- a/docs/computing/quantum-computing/running-quantum-jobs.md
+++ b/docs/computing/quantum-computing/running-quantum-jobs.md
@@ -254,12 +254,14 @@ To load the Cirq module use `module load fiqci-vtt-cirq`.
     print(result.measurements['m'])
     ```
 
+!!! info "Save your Job ID!"
+    Note that there is currently no method to list previous Job ID's therefore it is recommended to always print your Job ID after job submission and save it somewhere!
+    The same applies for the calibration set id.
+
+
 ## Additional examples
 
-An additional [set of examples can be found here](https://github.com/FiQCI/fiqci-examples).
-The examples emphasize the difference between running on a simulator and a real physical quantum computer,
-and how to construct your circuits for optimum results on the quantum computers. The repository also contains some useful
-scripts for submitting jobs.
+An additionalexamples for e.g querying additional job metadata can be found [here](https://github.com/FiQCI/fiqci-examples).
 
 
 ## Simulated test runs
@@ -267,70 +269,6 @@ scripts for submitting jobs.
 As quantum resources can be scarce, it is recommended that you prepare the codes and algorithms you intend to run on the quantum computers in advance. To help with this process, [`qiskit-on-iqm` provides a fake noise model backend](https://docs.meetiqm.com/iqm-client/user_guide_qiskit.html#noisy-simulation-of-quantum-circuit-execution). You can run the fake noise model backend locally on your laptop for simulation and testing.
 
 A set of Qiskit and Cirq examples and scripts for guidance in using the quantum computers are also available. [You can find these here](https://github.com/FiQCI/fiqci-examples).
-
-## Job Metadata
-
-Additional metadata about your job can be queried directly with Qiskit. For example:
-
-=== "Q20
-
-    ```python
-
-    DEVICE_CORTEX_URL = os.getenv('Q20_CORTEX_URL')
-    provider = IQMProvider(DEVICE_CORTEX_URL, quantum_computer="radiance20")
-    backend = provider.get_backend()
-
-    #Retrieving backend information
-    print(f'Native operations: {backend.operation_names}')
-    print(f'Number of qubits: {backend.num_qubits}')
-    print(f'Coupling map: {backend.coupling_map}')
-
-    transpiled_circuit = transpile(circuit, backend)
-    job = backend.run(transpiled_circuit, shots=shots)
-    result = job.result()
-    exp_result = result._get_experiment(circuit)
-
-    print("Job ID: ", job.job_id())  # Retrieving the submitted job id
-    print(result.request.circuits)  # Retrieving the circuit request sent
-    print("Calibration Set ID: ", exp_result.calibration_set_id)  # Retrieving the current calibration set id.
-    print(result.request.qubit_mapping)  # Retrieving the qubit mapping
-    print(result.request.shots)  # Retrieving the number of requested shots.
-
-    #retrieve a job using the job_id from a previous session
-    #old_job = backend.retrieve_job(job_id)
-    ```
-
-=== "Q50"
-
-    ```python
-
-    DEVICE_CORTEX_URL = os.getenv('Q50_CORTEX_URL')
-    provider = IQMProvider(DEVICE_CORTEX_URL, quantum_computer="q50")
-    backend = provider.get_backend()
-
-    #Retrieving backend information
-    print(f'Native operations: {backend.operation_names}')
-    print(f'Number of qubits: {backend.num_qubits}')
-    print(f'Coupling map: {backend.coupling_map}')
-
-    transpiled_circuit = transpile(circuit, backend)
-    job = backend.run(transpiled_circuit, shots=shots)
-    result = job.result()
-    exp_result = result._get_experiment(circuit)
-
-    print("Job ID: ", job.job_id())  # Retrieving the submitted job id
-    print(result.request.circuits)  # Retrieving the circuit request sent
-    print("Calibration Set ID: ", exp_result.calibration_set_id)  # Retrieving the current calibration set id.
-    print(result.request.qubit_mapping)  # Retrieving the qubit mapping
-    print(result.request.shots)  # Retrieving the number of requested shots.
-
-    #retrieve a job using the job_id from a previous session
-    #old_job = backend.retrieve_job(job_id)
-    ```
-
-!!! info "Save your Job ID!"
-    Note that there is currently no method to list previous Job ID's therefore it is recommended to always print your Job ID after job submission and save it somewhere!
-    The same applies for the calibration set id.
 
 
 ## Calibration data


### PR DESCRIPTION
## Proposed changes

Remove outdated quantum job metadata fetching sections and point to upto date examples in https://github.com/FiQCI/fiqci-examples/ instead.

preview: https://csc-guide-preview.2.rahtiapp.fi/origin/remove-outdated-quantum-metadata-section/

## Checklist before requesting a review

- [x] I have followed the instructions in the [Contributing](https://github.com/CSCfi/csc-user-guide/blob/master/CONTRIBUTING.md) and [Styleguide](https://github.com/CSCfi/csc-user-guide/blob/master/STYLEGUIDE.md) documents.
- [x] My pull request passes the automated tests. If not, visit [pull requests at Travis CI](https://app.travis-ci.com/github/CSCfi/csc-user-guide/pull_requests) and have a look at the job log.
- [x] I have included a link to the appropriate [preview page](https://csc-guide-preview.2.rahtiapp.fi/origin/) (select your branch from the list).
